### PR TITLE
feat(goals): refresh card grid and roadmap actions

### DIFF
--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -54,7 +54,6 @@ import AIUsageDashboard from './components/AIUsageDashboard';
 import SprintPlannerMatrix from './components/SprintPlannerMatrix';
 import MigrationManager from './components/MigrationManager';
 import GoalVizPage from './components/visualization/GoalVizPage';
-import ThemeRoadmap from './components/visualization/ThemeRoadmap';
 import GoalRoadmapV3 from './components/visualization/GoalRoadmapV3';
 import SprintKanbanPage from './components/SprintKanbanPage';
 import TasksManagement from './components/TasksManagement';
@@ -227,7 +226,6 @@ function AppContent() {
             <Route path="/goals-management" element={<GoalsManagement />} />
             <Route path="/goals/roadmap" element={<GoalRoadmapV3 />} />
             {/* Legacy V2 removed; no preview route retained */}
-            <Route path="/goals/cards" element={<ThemeRoadmap />} />
             <Route path="/goals/viz" element={<GoalVizPage />} />
             
             {/* Goals Timeline uses Enhanced Gantt (V3) */}

--- a/react-app/src/components/GoalsCardView.css
+++ b/react-app/src/components/GoalsCardView.css
@@ -1,8 +1,37 @@
 .goals-card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 24px;
   align-items: stretch;
+  grid-auto-rows: 1fr;
+}
+
+.goals-card-grid--grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.goals-card-grid--comfortable {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 32px;
+}
+
+@media (max-width: 1600px) {
+  .goals-card-grid--grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 1200px) {
+  .goals-card-grid--grid,
+  .goals-card-grid--comfortable {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .goals-card-grid--grid,
+  .goals-card-grid--comfortable {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
 }
 
 .goals-card-tile {
@@ -11,14 +40,104 @@
   min-height: 100%;
 }
 
-@media (min-width: 992px) {
-  .goals-card-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
+.goals-card {
+  backdrop-filter: blur(6px);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-@media (min-width: 1280px) {
-  .goals-card-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
+.goals-card--grid {
+  min-height: 240px;
+}
+
+.goals-card--comfortable {
+  min-height: 300px;
+}
+
+.goals-card-quick-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.goals-card-quick-stat {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.32);
+  backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.goals-card-quick-stat .label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  opacity: 0.78;
+}
+
+.goals-card-quick-stat .value {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.goals-card-description {
+  margin: 0;
+}
+
+.goals-card-stats-detailed {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.goals-card-stat-block {
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.goals-card-stat-block .label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  opacity: 0.75;
+}
+
+.goals-card-stat-block .value {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.goals-card-metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  font-size: 13px;
+}
+
+.goals-card-metadata div {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.goals-card-activity-button--icon {
+  font-size: 0 !important;
+  padding: 6px !important;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px !important;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.goals-card-activity-button--icon svg {
+  margin: 0;
 }

--- a/react-app/src/components/GoalsCardView.css
+++ b/react-app/src/components/GoalsCardView.css
@@ -1,0 +1,24 @@
+.goals-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+  align-items: stretch;
+}
+
+.goals-card-tile {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+@media (min-width: 992px) {
+  .goals-card-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1280px) {
+  .goals-card-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}

--- a/react-app/src/components/GoalsCardView.css
+++ b/react-app/src/components/GoalsCardView.css
@@ -6,28 +6,39 @@
 }
 
 .goals-card-grid--grid {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(8, minmax(0, 1fr));
 }
 
 .goals-card-grid--comfortable {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 32px;
+}
+
+@media (max-width: 1920px) {
+  .goals-card-grid--grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 1600px) {
   .goals-card-grid--grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+  .goals-card-grid--comfortable {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 1200px) {
-  .goals-card-grid--grid,
+@media (max-width: 1280px) {
+  .goals-card-grid--grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
   .goals-card-grid--comfortable {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 980px) {
   .goals-card-grid--grid,
   .goals-card-grid--comfortable {
     grid-template-columns: repeat(1, minmax(0, 1fr));
@@ -46,11 +57,11 @@
 }
 
 .goals-card--grid {
-  min-height: 240px;
+  min-height: 200px;
 }
 
 .goals-card--comfortable {
-  min-height: 300px;
+  min-height: 280px;
 }
 
 .goals-card-quick-stats {

--- a/react-app/src/components/GoalsManagement.tsx
+++ b/react-app/src/components/GoalsManagement.tsx
@@ -22,7 +22,8 @@ const GoalsManagement: React.FC = () => {
   const [filterTheme, setFilterTheme] = useState<string>('all');
   const [searchTerm, setSearchTerm] = useState('');
   const [loading, setLoading] = useState(true);
-  const [viewMode, setViewMode] = useState<'list' | 'cards'>('list');
+  const [viewMode, setViewMode] = useState<'list' | 'cards'>('cards');
+  const [cardLayout, setCardLayout] = useState<'grid' | 'comfortable'>('grid');
   const [editGoal, setEditGoal] = useState<Goal | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<{ id: string; title: string } | null>(null);
   const [activeSprintId, setActiveSprintId] = useState<string | null>(null);
@@ -218,6 +219,26 @@ const GoalsManagement: React.FC = () => {
                 Cards
               </Button>
             </div>
+            {viewMode === 'cards' && (
+              <div style={{ display: 'flex', border: '1px solid var(--notion-border)', borderRadius: 6, overflow: 'hidden' }}>
+                <Button
+                  size="sm"
+                  variant={cardLayout === 'grid' ? 'primary' : 'outline-secondary'}
+                  onClick={() => setCardLayout('grid')}
+                  style={{ borderRadius: 0 }}
+                >
+                  4 × 5 Grid
+                </Button>
+                <Button
+                  size="sm"
+                  variant={cardLayout === 'comfortable' ? 'primary' : 'outline-secondary'}
+                  onClick={() => setCardLayout('comfortable')}
+                  style={{ borderRadius: 0 }}
+                >
+                  Comfortable
+                </Button>
+              </div>
+            )}
             <Button variant="primary" onClick={() => alert('Add new goal - coming soon')}>
               Add Goal
             </Button>
@@ -397,6 +418,7 @@ const GoalsManagement: React.FC = () => {
                     onGoalDelete={handleGoalDelete}
                     onGoalPriorityChange={handleGoalPriorityChange}
                     themes={globalThemes}
+                    cardLayout={cardLayout}
                   />
                 )}
               </div>

--- a/react-app/src/components/GoalsManagement.tsx
+++ b/react-app/src/components/GoalsManagement.tsx
@@ -396,6 +396,7 @@ const GoalsManagement: React.FC = () => {
                     onGoalUpdate={handleGoalUpdate}
                     onGoalDelete={handleGoalDelete}
                     onGoalPriorityChange={handleGoalPriorityChange}
+                    themes={globalThemes}
                   />
                 )}
               </div>

--- a/react-app/src/components/SidebarLayout.tsx
+++ b/react-app/src/components/SidebarLayout.tsx
@@ -60,7 +60,6 @@ const SidebarLayout: React.FC<SidebarLayoutProps> = ({ children, onSignOut }) =>
       items: [
         { label: 'Goals List', path: '/goals', icon: 'list' },
         { label: 'Goals Roadmap', path: '/goals/roadmap', icon: 'project-diagram' },
-        { label: 'Goal Card View (Review)', path: '/goals/cards', icon: 'th-large' },
         { label: 'Visual Canvas', path: '/canvas', icon: 'share-alt' }
       ]
     },

--- a/react-app/src/components/visualization/GoalRoadmapV3.css
+++ b/react-app/src/components/visualization/GoalRoadmapV3.css
@@ -32,10 +32,12 @@
 .grv3-bar.dragging { cursor: grabbing; z-index: 1000; transform: scale(1.03); }
 .grv3-title { font-weight: 800; font-size: 14px; line-height: 1.25; text-shadow: 0 1px 2px rgba(0,0,0,.2); white-space: normal; overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3; }
 .grv3-meta { font-size: 11px; opacity: .95; }
-.grv3-actions { position: absolute; right: 8px; top: 6px; display: flex; gap: 8px; opacity: 0; transition: opacity .12s; pointer-events: none; }
+.grv3-actions { position: absolute; right: 8px; top: 6px; opacity: 0; transition: opacity .12s; pointer-events: none; }
 .grv3-bar:hover .grv3-actions { opacity: 1; pointer-events: auto; }
-.grv3-action { background: transparent; color: inherit; border: none; border-radius: 6px; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; cursor: pointer; }
-.grv3-action:hover { opacity: 0.9; }
+.grv3-action-toggle { display: inline-flex; align-items: center; justify-content: center; padding: 2px 6px; border-radius: 999px; border: 1px solid rgba(0,0,0,0.12); background: rgba(255,255,255,0.92); color: #1f1f1f; box-shadow: 0 2px 8px rgba(0,0,0,0.12); line-height: 1; }
+.grv3-action-toggle.btn { line-height: 1; }
+.grv3-action-toggle:hover, .grv3-action-toggle:focus { background: rgba(255,255,255,1); color: #000; }
+.grv3-action-toggle svg { pointer-events: none; }
 .grv3-resize { position: absolute; top:0; bottom:0; width: 10px; background: rgba(255,255,255,.18); opacity: 0; transition: opacity .15s; }
 .grv3-bar:hover .grv3-resize { opacity: 1; }
 .grv3-resize.start { left: 0; cursor: ew-resize; border-radius: 10px 0 0 10px; }

--- a/react-app/src/config/scaffolding.ts
+++ b/react-app/src/config/scaffolding.ts
@@ -5,7 +5,6 @@ export const BOB_ROUTES = {
   // Core Entity Management
   GOALS: {
     TABLE: '/goals/table',
-    CARDS: '/goals/cards', 
     VISUALIZATION: '/goals/visualization'
   },
   


### PR DESCRIPTION
## Summary
- replace the legacy /goals/cards route with the updated Goals management card grid
- ensure goal cards inherit theme colors from user settings and use a responsive 4-up layout
- align Goal Roadmap V3 with the same theme palette, move goal actions into a dropdown, and expose the global activity stream shortcut

## Testing
- npm run build
