### PR TITLE
Docs: n8n integration guide + roadmap gaps + README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BOB — AI-Enhanced Productivity Platform v3.5.2 🚀
+# BOB — AI-Enhanced Productivity Platform 🚀
 
 ## 🌐 **IMPORTANT URLS & ACCESS**
 
@@ -27,19 +27,17 @@
 3. **Start Managing:** Create goals, stories, tasks with new visualization tools
 
 ### For Developers
-1. **Documentation:** Start with `Business Analyst AI/GETTING_STARTED.md`
-2. **Setup:** Follow the one-command setup process
-3. **Development:** See `Business Analyst AI/README.md` for complete guide
-4. **Automation:** Use scripts in `Business Analyst AI/automation-scripts/`
+1. **Docs:** Start with `Business Analyst AI/GETTING_STARTED.md`
+2. **Setup:** See root scripts (e.g., `setup-master.sh`) and `functions/`
+3. **Integrations:** Review `docs/integrations/n8n/` for external orchestration
+4. **Issues/Epics:** See Epics #229 (Finance) and #230 (Scheduling)
 
 ## 📚 Documentation Navigation
 
-- **📋 Project Overview:** `Business Analyst AI/README.md`
-- **🚀 Getting Started:** `Business Analyst AI/GETTING_STARTED.md`  
-- **📊 Project Status:** `Business Analyst AI/STATUS.md`
-- **🎯 Action Plan:** `CRITICAL_ACTION_PLAN.md`
-- **🔧 Automation:** `Business Analyst AI/automation-scripts/`
-- **🏗️ Architecture:** `Business Analyst AI/requirements-traceability-matrix.md`
+- Requirements & Guides: `Business Analyst AI/`
+- Integrations (n8n): `docs/integrations/n8n/`
+- Gaps & TODOs: `docs/ROADMAP_GAPS.md`
+- Action Plan: `CRITICAL_ACTION_PLAN.md`
 
 ## 📞 Support & Contributing
 
@@ -49,12 +47,14 @@
 
 ---
 
-**🔥 PRIORITY:** See [CRITICAL_ACTION_PLAN.md](./CRITICAL_ACTION_PLAN.md) for current development priorities and next steps. 
+**🔥 PRIORITY:** See [CRITICAL_ACTION_PLAN.md](./CRITICAL_ACTION_PLAN.md) and Epics #229/#230. 
 
-**Version:** v3.5.2 - Goals Refinements + Comprehensive UI Scaffolding  
-**Latest Features:** Goals Visualization, Calendar Integration, Sprint Management, Routes & Routines  
-**Next Phase:** Full CRUD operations for all platform entities  
-**Last Updated:** September 1, 2025
+**Current Focus**
+- Scheduling & Routines: Auto-scheduler, Daily Summary, Reminders bridge (#226, #218, #215, #227)
+- Finance Platform: Monzo ingestion → Budget engine → Dashboards (#220–#225)
+- Roadmap V3 polish and performance (#181, #203–#212)
+
+**Last Reviewed:** September 20, 2025
 
 ---
 
@@ -65,17 +65,21 @@
 **🔄 NEXT PHASE:** Backend API integration and real data connectivity  
 **📋 ACTION PLAN:** See [CRITICAL_ACTION_PLAN.md](./CRITICAL_ACTION_PLAN.md) for priorities
 
-### 🆕 **v3.5.2 New Components** 
-- **Goals Visualization:** Interactive roadmap timeline with drag-and-drop scheduling
-- **Calendar Integration:** Google/Outlook sync with goal linking and auto-task creation
-- **Sprint Management:** Complete sprint lifecycle with retrospectives and burndown charts
-- **Routes & Routines:** Daily optimization with efficiency tracking and navigation integration
+### Key Capabilities
+- Roadmap (V2/V3): Interactive timeline with drag/resize, filters, presets
+- Goals/Stories/Tasks: Firestore-backed CRUD, activity stream, AI helpers
+- Scheduling: Theme Blocks Auto-Scheduler (hybrid with n8n)
+- Messaging: Daily Priority Summary to Email/Telegram (n8n)
+- Reminders: iOS Reminders sync (hybrid with n8n)
+- Finance: Monzo → Budget Plan → Dashboards
+- Health: MyFitnessPal ingestion → Macro insights
+- Travel: Visited map → Stories
 
-### 📁 **Clean Documentation Structure**
-- **Master Documentation:** `Business Analyst AI/` (unified requirements, guides, automation)
-- **Developer Documentation:** `Developer AI/` (technical implementation details)  
-- **Archived Files:** `archive/` (historical documentation preserved in compressed format)
-- **Action Plan:** `CRITICAL_ACTION_PLAN.md` (current priorities and roadmap)
+### 📁 Documentation Structure
+- Requirements & Guides: `Business Analyst AI/`
+- Integrations (n8n): `docs/integrations/n8n/`
+- Gaps & TODOs: `docs/ROADMAP_GAPS.md`
+- Archives & Logs: `archive/`, `deployment-logs/`
 
 ## 🆕 **What's New in Version 3.5.2**
 
@@ -90,7 +94,7 @@
 - ✅ **Force Refresh Mechanism** - v3.5.2 prompts users to refresh for latest features
 - ✅ **Session Management** - Improved logout and cache clearing
 
-### **� Comprehensive UI Scaffolding**
+### **UI & Performance**
 - ✅ **Goals Visualization** - Interactive roadmap timeline with sprint markers
 - ✅ **Calendar Integration** - Google/Outlook sync with goal linking
 - ✅ **Sprint Management** - Complete Agile workflow with retrospectives
@@ -101,10 +105,9 @@
 - ✅ **Touch-Friendly Controls** - Optimized for tablet and phone interactions
 - ✅ **Dark Mode Support** - Consistent theming across all new components
 
-### **� Integration Ready**
-- ✅ **API Scaffolding** - Ready for backend integration
-- ✅ **Real-time Updates** - Firebase integration hooks prepared
-- ✅ **External Services** - Calendar, mapping, and optimization service stubs
+### **Integrations**
+- External I/O via n8n (Calendar, Reminders, Monzo, MFP). See `docs/integrations/n8n/`.
+- OAuth/verification in Firebase Functions.
 
 ## What this platform does
 - **Personal Productivity**: Goals ↔ Stories ↔ Tasks linkage with AI-powered prioritization
@@ -113,7 +116,7 @@
 - **Entertainment Tracking**: Personal backlogs for games, movies, books
 - **Mobile Optimization**: Touch-friendly interfaces with device detection
 - **Visual Organization**: Interactive mind mapping for project visualization 
-## Setup
+## Setup (Firebase)
 ```bash
 cd /Users/jim/Github/bob/functions
 npm install
@@ -130,29 +133,12 @@ firebase functions:secrets:set STEAM_WEB_API_KEY
 # Deploy storage rules (for file uploads)
 firebase deploy --only storage
 
-# Deploy everything
-firebase deploy
+# Deploy functions/hosting
+firebase deploy --only functions,hosting
 ```
 
-## Overwrite your existing folder
-```bash
-# Backup current project
-mv /Users/jim/Github/bob /Users/jim/Github/bob_backup_$(date +%Y%m%d)
-
-# Unzip this bundle (adjust path to your download)
-unzip ~/Downloads/bob_full_no_goodreads.zip -d /Users/jim/Github/bob
-```
-
-## Push to GitHub
-```bash
-cd /Users/jim/Github/bob
-git init
-git add .
-git commit -m "Bob full bundle: Goals/OKRs, Kanban, Imports, Storage, Trakt/Steam stubs"
-git branch -M main
-git remote add origin https://github.com/<YOUR_USERNAME>/bob.git
-git push -u origin main
-```
+## Project Hygiene
+- Use issues/epics for tracking. Avoid manual bundle overwrites.
 
 ## Using the app
 - Open your hosting URL (e.g., https://bob20250810.web.app), Sign in with Google.
@@ -163,5 +149,5 @@ firebase.functions("europe-west2").httpsCallable("linkOkrsToGoals")().then(x=>co
 ```
 
 ## Notes
-- Trakt/Steam callables are stubs until secrets are configured and fetchers implemented.
-- If you want scheduled nightly syncs, I’ll add `onSchedule` functions and parsers for each platform.
+- Trakt/Steam/Goodreads require secrets and per‑integration enablement.
+- n8n workflows are stubs; configure credentials and endpoints before enabling.

--- a/docs/ROADMAP_GAPS.md
+++ b/docs/ROADMAP_GAPS.md
@@ -1,0 +1,29 @@
+# Roadmap Gaps Identified from Documentation
+
+This note captures features referenced in documentation that do not currently have focused issues, or that need refreshed tracking.
+
+Candidate New Issues
+- Apple HealthKit Ingestion & Insights
+  - Source: 📱 BOB iOS App – MVP Requirements.ini (HealthKit Integration), create_requirements_issues.sh
+  - Scope: HRV, VO₂ Max, resting HR, steps; privacy controls; owner‑scoped collections.
+  - Fit: Hybrid (iOS → Functions); optional n8n for nightly imports/exports.
+- Strava Activity Sync
+  - Source: DEPLOYMENT_SUCCESS_v3.0.8_UNIFIED_DND_20250831.md; create_requirements_issues.sh
+  - Scope: OAuth, activity import, summaries to insights; optional calendar push.
+- Runna Training Plan Import
+  - Source: DEPLOYMENT_SUCCESS_v3.0.8_UNIFIED_DND_20250831.md
+  - Scope: Pull plan, map to stories/tasks/blocks.
+- CSV/Export Enhancements (Finance & Health)
+  - Source: multiple docs call out CSV exports; extend #222/#223 to include export endpoints.
+
+Already Tracked (for clarity)
+- Monzo ingestion/budget engine/dashboards: #220, #221, #222, #223, #224, #225
+- Reminders/Calendar Scheduler/Summary/Routines: #215, #226, #218, #227, #219
+- Travel Map: #216
+- Trakt/Goodreads/Steam: #106, #107, #108
+- Traceability Graph: #49
+
+Notes
+- Consolidate any overlapping “daily digest/summary/telegram” docs under #218.
+- Keep legacy “calendar child event maintenance” (#158) related to #226.
+

--- a/docs/integrations/n8n/README.md
+++ b/docs/integrations/n8n/README.md
@@ -1,0 +1,50 @@
+# n8n Integrations for BOB
+
+This folder documents how BOB uses n8n to orchestrate external integrations (Calendar, Reminders, Finance, Health) while keeping deterministic business logic and security-sensitive pieces in Firebase Functions.
+
+Principles
+- Keep scheduling/compute in Firebase Functions; do external API I/O in n8n.
+- Use Firestore documents as the contract between Functions and n8n (intent → status → result).
+- Enforce idempotency with composite keys (e.g., `storyId+start`) and `status` fields.
+- Prefer n8n cron and webhook triggers; backstop with Cloud Scheduler where needed.
+
+Workflows (stubs in `workflows/`)
+- bob_daily_summary_v1 (Issue #218)
+  - Trigger: Cron (default 07:00, configurable)
+  - Inputs: Firestore query params (user, timeframe)
+  - Outputs: Email via SendGrid/SMTP, Telegram message, Firestore `/summaries` log
+- bob_calendar_sync_v1 (Issue #226)
+  - Trigger: Firestore event doc or HTTP webhook from Functions
+  - Inputs: `/calendar/events` doc with `{storyId, blockId, start, end, status}`
+  - Outputs: Google Calendar create/update/delete; updates `gcalEventId`, `status`, `lastAttempt`
+- bob_monzo_sync_v1 (Issue #220)
+  - Trigger: Cron (15m) + webhook fallback
+  - Inputs: Secured sync token from Functions; account IDs
+  - Outputs: `/finance/accounts`, `/finance/pots`, `/finance/transactions`, `/logs/finance_sync`
+- bob_reminders_bridge_v1 (Issue #215)
+  - Trigger: iOS Shortcuts / Webhook
+  - Inputs: task create/complete payload with `ref`
+  - Outputs: Firestore task updates; reconciliation report
+- bob_routines_calendar_v1 (Issue #227)
+  - Trigger: New `/routine_instances` docs
+  - Inputs: `{title, rrule/date, durationMin, pushToCalendar, pushToReminders}`
+  - Outputs: Calendar/Reminders entries; instance status back to Firestore
+- bob_mfp_ingest_v1 (Issue #228)
+  - Trigger: Cron (daily) or file/email ingest
+  - Inputs: Daily totals and meals
+  - Outputs: `/health/mfpDaily/{yyyy-mm-dd}`, triggers adherence compute
+
+Firestore Contracts (core)
+- `/calendar/events/{id}`: `{storyId, blockId, start, end, status: 'pending'|'sent'|'error', gcalEventId?, source, lastAttempt?, error?}`
+- `/summaries/{uid:date}`: `{uid, date, subject, html, telegramMessageId?, sentAt}`
+- `/finance/*`: `accounts`, `pots`, `transactions` (normalized, owner-scoped)
+- `/health/mfpDaily/{yyyy-mm-dd}` and `/health/insights/{yyyy-mm-dd}`
+- `/routine_instances/{id}` with scheduling/completion state
+
+Security
+- OAuth/token handling and signature verification live in Firebase Functions.
+- n8n calls a secured HTTPS Callable/HTTP endpoint exposed by Functions to write to Firestore.
+
+Importing the stubs
+- Use the JSON files in `workflows/` as starting points; update credentials and node params.
+

--- a/docs/integrations/n8n/workflows/bob_calendar_sync_v1.json
+++ b/docs/integrations/n8n/workflows/bob_calendar_sync_v1.json
@@ -1,0 +1,10 @@
+{
+  "name": "bob_calendar_sync_v1 (stub)",
+  "nodes": [
+    { "parameters": { "path": "calendar/event", "options": { "responseCode": 200 } }, "name": "Webhook (event intent)", "type": "n8n-nodes-base.webhook" },
+    { "parameters": { "operation": "create", "calendar": "primary", "additionalFields": { "summary": "{{ $json.title }}", "description": "{{ $json.description }}", "start": "{{ $json.start }}", "end": "{{ $json.end }}" } }, "name": "Google Calendar (CRUD)", "type": "n8n-nodes-base.googleCalendar" },
+    { "parameters": { "url": "{{ $json.functionsAckUrl }}" }, "name": "Ack/Update Firestore (HTTP)", "type": "n8n-nodes-base.httpRequest" }
+  ],
+  "connections": {}
+}
+

--- a/docs/integrations/n8n/workflows/bob_daily_summary_v1.json
+++ b/docs/integrations/n8n/workflows/bob_daily_summary_v1.json
@@ -1,0 +1,12 @@
+{
+  "name": "bob_daily_summary_v1 (stub)",
+  "nodes": [
+    { "parameters": { "rule": "0 7 * * *" }, "name": "Cron", "type": "n8n-nodes-base.cron" },
+    { "parameters": { "url": "{{ $json.functionsFetchUrl }}", "options": {} }, "name": "Fetch Summary Data (HTTP)", "type": "n8n-nodes-base.httpRequest" },
+    { "parameters": { "fromEmail": "no-reply@bob.app", "toEmail": "{{ $json.userEmail }}", "subject": "BOB Daily Summary", "text": "{{ $json.summaryText }}", "html": "{{ $json.summaryHtml }}" }, "name": "Send Email (SMTP)", "type": "n8n-nodes-base.emailSend" },
+    { "parameters": { "resource": "message", "operation": "sendText", "chatId": "{{ $json.telegramChatId }}", "text": "{{ $json.summaryText }}" }, "name": "Send Telegram", "type": "n8n-nodes-base.telegram" },
+    { "parameters": { "url": "{{ $json.functionsLogUrl }}", "options": {} }, "name": "Log to Firestore (HTTP)", "type": "n8n-nodes-base.httpRequest" }
+  ],
+  "connections": {}
+}
+

--- a/docs/integrations/n8n/workflows/bob_mfp_ingest_v1.json
+++ b/docs/integrations/n8n/workflows/bob_mfp_ingest_v1.json
@@ -1,0 +1,11 @@
+{
+  "name": "bob_mfp_ingest_v1 (stub)",
+  "nodes": [
+    { "parameters": { "rule": "0 6 * * *" }, "name": "Cron (06:00)", "type": "n8n-nodes-base.cron" },
+    { "parameters": { "url": "{{ $json.mfpExportUrlOrSource }}" }, "name": "Fetch MFP Data", "type": "n8n-nodes-base.httpRequest" },
+    { "parameters": { "url": "{{ $json.functionsNormalizeUrl }}" }, "name": "Normalize (HTTP)", "type": "n8n-nodes-base.httpRequest" },
+    { "parameters": { "url": "{{ $json.functionsUpsertDailyUrl }}" }, "name": "Upsert Daily Totals (HTTP)", "type": "n8n-nodes-base.httpRequest" }
+  ],
+  "connections": {}
+}
+

--- a/docs/integrations/n8n/workflows/bob_monzo_sync_v1.json
+++ b/docs/integrations/n8n/workflows/bob_monzo_sync_v1.json
@@ -1,0 +1,12 @@
+{
+  "name": "bob_monzo_sync_v1 (stub)",
+  "nodes": [
+    { "parameters": { "rule": "*/15 * * * *" }, "name": "Cron (15m)", "type": "n8n-nodes-base.cron" },
+    { "parameters": { "url": "{{ $json.functionsSignedSyncUrl }}" }, "name": "Get Signed Sync Token (HTTP)", "type": "n8n-nodes-base.httpRequest" },
+    { "parameters": { "url": "https://api.monzo.com/transactions?account_id={{$json.accountId}}", "authentication": "predefinedCredentialType" }, "name": "Fetch Transactions", "type": "n8n-nodes-base.httpRequest" },
+    { "parameters": { "url": "{{ $json.functionsUpsertUrl }}" }, "name": "Upsert to Firestore (HTTP)", "type": "n8n-nodes-base.httpRequest" },
+    { "parameters": { "url": "{{ $json.functionsLogUrl }}" }, "name": "Log Run (HTTP)", "type": "n8n-nodes-base.httpRequest" }
+  ],
+  "connections": {}
+}
+

--- a/docs/integrations/n8n/workflows/bob_reminders_bridge_v1.json
+++ b/docs/integrations/n8n/workflows/bob_reminders_bridge_v1.json
@@ -1,0 +1,10 @@
+{
+  "name": "bob_reminders_bridge_v1 (stub)",
+  "nodes": [
+    { "parameters": { "path": "reminders/hook", "options": { "responseCode": 200 } }, "name": "Webhook (Shortcuts)", "type": "n8n-nodes-base.webhook" },
+    { "parameters": { "url": "{{ $json.functionsVerifyUrl }}" }, "name": "Verify & Normalize (HTTP)", "type": "n8n-nodes-base.httpRequest" },
+    { "parameters": { "url": "{{ $json.functionsUpsertTaskUrl }}" }, "name": "Upsert Task (HTTP)", "type": "n8n-nodes-base.httpRequest" }
+  ],
+  "connections": {}
+}
+

--- a/docs/integrations/n8n/workflows/bob_routines_calendar_v1.json
+++ b/docs/integrations/n8n/workflows/bob_routines_calendar_v1.json
@@ -1,0 +1,10 @@
+{
+  "name": "bob_routines_calendar_v1 (stub)",
+  "nodes": [
+    { "parameters": { "path": "routines/instance" }, "name": "Webhook (new instance)", "type": "n8n-nodes-base.webhook" },
+    { "parameters": { "operation": "create", "calendar": "primary" }, "name": "Google Calendar (create)", "type": "n8n-nodes-base.googleCalendar" },
+    { "parameters": { "url": "{{ $json.functionsAckUrl }}" }, "name": "Ack Instance (HTTP)", "type": "n8n-nodes-base.httpRequest" }
+  ],
+  "connections": {}
+}
+


### PR DESCRIPTION
This PR updates documentation and adds n8n workflow stubs.\n\nChanges:\n- Add n8n integration guide and stub workflows (Calendar, Daily Summary, Monzo, Reminders, Routines, MFP) under docs/integrations/n8n/.\n- Add docs/ROADMAP_GAPS.md to record Health/Strava/Runna/CSV export gaps.\n- Refresh README to reflect current capabilities, epics (#229/#230), and n8n hybrid architecture.\n\nNotes:\n- No application code changes; only docs.\n- Intended as baseline for configuring n8n credentials and endpoints.