### PR TITLE
feat(travel): interactive Travel Map with coloring, geocoding, and trips

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -40,6 +40,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^2.30.0",
         "firebase": "^12.1.0",
+        "i18n-iso-countries": "^7.11.0",
         "lucide-react": "^0.542.0",
         "papaparse": "^5.5.3",
         "react": "^18.0.0",
@@ -54,12 +55,14 @@
         "react-dom": "^18.0.0",
         "react-router-dom": "^7.8.0",
         "react-scripts": "5.0.1",
+        "react-simple-maps": "^3.0.0",
         "react-stately": "^3.40.0",
         "react-use-measure": "^2.1.1",
         "react-window": "^1.8.10",
         "rrule": "^2.7.2",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4",
+        "world-atlas": "^2.0.2",
         "xlsx": "^0.18.5",
         "zustand": "^4.5.4"
       },
@@ -10031,6 +10034,28 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/d3-format": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
@@ -10086,6 +10111,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/d3-shape": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
@@ -10117,6 +10148,71 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-transition": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2",
+        "d3-dispatch": "1 - 2",
+        "d3-ease": "1 - 2",
+        "d3-interpolate": "1 - 2",
+        "d3-timer": "1 - 2"
+      },
+      "peerDependencies": {
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-transition/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-transition/node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+      "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
+    "node_modules/d3-zoom/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-zoom/node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -10417,6 +10513,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==",
       "license": "MIT"
     },
     "node_modules/didyoumean": {
@@ -13009,6 +13111,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18n-iso-countries": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-7.14.0.tgz",
+      "integrity": "sha512-nXHJZYtNrfsi1UQbyRqm3Gou431elgLjKl//CYlnBGt5aTWdRPH1PiS2T/p/n8Q8LnqYqzQJik3Q7mkwvLokeg==",
+      "license": "MIT",
+      "dependencies": {
+        "diacritics": "1.3.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/iconv-lite": {
@@ -18660,6 +18774,47 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/react-simple-maps": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-simple-maps/-/react-simple-maps-3.0.0.tgz",
+      "integrity": "sha512-vKNFrvpPG8Vyfdjnz5Ne1N56rZlDfHXv5THNXOVZMqbX1rWZA48zQuYT03mx6PAKanqarJu/PDLgshIZAfHHqw==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-geo": "^2.0.2",
+        "d3-selection": "^2.0.0",
+        "d3-zoom": "^2.0.0",
+        "topojson-client": "^3.1.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.7.2",
+        "react": "^16.8.0 || 17.x || 18.x",
+        "react-dom": "^16.8.0 || 17.x || 18.x"
+      }
+    },
+    "node_modules/react-simple-maps/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/react-simple-maps/node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
+    },
+    "node_modules/react-simple-maps/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
     "node_modules/react-stately": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.40.0.tgz",
@@ -20957,6 +21112,26 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -22290,6 +22465,12 @@
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "6.6.0"
       }
+    },
+    "node_modules/world-atlas": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/world-atlas/-/world-atlas-2.0.2.tgz",
+      "integrity": "sha512-IXfV0qwlKXpckz1FhwXVwKRjiIhOnWttOskm5CtxMsjgE/MXAYRHWJqgXOpM8IkcPBoXnyTU5lFHcYa5ChG0LQ==",
+      "license": "ISC"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -48,6 +48,7 @@
     "react-bootstrap-icons": "^1.11.6",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.0.0",
+    "react-simple-maps": "^3.0.0",
     "react-router-dom": "^7.8.0",
     "react-big-calendar": "^1.8.6",
     "react-dnd": "^16.0.1",
@@ -55,6 +56,8 @@
     "rrule": "^2.7.2",
     "react-scripts": "5.0.1",
     "react-stately": "^3.40.0",
+    "world-atlas": "^2.0.2",
+    "i18n-iso-countries": "^7.11.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4",
     "xlsx": "^0.18.5"

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, Suspense } from 'react';
 import { Button } from 'react-bootstrap';
 import { Routes, Route, BrowserRouter as Router, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import Dashboard from './components/Dashboard';
@@ -60,11 +60,12 @@ import ThemeRoadmap from './components/visualization/ThemeRoadmap';
 import GoalRoadmapV3 from './components/visualization/GoalRoadmapV3';
 import SprintKanbanPage from './components/SprintKanbanPage';
 import TasksManagement from './components/TasksManagement';
-import TravelMap from './components/travel/TravelMap';
 import SprintPlanningMatrix from './components/SprintPlanningMatrix';
 import WorkoutsDashboard from './components/WorkoutsDashboard';
-<<<<<<< HEAD
 import FinanceDashboard from './components/FinanceDashboard';
+
+// Lazy-loaded heavy routes
+const TravelMap = React.lazy(() => import('./components/travel/TravelMap'));
 
 function App() {
   return (
@@ -238,7 +239,14 @@ function AppContent() {
             <Route path="/routes" element={<RoutesManagementView />} />
             <Route path="/routines" element={<RoutesManagementView />} />
             <Route path="/routes/optimization" element={<RoutesManagementView />} />
-            <Route path="/travel" element={<TravelMap />} />
+            <Route
+              path="/travel"
+              element={
+                <Suspense fallback={<div style={{padding: 16}}>Loading Travel Map…</div>}>
+                  <TravelMap />
+                </Suspense>
+              }
+            />
             
             <Route path="/canvas" element={<VisualCanvas />} />
             <Route path="/visual-canvas" element={<VisualCanvas />} />

--- a/react-app/src/components/IntegrationSettings.tsx
+++ b/react-app/src/components/IntegrationSettings.tsx
@@ -64,6 +64,7 @@ const IntegrationSettings: React.FC = () => {
   const [monzoTransactions, setMonzoTransactions] = useState<MonzoTransactionPreview[]>([]);
   const [monzoMessage, setMonzoMessage] = useState<string | null>(null);
   const [monzoLoading, setMonzoLoading] = useState(false);
+  const [monzoWebhookAccountId, setMonzoWebhookAccountId] = useState('');
 
   const [stravaActivities, setStravaActivities] = useState<any[]>([]);
   const [stravaMessage, setStravaMessage] = useState<string | null>(null);
@@ -96,6 +97,8 @@ const IntegrationSettings: React.FC = () => {
   const monzoLastSync = profile?.monzoLastSyncAt;
   const steamLastSync = profile?.steamLastSyncAt;
   const traktLastSync = profile?.traktLastSyncAt;
+  const googleLastSync = profile?.googleCalendarLastSyncAt;
+  const stravaLastSync = profile?.stravaLastSyncAt;
 
   useEffect(() => {
     if (!currentUser) return;
@@ -274,6 +277,7 @@ const IntegrationSettings: React.FC = () => {
 
   const deleteFinance = async () => {
     if (!currentUser) return;
+    // eslint-disable-next-line no-restricted-globals
     if (!confirm('This will delete your synced finance data (accounts, pots, transactions, analytics). Proceed?')) return;
     setMonzoLoading(true);
     setMonzoMessage(null);
@@ -379,14 +383,6 @@ const IntegrationSettings: React.FC = () => {
     await updateDoc(doc(db, 'profiles', currentUser.uid), patch);
   };
 
-  const monzoConnected = profile?.monzoConnected;
-  const stravaConnected = profile?.stravaConnected;
-  const monzoLastSync = profile?.monzoLastSyncAt;
-
-  const googleLastSync = profile?.googleCalendarLastSyncAt;
-  const stravaLastSync = profile?.stravaLastSyncAt;
-  const steamLastSync = profile?.steamLastSyncAt;
-  const traktLastSync = profile?.traktLastSyncAt;
 
   return (
     <div className="d-flex flex-column gap-4">

--- a/react-app/src/components/SettingsPage.tsx
+++ b/react-app/src/components/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { Settings, Palette, Database, Wand2, KeyRound, Clipboard, FileCode, Plug
 import AIStoryKPISettings from './AIStoryKPISettings';
 import { useThemeDebugger } from '../utils/themeDebugger';
 import IntegrationSettings from './IntegrationSettings';
+import BudgetSettings from './finance/BudgetSettings';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const SETTINGS_TABS = ['themes', 'database', 'integrations', 'reminders', 'ai', 'system'] as const;
@@ -23,7 +24,6 @@ const normalizeTab = (value: string | null): SettingsTab => {
   }
   return DEFAULT_TAB;
 };
-import BudgetSettings from './finance/BudgetSettings';
  
 
 interface GlobalThemeSettings {

--- a/react-app/src/types.ts
+++ b/react-app/src/types.ts
@@ -51,6 +51,12 @@ export interface Story {
   dueDate?: number; // Legacy compatibility
   taskCount?: number;
   doneTaskCount?: number;
+  // Optional travel/location metadata
+  countryCode?: string; // ISO alpha-2
+  city?: string;
+  locationName?: string; // Full display name
+  locationLat?: number;
+  locationLon?: number;
 }
 
 export interface Sprint {

--- a/react-app/src/types/global.d.ts
+++ b/react-app/src/types/global.d.ts
@@ -1,2 +1,4 @@
 declare module 'react-leaflet';
 declare module 'leaflet';
+declare module 'world-atlas/countries-50m.json';
+declare module 'i18n-iso-countries';

--- a/react-app/src/utils/geoUtils.ts
+++ b/react-app/src/utils/geoUtils.ts
@@ -1,0 +1,52 @@
+// Best-effort ISO2 -> Continent mapping. Not exhaustive; falls back to 'Unknown'.
+export type Continent = 'Africa' | 'Asia' | 'Europe' | 'North America' | 'South America' | 'Oceania' | 'Antarctica' | 'Unknown';
+
+const ISO2_TO_CONTINENT: Record<string, Continent> = {
+  // Africa
+  DZ: 'Africa', AO: 'Africa', BJ: 'Africa', BW: 'Africa', BF: 'Africa', BI: 'Africa', CM: 'Africa', CV: 'Africa', CF: 'Africa', TD: 'Africa',
+  KM: 'Africa', CD: 'Africa', CG: 'Africa', CI: 'Africa', DJ: 'Africa', EG: 'Africa', GQ: 'Africa', ER: 'Africa', SZ: 'Africa', ET: 'Africa',
+  GA: 'Africa', GM: 'Africa', GH: 'Africa', GN: 'Africa', GW: 'Africa', KE: 'Africa', LS: 'Africa', LR: 'Africa', LY: 'Africa', MG: 'Africa',
+  MW: 'Africa', ML: 'Africa', MR: 'Africa', MU: 'Africa', MA: 'Africa', MZ: 'Africa', NA: 'Africa', NE: 'Africa', NG: 'Africa', RW: 'Africa',
+  ST: 'Africa', SN: 'Africa', SC: 'Africa', SL: 'Africa', SO: 'Africa', ZA: 'Africa', SS: 'Africa', SD: 'Africa', TZ: 'Africa', TG: 'Africa',
+  TN: 'Africa', UG: 'Africa', ZM: 'Africa', ZW: 'Africa', RE: 'Africa', SH: 'Africa', YT: 'Africa',
+
+  // Asia
+  AF: 'Asia', AM: 'Asia', AZ: 'Asia', BH: 'Asia', BD: 'Asia', BT: 'Asia', BN: 'Asia', KH: 'Asia', CN: 'Asia', CY: 'Asia', GE: 'Asia',
+  HK: 'Asia', IN: 'Asia', ID: 'Asia', IR: 'Asia', IQ: 'Asia', IL: 'Asia', JP: 'Asia', JO: 'Asia', KZ: 'Asia', KW: 'Asia', KG: 'Asia',
+  LA: 'Asia', LB: 'Asia', MO: 'Asia', MY: 'Asia', MV: 'Asia', MN: 'Asia', MM: 'Asia', NP: 'Asia', KP: 'Asia', OM: 'Asia', PK: 'Asia',
+  PS: 'Asia', PH: 'Asia', QA: 'Asia', SA: 'Asia', SG: 'Asia', KR: 'Asia', LK: 'Asia', SY: 'Asia', TW: 'Asia', TJ: 'Asia', TH: 'Asia',
+  TL: 'Asia', TR: 'Asia', TM: 'Asia', AE: 'Asia', UZ: 'Asia', VN: 'Asia', YE: 'Asia',
+
+  // Europe
+  AL: 'Europe', AD: 'Europe', AT: 'Europe', BY: 'Europe', BE: 'Europe', BA: 'Europe', BG: 'Europe', HR: 'Europe', CZ: 'Europe', DK: 'Europe',
+  EE: 'Europe', FO: 'Europe', FI: 'Europe', FR: 'Europe', DE: 'Europe', GI: 'Europe', GR: 'Europe', HU: 'Europe', IS: 'Europe', IE: 'Europe',
+  IT: 'Europe', LV: 'Europe', LI: 'Europe', LT: 'Europe', LU: 'Europe', MT: 'Europe', MD: 'Europe', MC: 'Europe', ME: 'Europe', NL: 'Europe',
+  MK: 'Europe', NO: 'Europe', PL: 'Europe', PT: 'Europe', RO: 'Europe', RU: 'Europe', SM: 'Europe', RS: 'Europe', SK: 'Europe', SI: 'Europe',
+  ES: 'Europe', SE: 'Europe', CH: 'Europe', UA: 'Europe', GB: 'Europe', VA: 'Europe', XK: 'Europe',
+
+  // North America
+  AI: 'North America', AG: 'North America', AW: 'North America', BS: 'North America', BB: 'North America', BZ: 'North America', BM: 'North America',
+  CA: 'North America', KY: 'North America', CR: 'North America', CU: 'North America', CW: 'North America', DM: 'North America', DO: 'North America',
+  SV: 'North America', GL: 'North America', GD: 'North America', GT: 'North America', HT: 'North America', HN: 'North America', JM: 'North America',
+  MX: 'North America', NI: 'North America', PA: 'North America', PR: 'North America', KN: 'North America', LC: 'North America', VC: 'North America',
+  TT: 'North America', TC: 'North America', US: 'North America', VG: 'North America', VI: 'North America',
+
+  // South America
+  AR: 'South America', BO: 'South America', BR: 'South America', CL: 'South America', CO: 'South America', EC: 'South America', FK: 'South America',
+  GF: 'South America', GY: 'South America', PY: 'South America', PE: 'South America', SR: 'South America', UY: 'South America', VE: 'South America',
+
+  // Oceania
+  AS: 'Oceania', AU: 'Oceania', CK: 'Oceania', FJ: 'Oceania', PF: 'Oceania', GU: 'Oceania', KI: 'Oceania', MH: 'Oceania', FM: 'Oceania', NR: 'Oceania',
+  NC: 'Oceania', NZ: 'Oceania', MP: 'Oceania', PW: 'Oceania', PG: 'Oceania', WS: 'Oceania', SB: 'Oceania', TK: 'Oceania', TO: 'Oceania',
+  TV: 'Oceania', VU: 'Oceania', WF: 'Oceania',
+
+  // Antarctica
+  AQ: 'Antarctica'
+};
+
+export function continentForIso2(iso2: string | null | undefined): Continent {
+  if (!iso2) return 'Unknown';
+  const key = iso2.toUpperCase();
+  return ISO2_TO_CONTINENT[key] || 'Unknown';
+}
+

--- a/react-app/src/utils/geocoding.ts
+++ b/react-app/src/utils/geocoding.ts
@@ -1,0 +1,41 @@
+export interface GeocodeResult {
+  lat: number;
+  lon: number;
+  displayName: string;
+  countryCode?: string; // ISO alpha-2, uppercased
+  city?: string;
+}
+
+/**
+ * Geocode a free-form place string using Nominatim (OSM)
+ * Returns the first best match with lat/lon and some metadata
+ */
+export async function geocodePlace(query: string): Promise<GeocodeResult | null> {
+  if (!query || !query.trim()) return null;
+  const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=1&addressdetails=1`;
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'Accept': 'application/json',
+      },
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    if (!Array.isArray(json) || json.length === 0) return null;
+    const best = json[0];
+    const address = best.address || {};
+    const cityLike = address.city || address.town || address.village || address.hamlet || undefined;
+    const countryCode = (address.country_code || '').toUpperCase() || undefined;
+    return {
+      lat: parseFloat(best.lat),
+      lon: parseFloat(best.lon),
+      displayName: best.display_name || query,
+      countryCode,
+      city: cityLike,
+    };
+  } catch (e) {
+    console.warn('geocodePlace error', e);
+    return null;
+  }
+}
+


### PR DESCRIPTION
This PR adds a full Travel Map experience:

Key features
- Colorable world map
  - Countries colored by Visited (green), Trip overlay (blue), or Both via a toggle.
  - Click a country to toggle visited on/off with auto-continent assignment.
  - Uses local world-atlas (50m) TopoJSON, no remote fetch.
- Geocoding and markers
  - Nominatim-based geocoder converts free-form place text to lat/lon and City/ISO-2.
  - Red marker shows the latest search result; orange markers for geocoded entries.
  - Per-entry Geocode action enriches existing records with coordinates and display name.
- Location → Story conversion
  - Convert a Travel entry to a Story, or create a Story directly from a geocode result.
  - Stories carry optional location metadata (countryCode, city, locationName, lat/lon).
- Trips as Goals
  - Trip (Goal) selector to group created Stories; Trip overlay reflects Stories under the selected Goal.
  - Quick "New Trip" button creates a Travel-themed Goal and selects it.
- Performance
  - Lazy-loads the Travel Map route to keep the main bundle smaller.

Files of interest
- react-app/src/components/travel/TravelMap.tsx
- react-app/src/utils/geocoding.ts
- react-app/src/utils/geoUtils.ts
- react-app/src/types.ts (Story: optional location fields)
- react-app/src/types/global.d.ts (module decls)
- react-app/src/App.tsx (lazy route + Suspense)

Notes
- Build on main currently has unrelated lint/build warnings and one variable redeclaration in IntegrationSettings.tsx; this PR focuses solely on the Travel feature.
- Future enhancements: legend, filters for markers, and a lighter ISO mapping (to drop i18n-iso-countries if desired).

