### PR TITLE
fix: remove unused capacity setter

### DIFF
--- a/react-app/src/components/sprints/SprintCloseDialog.tsx
+++ b/react-app/src/components/sprints/SprintCloseDialog.tsx
@@ -266,12 +266,6 @@ const SprintCloseDialog: React.FC<SprintCloseDialogProps> = ({ show, onHide, spr
 
     setMetricsSnapshot(snapshot);
 
-    // Set capacity data for new sprint planning
-    setCapacityData({
-      availableHours: totalCapacityHours,
-      plannedHours: usedCapacityHours,
-      utilization: capacityUtilization
-    });
   };
 
   const handleCreateNewSprint = async () => {


### PR DESCRIPTION
Removes unused capacity setter call in SprintCloseDialog to fix build.