### PR TITLE
fix: task deep-link modal + activity tab support

### DIFF
--- a/react-app/src/components/routes/DeepLinkTask.tsx
+++ b/react-app/src/components/routes/DeepLinkTask.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
 import { doc, getDoc, updateDoc, serverTimestamp, collection, query, where, limit, getDocs } from 'firebase/firestore';
 import { db } from '../../firebase';
 import TaskListView from '../TaskListView';
@@ -9,6 +9,12 @@ import { useNavigate } from 'react-router-dom';
 const DeepLinkTask: React.FC = () => {
   const { id: refOrId } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+  const initialTab = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const tab = (params.get('tab') || '').toLowerCase();
+    return tab === 'activity' ? 'activity' : 'details';
+  }, [location.search]);
   const [item, setItem] = useState<any | null>(null);
   const [open, setOpen] = useState(true);
   const [loaded, setLoaded] = useState(false);
@@ -19,15 +25,25 @@ const DeepLinkTask: React.FC = () => {
     let cancelled = false;
     const run = async () => {
       if (!refOrId) return;
-      // Try by human-readable ref first
+      // Try by human-readable ref first; fall back to common alt field names
       const q = query(collection(db, 'tasks'), where('ref', '==', refOrId), limit(1));
-      const qs = await getDocs(q);
+      let qs = await getDocs(q);
       let opened = false;
       if (!qs.empty) {
         const d = qs.docs[0];
         const it = { id: d.id, ...(d.data() || {}) } as any;
         setItem(it);
         opened = true;
+      }
+      if (!opened) {
+        const q2 = query(collection(db, 'tasks'), where('referenceNumber', '==', refOrId), limit(1));
+        qs = await getDocs(q2);
+        if (!qs.empty) {
+          const d = qs.docs[0];
+          const it = { id: d.id, ...(d.data() || {}) } as any;
+          setItem(it);
+          opened = true;
+        }
       }
       if (!opened) {
         const snap = await getDoc(doc(db, 'tasks', refOrId));
@@ -52,6 +68,7 @@ const DeepLinkTask: React.FC = () => {
         onHide={() => { setOpen(false); navigate('/tasks', { replace: true }); }}
         type="task"
         item={item}
+        initialTab={initialTab as any}
       />
     </>
   );


### PR DESCRIPTION
Enhances /task/:id route to find by ref or referenceNumber and opens the detail modal. Adds support for ?tab=activity to focus activity section.