### PR TITLE
Auth: remove Google sign-in redirect; popup-only + hosting fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,17 +15,16 @@ STRAVA_WEBHOOK_VERIFY_TOKEN=REPLACE_ME_RANDOM
 # STEAM_WEB_API_KEY=
 
 # Frontend (React) environment
-# If App Check enforcement is enabled in Firebase, set this to your Web reCAPTCHA v3 site key
-# This gets read by react-app/src/firebase.ts during App initialization
-# Copy into react-app/.env for local dev or inject via your CI/CD for deployments
-# REACT_APP_RECAPTCHA_V3_SITE_KEY=
-# App Check provider and site key (web)
-# Choose provider: 'recaptcha-v3' (default) or 'recaptcha-enterprise'
+# App Check (Web)
+## If App Check enforcement is enabled in Firebase Console, configure one of the following:
+## Provider selection (optional): 'recaptcha-v3' (default) or 'recaptcha-enterprise'
 # REACT_APP_APPCHECK_PROVIDER=recaptcha-v3
-# Generic site key variable (or use provider-specific ones below)
+## Site key options (first non-empty is used):
+# REACT_APP_APP_CHECK_SITE_KEY=
 # REACT_APP_APPCHECK_SITE_KEY=
-# Provider-specific (either is fine if APPCHECK_SITE_KEY is unset)
 # REACT_APP_RECAPTCHA_V3_SITE_KEY=
 # REACT_APP_RECAPTCHA_ENTERPRISE_SITE_KEY=
+## Debug token for dev/emulator (NEVER set in prod):
+# REACT_APP_APPCHECK_DEBUG_TOKEN=true
 # Set to true only for local emulator usage
 # REACT_APP_USE_FIREBASE_EMULATOR=false

--- a/firebase.json
+++ b/firebase.json
@@ -89,7 +89,7 @@
         "headers": [
           {
             "key": "X-Frame-Options",
-            "value": "DENY"
+            "value": "SAMEORIGIN"
           },
           {
             "key": "X-Content-Type-Options",

--- a/functions/index.js
+++ b/functions/index.js
@@ -42,7 +42,7 @@ function stateDecode(s) {
 }
 
 // ===== OAuth: start
-exports.oauthStart = httpsV2.onRequest({ secrets: [GOOGLE_OAUTH_CLIENT_ID] }, async (req, res) => {
+exports.oauthStart = httpsV2.onRequest({ secrets: [GOOGLE_OAUTH_CLIENT_ID], invoker: 'public' }, async (req, res) => {
   try {
     const uid = String(req.query.uid || "");
     const nonce = String(req.query.nonce || "");
@@ -60,7 +60,7 @@ exports.oauthStart = httpsV2.onRequest({ secrets: [GOOGLE_OAUTH_CLIENT_ID] }, as
 });
 
 // ===== OAuth: callback
-exports.oauthCallback = httpsV2.onRequest({ secrets: [GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET] }, async (req, res) => {
+exports.oauthCallback = httpsV2.onRequest({ secrets: [GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET], invoker: 'public' }, async (req, res) => {
   try {
     const code = String(req.query.code || "");
     const state = stateDecode(req.query.state);

--- a/react-app/src/components/LoginPage.tsx
+++ b/react-app/src/components/LoginPage.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { Container, Row, Col, Card, Button, Form, Alert, Spinner } from 'react-bootstrap';
 import { useAuth } from '../contexts/AuthContext';
-import { GoogleAuthProvider, signInWithRedirect } from 'firebase/auth';
+import { GoogleAuthProvider } from 'firebase/auth';
 import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '../firebase';
 
 const LoginPage: React.FC = () => {
-  const { signInWithGoogle, signInWithGoogleRedirect } = useAuth();
+  const { signInWithGoogle } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isSignUp, setIsSignUp] = useState(false);
@@ -36,16 +36,16 @@ const LoginPage: React.FC = () => {
       case 'auth/unauthorized-domain':
         return 'This domain is not authorized for Google sign-in. Please use the production URL or contact support.';
       case 'auth/popup-blocked':
-        return 'Popup was blocked by the browser. Try the Redirect option below.';
+        return 'Popup was blocked by the browser. Please allow popups for this site and try again.';
       case 'auth/popup-closed-by-user':
-        return 'Popup was closed before completing sign-in. Try again or use Redirect sign-in.';
+        return 'Popup was closed before completing sign-in. Please try again.';
       case 'auth/operation-not-supported-in-this-environment':
-        return 'This browser blocks popups. Use Redirect sign-in instead.';
+        return 'This browser blocks popups. Please use a different browser or adjust settings.';
       case 'auth/network-request-failed':
         return 'Network error. Check your connection and retry.';
       default:
         if (message?.toLowerCase().includes('cookie')) return 'Third‑party cookies are blocked. Enable them for accounts.google.com and retry.';
-        return 'Sign-in failed. Please try again or use Redirect sign-in.';
+        return 'Sign-in failed. Please try again.';
     }
   };
 
@@ -63,18 +63,7 @@ const LoginPage: React.FC = () => {
     }
   };
 
-  const handleGoogleRedirect = async () => {
-    setError('');
-    setLoading(true);
-    try {
-      await signInWithGoogleRedirect();
-    } catch (error: any) {
-      const code = error?.code;
-      setError(friendlyAuthMessage(code, error?.message));
-    } finally {
-      setLoading(false);
-    }
-  };
+  // Redirect sign-in removed per request
 
   return (
     <Container fluid className="vh-100 d-flex align-items-center justify-content-center bg-light">
@@ -105,15 +94,7 @@ const LoginPage: React.FC = () => {
                 Continue with Google
               </Button>
 
-              <Button
-                variant="link"
-                size="sm"
-                className="w-100 mb-2"
-                onClick={handleGoogleRedirect}
-                disabled={loading}
-              >
-                Use redirect sign-in (for popup blockers)
-              </Button>
+              {/* Redirect sign-in option removed */}
 
               <div className="text-center my-3">
                 <small className="text-muted">or</small>


### PR DESCRIPTION
- Remove redirect fallback (popup-only) in AuthContext and LoginPage
- Keep friendly error guidance for popup/cookie issues
- Hosting: set X-Frame-Options SAMEORIGIN to allow Firebase Auth iframe
- Functions: make oauthStart/oauthCallback public (invoker: public)
- Docs: clarify App Check env variables in .env.example

Notes:
- App Check initialization was removed from client (firebase.ts is git-ignored), so enforcement must be OFF in Console for Auth/Firestore/Functions, or re-add client App Check with a site key later.
- Tested build locally; redirect handler 200s; login should complete once enforcement is off.
