### PR TITLE
feat(finance): rework spend intelligence dashboard and transfer workflow

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -188,6 +188,82 @@ service cloud.firestore {
       allow delete: if isSignedIn() && (request.auth.uid == uid || resource.data.ownerUid == request.auth.uid || resource.data.ownerUid == null);
     }
 
+    // Finance enrichment + sync pipeline collections
+    match /merchant_mappings/{id} {
+      allow create: if isSignedIn() && request.resource.data.ownerUid == request.auth.uid;
+      allow read, delete: if isSignedIn() && resource.data.ownerUid == request.auth.uid;
+      allow update: if isSignedIn() &&
+                    resource.data.ownerUid == request.auth.uid &&
+                    request.resource.data.ownerUid == resource.data.ownerUid;
+    }
+    match /monzo_ai_merchant_categories/{id} {
+      allow create: if isSignedIn() && request.resource.data.ownerUid == request.auth.uid;
+      allow read, delete: if isSignedIn() && resource.data.ownerUid == request.auth.uid;
+      allow update: if isSignedIn() &&
+                    resource.data.ownerUid == request.auth.uid &&
+                    request.resource.data.ownerUid == resource.data.ownerUid;
+    }
+    match /monzo_ai_anomaly_summary/{uid} {
+      allow create: if isSignedIn() && (request.auth.uid == uid || request.resource.data.ownerUid == request.auth.uid);
+      allow read: if isSignedIn() && (request.auth.uid == uid || resource.data.ownerUid == request.auth.uid);
+      allow update: if isSignedIn() && (request.auth.uid == uid || resource.data.ownerUid == request.auth.uid);
+      allow delete: if isSignedIn() && (request.auth.uid == uid || resource.data.ownerUid == request.auth.uid);
+    }
+    match /monzo_sync_state/{id} {
+      allow create: if isSignedIn() && request.resource.data.ownerUid == request.auth.uid;
+      allow read, delete: if isSignedIn() && resource.data.ownerUid == request.auth.uid;
+      allow update: if isSignedIn() &&
+                    resource.data.ownerUid == request.auth.uid &&
+                    request.resource.data.ownerUid == resource.data.ownerUid;
+    }
+    match /monzo_sync_jobs/{id} {
+      allow create: if isSignedIn() && request.resource.data.ownerUid == request.auth.uid;
+      allow read, delete: if isSignedIn() && resource.data.ownerUid == request.auth.uid;
+      allow update: if isSignedIn() &&
+                    resource.data.ownerUid == request.auth.uid &&
+                    request.resource.data.ownerUid == resource.data.ownerUid;
+    }
+    match /monzo_transfer_runs/{id} {
+      allow create: if isSignedIn() && request.resource.data.ownerUid == request.auth.uid;
+      allow read, delete: if isSignedIn() && resource.data.ownerUid == request.auth.uid;
+      allow update: if isSignedIn() &&
+                    resource.data.ownerUid == request.auth.uid &&
+                    request.resource.data.ownerUid == resource.data.ownerUid;
+    }
+    match /finance_external_transactions/{id} {
+      allow create: if isSignedIn() && request.resource.data.ownerUid == request.auth.uid;
+      allow read, delete: if isSignedIn() && resource.data.ownerUid == request.auth.uid;
+      allow update: if isSignedIn() &&
+                    resource.data.ownerUid == request.auth.uid &&
+                    request.resource.data.ownerUid == resource.data.ownerUid;
+    }
+    match /finance_transaction_matches/{id} {
+      allow create: if isSignedIn() && request.resource.data.ownerUid == request.auth.uid;
+      allow read, delete: if isSignedIn() && resource.data.ownerUid == request.auth.uid;
+      allow update: if isSignedIn() &&
+                    resource.data.ownerUid == request.auth.uid &&
+                    request.resource.data.ownerUid == resource.data.ownerUid;
+    }
+    match /finance_debt_service/{uid} {
+      allow create: if isSignedIn() && (request.auth.uid == uid || request.resource.data.ownerUid == request.auth.uid);
+      allow read: if isSignedIn() && (request.auth.uid == uid || resource.data.ownerUid == request.auth.uid);
+      allow update: if isSignedIn() && (request.auth.uid == uid || resource.data.ownerUid == request.auth.uid);
+      allow delete: if isSignedIn() && (request.auth.uid == uid || resource.data.ownerUid == request.auth.uid);
+    }
+    match /finance_action_insights/{uid} {
+      allow create: if isSignedIn() && (request.auth.uid == uid || request.resource.data.ownerUid == request.auth.uid);
+      allow read: if isSignedIn() && (request.auth.uid == uid || resource.data.ownerUid == request.auth.uid);
+      allow update: if isSignedIn() && (request.auth.uid == uid || resource.data.ownerUid == request.auth.uid);
+      allow delete: if isSignedIn() && (request.auth.uid == uid || resource.data.ownerUid == request.auth.uid);
+    }
+    match /finance_manual_accounts/{id} {
+      allow create: if isSignedIn() && request.resource.data.ownerUid == request.auth.uid;
+      allow read, delete: if isSignedIn() && resource.data.ownerUid == request.auth.uid;
+      allow update: if isSignedIn() &&
+                    resource.data.ownerUid == request.auth.uid &&
+                    request.resource.data.ownerUid == resource.data.ownerUid;
+    }
+
     // New scheduler-related collections
     match /themes/{id} { allow create: if isOwnerForCreate(); allow read, update, delete: if isOwner(); }
     match /chores/{id} { allow create: if isOwnerForCreate(); allow read, update, delete: if isOwner(); }

--- a/functions/finance/dashboard.js
+++ b/functions/finance/dashboard.js
@@ -67,7 +67,8 @@ function aggregateTransactions(transactions, startDate, endDate) {
         const minor = Number.isFinite(tx.amountMinor) ? tx.amountMinor : null;
         const rawAmount = typeof tx.amount === 'number' ? tx.amount : 0;
         const amount = minor !== null ? minor / 100 : (Math.abs(rawAmount) < 10 ? rawAmount * 100 : rawAmount);
-        const bucketRaw = potId ? 'bank_transfer' : (tx.aiBucket || tx.userCategoryType || tx.defaultCategoryType || 'unspecified');
+        // User overrides should win over AI for reporting.
+        const bucketRaw = potId ? 'bank_transfer' : (tx.userCategoryType || tx.aiBucket || tx.defaultCategoryType || 'unspecified');
         const bucket = String(bucketRaw).toLowerCase();
         const bucketNormalized = bucket === 'optional' ? 'discretionary' : bucket;
 
@@ -92,7 +93,7 @@ function aggregateTransactions(transactions, startDate, endDate) {
         result.timeSeriesByBucket[bucketNormalized][month] = (result.timeSeriesByBucket[bucketNormalized][month] || 0) + amount;
 
         // Category aggregation
-        const catKey = tx.aiCategoryKey || tx.userCategoryKey || tx.category || 'uncategorized';
+        const catKey = tx.userCategoryKey || tx.aiCategoryKey || tx.category || 'uncategorized';
         result.spendByCategory[catKey] = (result.spendByCategory[catKey] || 0) + amount;
 
         if (!result.timeSeriesByCategory) result.timeSeriesByCategory = {};

--- a/functions/finance/enhancements.js
+++ b/functions/finance/enhancements.js
@@ -7,6 +7,7 @@ const { normaliseMerchantName } = require('../monzo/shared');
 const { mergeFinanceCategories } = require('./categories');
 
 const GOOGLE_AI_STUDIO_API_KEY = defineSecret('GOOGLEAISTUDIOAPIKEY');
+const FUNCTION_REGION = 'europe-west2';
 const EXTERNAL_SOURCES = new Set(['barclays', 'paypal', 'other']);
 const MANUAL_ACCOUNT_TYPES = new Set(['asset', 'debt', 'investment', 'cash', 'savings']);
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -292,7 +293,7 @@ async function callGeminiActionRefinement({ uid, actions }) {
   return list;
 }
 
-const importExternalFinanceTransactions = httpsV2.onCall(async (req) => {
+const importExternalFinanceTransactions = httpsV2.onCall({ region: FUNCTION_REGION }, async (req) => {
   if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
   const uid = req.auth.uid;
   const source = normalizeExternalSource(req.data?.source);
@@ -349,7 +350,7 @@ const importExternalFinanceTransactions = httpsV2.onCall(async (req) => {
   };
 });
 
-const matchExternalToMonzoTransactions = httpsV2.onCall(async (req) => {
+const matchExternalToMonzoTransactions = httpsV2.onCall({ region: FUNCTION_REGION }, async (req) => {
   if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
   const uid = req.auth.uid;
   const source = req.data?.source ? normalizeExternalSource(req.data?.source) : null;
@@ -495,7 +496,7 @@ const matchExternalToMonzoTransactions = httpsV2.onCall(async (req) => {
   return { ok: true, source, windowDays, amountTolerancePence, matched, unmatched, bySource };
 });
 
-const recomputeDebtServiceBreakdown = httpsV2.onCall(async (req) => {
+const recomputeDebtServiceBreakdown = httpsV2.onCall({ region: FUNCTION_REGION }, async (req) => {
   if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
   const uid = req.auth.uid;
   const source = normalizeExternalSource(req.data?.source || 'barclays');
@@ -603,7 +604,7 @@ const recomputeDebtServiceBreakdown = httpsV2.onCall(async (req) => {
   return { ok: true, source, perMonth, totals };
 });
 
-const generateFinanceActionInsights = httpsV2.onCall({ secrets: [GOOGLE_AI_STUDIO_API_KEY] }, async (req) => {
+const generateFinanceActionInsights = httpsV2.onCall({ region: FUNCTION_REGION, secrets: [GOOGLE_AI_STUDIO_API_KEY] }, async (req) => {
   if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
   const uid = req.auth.uid;
   const source = normalizeExternalSource(req.data?.source || 'barclays');
@@ -761,7 +762,7 @@ const generateFinanceActionInsights = httpsV2.onCall({ secrets: [GOOGLE_AI_STUDI
   return { ok: true, source, actions };
 });
 
-const convertFinanceActionToStory = httpsV2.onCall(async (req) => {
+const convertFinanceActionToStory = httpsV2.onCall({ region: FUNCTION_REGION }, async (req) => {
   if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
   const uid = req.auth.uid;
   const actionId = String(req.data?.actionId || '').trim();
@@ -839,7 +840,7 @@ const convertFinanceActionToStory = httpsV2.onCall(async (req) => {
   };
 });
 
-const upsertManualFinanceAccount = httpsV2.onCall(async (req) => {
+const upsertManualFinanceAccount = httpsV2.onCall({ region: FUNCTION_REGION }, async (req) => {
   if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
   const uid = req.auth.uid;
   const name = String(req.data?.name || '').trim();
@@ -896,7 +897,7 @@ const upsertManualFinanceAccount = httpsV2.onCall(async (req) => {
   };
 });
 
-const deleteManualFinanceAccount = httpsV2.onCall(async (req) => {
+const deleteManualFinanceAccount = httpsV2.onCall({ region: FUNCTION_REGION }, async (req) => {
   if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
   const uid = req.auth.uid;
   const accountId = String(req.data?.accountId || '').trim();
@@ -911,7 +912,7 @@ const deleteManualFinanceAccount = httpsV2.onCall(async (req) => {
   return { ok: true, deleted: true, accountId };
 });
 
-const fetchFinanceEnhancementData = httpsV2.onCall(async (req) => {
+const fetchFinanceEnhancementData = httpsV2.onCall({ region: FUNCTION_REGION }, async (req) => {
   if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
   const uid = req.auth.uid;
   const startMs = Date.parse(String(req.data?.startDate || '2018-01-01T00:00:00.000Z'));

--- a/functions/finance/enhancements.js
+++ b/functions/finance/enhancements.js
@@ -1,0 +1,1375 @@
+const httpsV2 = require('firebase-functions/v2/https');
+const { defineSecret } = require('firebase-functions/params');
+const admin = require('firebase-admin');
+const crypto = require('crypto');
+const { GoogleGenerativeAI } = require('@google/generative-ai');
+const { normaliseMerchantName } = require('../monzo/shared');
+const { mergeFinanceCategories } = require('./categories');
+
+const GOOGLE_AI_STUDIO_API_KEY = defineSecret('GOOGLEAISTUDIOAPIKEY');
+const EXTERNAL_SOURCES = new Set(['barclays', 'paypal', 'other']);
+const MANUAL_ACCOUNT_TYPES = new Set(['asset', 'debt', 'investment', 'cash', 'savings']);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function normalizeExternalSource(raw) {
+  const source = String(raw || 'other').trim().toLowerCase();
+  if (source === 'barclaycard' || source === 'barclay') return 'barclays';
+  if (source === 'pay_pal') return 'paypal';
+  if (EXTERNAL_SOURCES.has(source)) return source;
+  return 'other';
+}
+
+function normalizeManualAccountType(rawType) {
+  const type = String(rawType || 'asset').trim().toLowerCase();
+  if (MANUAL_ACCOUNT_TYPES.has(type)) return type;
+  return 'asset';
+}
+
+function csvSplitLine(line, delimiter) {
+  const cells = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    const next = line[i + 1];
+    if (ch === '"') {
+      if (inQuotes && next === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+    if (ch === delimiter && !inQuotes) {
+      cells.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  cells.push(current.trim());
+  return cells;
+}
+
+function parseCsvRows(csvText) {
+  const lines = String(csvText || '')
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (!lines.length) return [];
+  const sample = lines[0] || '';
+  const commaCount = (sample.match(/,/g) || []).length;
+  const semicolonCount = (sample.match(/;/g) || []).length;
+  const tabCount = (sample.match(/\t/g) || []).length;
+  const delimiter = tabCount >= commaCount && tabCount >= semicolonCount
+    ? '\t'
+    : semicolonCount > commaCount
+      ? ';'
+      : ',';
+  return lines.map((line) => csvSplitLine(line, delimiter));
+}
+
+function normalizeHeader(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function parseDateMs(rawValue) {
+  if (rawValue === undefined || rawValue === null) return null;
+  if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+    if (rawValue > 20000 && rawValue < 60000) {
+      const excelEpoch = Date.UTC(1899, 11, 30);
+      return excelEpoch + Math.round(rawValue * DAY_MS);
+    }
+    if (rawValue > 1_000_000_000_000) return rawValue;
+  }
+  const value = String(rawValue).trim();
+  if (!value) return null;
+  const direct = Date.parse(value);
+  if (!Number.isNaN(direct)) return direct;
+  const slash = value.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})$/);
+  if (slash) {
+    const d = Number(slash[1]);
+    const m = Number(slash[2]);
+    let y = Number(slash[3]);
+    if (y < 100) y += 2000;
+    const dt = new Date(Date.UTC(y, m - 1, d));
+    return Number.isNaN(dt.getTime()) ? null : dt.getTime();
+  }
+  return null;
+}
+
+function parseMoneyMinor(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.round(value * 100);
+  let text = String(value).trim();
+  if (!text) return null;
+  let negative = false;
+  if (/^\(.*\)$/.test(text)) {
+    negative = true;
+    text = text.slice(1, -1);
+  }
+  text = text.replace(/[£$€,\s]/g, '');
+  if (text.includes('.') && text.includes(',')) {
+    text = text.replace(/,/g, '');
+  } else if (text.includes(',') && !text.includes('.')) {
+    text = text.replace(/,/g, '.');
+  }
+  const parsed = Number(text);
+  if (!Number.isFinite(parsed)) return null;
+  let minor = Math.round(parsed * 100);
+  if (negative) minor = -Math.abs(minor);
+  return minor;
+}
+
+function buildExternalRowsFromCsv(csvText, source) {
+  const rows = parseCsvRows(csvText);
+  if (!rows.length) return [];
+  const first = rows[0];
+  const firstHeader = first.map(normalizeHeader);
+  const headerLike = firstHeader.some((h) => h.includes('date') || h.includes('amount') || h.includes('description') || h.includes('merchant'));
+  const header = headerLike ? firstHeader : [];
+  const dataRows = headerLike ? rows.slice(1) : rows;
+  const idx = (needles, fallback = -1) => {
+    if (!header.length) return fallback;
+    for (let i = 0; i < header.length; i += 1) {
+      if (needles.some((n) => header[i].includes(n))) return i;
+    }
+    return fallback;
+  };
+  const dateIdx = idx(['date', 'posted', 'booking', 'transaction']);
+  const descIdx = idx(['description', 'details', 'merchant', 'name', 'memo'], 1);
+  const debitIdx = idx(['debit', 'withdrawal', 'out']);
+  const creditIdx = idx(['credit', 'deposit', 'in']);
+  const amountIdx = idx(['amount', 'value'], 2);
+  const idIdx = idx(['id', 'reference', 'txn', 'transaction id', 'unique']);
+
+  const result = [];
+  dataRows.forEach((row, index) => {
+    if (!row || !row.length) return;
+    const dateRaw = dateIdx >= 0 ? row[dateIdx] : row[0];
+    const dateMs = parseDateMs(dateRaw);
+    if (!dateMs) return;
+
+    let amountMinor = null;
+    const debitMinor = debitIdx >= 0 ? parseMoneyMinor(row[debitIdx]) : null;
+    const creditMinor = creditIdx >= 0 ? parseMoneyMinor(row[creditIdx]) : null;
+    const amountMinorRaw = amountIdx >= 0 ? parseMoneyMinor(row[amountIdx]) : null;
+    if (Number.isFinite(debitMinor) && debitMinor !== 0) amountMinor = -Math.abs(debitMinor);
+    else if (Number.isFinite(creditMinor) && creditMinor !== 0) amountMinor = Math.abs(creditMinor);
+    else if (Number.isFinite(amountMinorRaw)) amountMinor = amountMinorRaw;
+    if (!Number.isFinite(amountMinor) || amountMinor === 0) return;
+
+    const description = String(descIdx >= 0 ? row[descIdx] : row[1] || row[0] || '').trim();
+    const descLower = description.toLowerCase();
+    if ((source === 'barclays' || source === 'paypal') && amountMinor > 0) {
+      const keepPositive = /refund|reversal|credit|cashback|payment received|deposit|received/.test(descLower);
+      if (!keepPositive) amountMinor = -Math.abs(amountMinor);
+    }
+
+    const merchantName = description.split(/[-*|]/)[0].trim() || description || `${source}-${index + 1}`;
+    const merchantKey = normaliseMerchantName(merchantName);
+    const externalRef = idIdx >= 0 ? String(row[idIdx] || '').trim() : '';
+    const fingerprint = `${source}|${externalRef || `${dateMs}|${amountMinor}|${description}|${index}`}`;
+    const externalId = crypto.createHash('sha1').update(fingerprint).digest('hex').slice(0, 24);
+    result.push({
+      source,
+      externalId,
+      externalRef: externalRef || null,
+      postedDateISO: new Date(dateMs).toISOString(),
+      postedDateMs: dateMs,
+      amountMinor,
+      amount: amountMinor / 100,
+      currency: 'GBP',
+      description: description || merchantName,
+      merchantName,
+      merchantKey,
+      rawRow: row,
+    });
+  });
+  return result;
+}
+
+function normalizeAmountMinor(data) {
+  if (Number.isFinite(data?.amountMinor)) return Math.round(Number(data.amountMinor));
+  const amount = Number(data?.amount || 0);
+  if (!Number.isFinite(amount)) return 0;
+  return Math.round(amount * 100);
+}
+
+function timestampToMs(ts, fallbackISO) {
+  if (ts?.toMillis) return ts.toMillis();
+  if (ts?.toDate) return ts.toDate().getTime();
+  if (typeof ts === 'number' && Number.isFinite(ts)) return ts;
+  if (fallbackISO) {
+    const parsed = Date.parse(String(fallbackISO));
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+function tokenize(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]+/g, ' ')
+    .split(/\s+/)
+    .map((v) => v.trim())
+    .filter((v) => v && !['the', 'and', 'ltd', 'limited', 'plc', 'payment', 'card'].includes(v));
+}
+
+function jaccard(a, b) {
+  const aSet = new Set(a);
+  const bSet = new Set(b);
+  if (!aSet.size && !bSet.size) return 0;
+  let inter = 0;
+  aSet.forEach((v) => { if (bSet.has(v)) inter += 1; });
+  const union = new Set([...aSet, ...bSet]).size;
+  return union ? inter / union : 0;
+}
+
+function monthKeyFromMs(ms) {
+  if (!ms) return null;
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return null;
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+function normalizeBucket(bucketRaw) {
+  const bucket = String(bucketRaw || '').toLowerCase();
+  if (!bucket) return 'unknown';
+  if (bucket === 'discretionary') return 'optional';
+  if (bucket.includes('saving') || bucket === 'investment') return 'savings';
+  if (bucket === 'net_salary' || bucket === 'irregular_income') return 'income';
+  if (bucket === 'debt_repayment') return 'mandatory';
+  return bucket;
+}
+
+function buildActionId(action) {
+  return crypto
+    .createHash('sha1')
+    .update(`${action.source || 'heuristic'}|${action.type}|${action.merchantKey || action.title}|${action.reference || ''}`)
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function extractJson(text) {
+  if (!text) return null;
+  const trimmed = String(text).trim();
+  try { return JSON.parse(trimmed); } catch { }
+  const block = trimmed.match(/```json([\s\S]*?)```/i) || trimmed.match(/```([\s\S]*?)```/i);
+  if (block && block[1]) {
+    try { return JSON.parse(block[1].trim()); } catch { }
+  }
+  const firstBrace = trimmed.indexOf('{');
+  const lastBrace = trimmed.lastIndexOf('}');
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    try { return JSON.parse(trimmed.slice(firstBrace, lastBrace + 1)); } catch { }
+  }
+  return null;
+}
+
+async function callGeminiActionRefinement({ uid, actions }) {
+  const apiKey = process.env.GOOGLEAISTUDIOAPIKEY || process.env.GOOGLE_AI_STUDIO_API_KEY || '';
+  if (!apiKey || !actions.length) return null;
+  const modelName = process.env.GEMINI_MODEL || 'gemini-1.5-flash';
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({ model: modelName });
+  const prompt = [
+    'You are a personal finance optimization assistant.',
+    'Given these action candidates, return JSON only in the shape:',
+    '{"actions":[{"merchantKey":"string","type":"cancel|reduce|review|debt_optimization","title":"string","reason":"string","estimatedMonthlySavings":number,"confidence":0-1}]}',
+    'Keep at most 12 actions. Be conservative and practical.',
+    `Candidates: ${JSON.stringify(actions.slice(0, 40))}`,
+  ].join('\n');
+  const result = await model.generateContent(prompt);
+  const text = result?.response?.text?.() || '';
+  const parsed = extractJson(text);
+  const list = Array.isArray(parsed?.actions) ? parsed.actions : [];
+  if (!list.length) return null;
+  return list;
+}
+
+const importExternalFinanceTransactions = httpsV2.onCall(async (req) => {
+  if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
+  const uid = req.auth.uid;
+  const source = normalizeExternalSource(req.data?.source);
+  const csvText = String(req.data?.csv || '').trim();
+  if (!csvText) throw new httpsV2.HttpsError('invalid-argument', 'csv is required');
+
+  const parsedRows = buildExternalRowsFromCsv(csvText, source);
+  if (!parsedRows.length) {
+    return { ok: true, source, parsed: 0, upserted: 0, skipped: 0, message: 'No valid rows detected in CSV.' };
+  }
+
+  const db = admin.firestore();
+  let batch = db.batch();
+  let ops = 0;
+  let upserted = 0;
+  const maxBatch = 400;
+
+  for (const row of parsedRows) {
+    const docRef = db.collection('finance_external_transactions').doc(`${uid}_${source}_${row.externalId}`);
+    batch.set(docRef, {
+      ownerUid: uid,
+      source,
+      externalId: row.externalId,
+      externalRef: row.externalRef || null,
+      postedDateISO: row.postedDateISO,
+      postedAt: admin.firestore.Timestamp.fromDate(new Date(row.postedDateMs)),
+      amountMinor: row.amountMinor,
+      amount: row.amount,
+      currency: row.currency || 'GBP',
+      description: row.description,
+      merchantName: row.merchantName,
+      merchantKey: row.merchantKey || normaliseMerchantName(row.merchantName || row.description || row.externalId),
+      rawRow: row.rawRow || null,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      importedAt: admin.firestore.FieldValue.serverTimestamp(),
+    }, { merge: true });
+    upserted += 1;
+    ops += 1;
+    if (ops >= maxBatch) {
+      await batch.commit();
+      batch = db.batch();
+      ops = 0;
+    }
+  }
+  if (ops > 0) await batch.commit();
+
+  return {
+    ok: true,
+    source,
+    parsed: parsedRows.length,
+    upserted,
+    skipped: Math.max(0, parseCsvRows(csvText).length - parsedRows.length),
+    sample: parsedRows.slice(0, 5),
+  };
+});
+
+const matchExternalToMonzoTransactions = httpsV2.onCall(async (req) => {
+  if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
+  const uid = req.auth.uid;
+  const source = req.data?.source ? normalizeExternalSource(req.data?.source) : null;
+  const windowDays = Math.max(1, Math.min(Number(req.data?.windowDays || 5), 30));
+  const amountTolerancePence = Math.max(1, Math.min(Number(req.data?.amountTolerancePence || 150), 2_000));
+
+  const db = admin.firestore();
+  const [externalSnap, monzoSnap] = await Promise.all([
+    db.collection('finance_external_transactions').where('ownerUid', '==', uid).get(),
+    db.collection('monzo_transactions').where('ownerUid', '==', uid).get(),
+  ]);
+
+  const externalRows = externalSnap.docs
+    .map((d) => ({ id: d.id, ref: d.ref, ...(d.data() || {}) }))
+    .filter((row) => !source || row.source === source);
+  if (!externalRows.length) {
+    return { ok: true, matched: 0, unmatched: 0, source, message: 'No external rows available for matching.' };
+  }
+
+  const monzoRows = monzoSnap.docs.map((d) => {
+    const data = d.data() || {};
+    const amountMinor = normalizeAmountMinor(data);
+    const dateMs = timestampToMs(data.createdAt, data.createdISO);
+    const merchantText = `${data.merchant?.name || ''} ${data.counterparty?.name || ''} ${data.description || ''}`.trim();
+    return {
+      docId: d.id,
+      transactionId: data.transactionId || d.id,
+      amountMinor: Math.abs(amountMinor),
+      rawAmountMinor: amountMinor,
+      dateMs,
+      merchantTokens: tokenize(merchantText),
+      merchantText: merchantText.toLowerCase(),
+    };
+  }).filter((row) => row.dateMs && row.amountMinor > 0);
+
+  monzoRows.sort((a, b) => a.dateMs - b.dateMs);
+  externalRows.sort((a, b) => {
+    const aMs = timestampToMs(a.postedAt, a.postedDateISO) || 0;
+    const bMs = timestampToMs(b.postedAt, b.postedDateISO) || 0;
+    return aMs - bMs;
+  });
+
+  const usedMonzo = new Set();
+  let matched = 0;
+  let unmatched = 0;
+  let ops = 0;
+  let batch = db.batch();
+  const maxBatch = 350;
+  const bySource = {};
+
+  for (const ext of externalRows) {
+    const extDateMs = timestampToMs(ext.postedAt, ext.postedDateISO);
+    const extAmountMinor = Math.abs(normalizeAmountMinor(ext));
+    const extTokens = tokenize(`${ext.merchantName || ''} ${ext.description || ''}`);
+    if (!extDateMs || !extAmountMinor) continue;
+
+    let best = null;
+    for (const monzo of monzoRows) {
+      if (usedMonzo.has(monzo.docId)) continue;
+      const amountDiff = Math.abs(monzo.amountMinor - extAmountMinor);
+      if (amountDiff > amountTolerancePence) continue;
+      const dateDiffDays = Math.abs(monzo.dateMs - extDateMs) / DAY_MS;
+      if (dateDiffDays > windowDays) continue;
+      const similarity = jaccard(extTokens, monzo.merchantTokens);
+      const normalizedAmount = amountDiff / amountTolerancePence;
+      const normalizedDate = dateDiffDays / windowDays;
+      const score = (normalizedAmount * 0.55) + (normalizedDate * 0.35) + ((1 - similarity) * 0.10);
+      if (!best || score < best.score) {
+        best = { monzo, score, amountDiff, dateDiffDays, similarity };
+      }
+    }
+
+    const matchId = `${uid}_${ext.source || 'other'}_${ext.externalId || ext.id}`;
+    const matchRef = db.collection('finance_transaction_matches').doc(matchId);
+    if (best) {
+      usedMonzo.add(best.monzo.docId);
+      const confidence = Math.max(0, Math.min(1, Number((1 - best.score).toFixed(3))));
+      matched += 1;
+      bySource[ext.source || 'other'] = bySource[ext.source || 'other'] || { matched: 0, unmatched: 0 };
+      bySource[ext.source || 'other'].matched += 1;
+      batch.set(matchRef, {
+        ownerUid: uid,
+        source: ext.source || 'other',
+        externalDocId: ext.id,
+        externalId: ext.externalId || null,
+        externalRef: ext.externalRef || null,
+        externalDateISO: ext.postedDateISO || null,
+        externalAmountMinor: normalizeAmountMinor(ext),
+        externalMerchant: ext.merchantName || ext.description || null,
+        monzoDocId: best.monzo.docId,
+        monzoTransactionId: best.monzo.transactionId,
+        monzoDateMs: best.monzo.dateMs,
+        monzoAmountMinor: best.monzo.rawAmountMinor,
+        amountDiffPence: best.amountDiff,
+        dateDiffDays: Number(best.dateDiffDays.toFixed(3)),
+        merchantSimilarity: Number(best.similarity.toFixed(3)),
+        confidence,
+        status: 'matched',
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+      batch.set(ext.ref, {
+        matchedMonzoDocId: best.monzo.docId,
+        matchedMonzoTransactionId: best.monzo.transactionId,
+        matchConfidence: confidence,
+        matchedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+    } else {
+      unmatched += 1;
+      bySource[ext.source || 'other'] = bySource[ext.source || 'other'] || { matched: 0, unmatched: 0 };
+      bySource[ext.source || 'other'].unmatched += 1;
+      batch.set(matchRef, {
+        ownerUid: uid,
+        source: ext.source || 'other',
+        externalDocId: ext.id,
+        externalId: ext.externalId || null,
+        externalRef: ext.externalRef || null,
+        externalDateISO: ext.postedDateISO || null,
+        externalAmountMinor: normalizeAmountMinor(ext),
+        externalMerchant: ext.merchantName || ext.description || null,
+        monzoDocId: null,
+        monzoTransactionId: null,
+        confidence: 0,
+        status: 'unmatched',
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+      batch.set(ext.ref, {
+        matchedMonzoDocId: null,
+        matchedMonzoTransactionId: null,
+        matchConfidence: 0,
+        matchedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+    }
+
+    ops += 2;
+    if (ops >= maxBatch) {
+      await batch.commit();
+      batch = db.batch();
+      ops = 0;
+    }
+  }
+
+  if (ops > 0) await batch.commit();
+  return { ok: true, source, windowDays, amountTolerancePence, matched, unmatched, bySource };
+});
+
+const recomputeDebtServiceBreakdown = httpsV2.onCall(async (req) => {
+  if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
+  const uid = req.auth.uid;
+  const source = normalizeExternalSource(req.data?.source || 'barclays');
+  const db = admin.firestore();
+
+  const [externalSnap, monzoSnap] = await Promise.all([
+    db.collection('finance_external_transactions').where('ownerUid', '==', uid).get(),
+    db.collection('monzo_transactions').where('ownerUid', '==', uid).get(),
+  ]);
+
+  const sourceRows = externalSnap.docs
+    .map((d) => ({ id: d.id, ...(d.data() || {}) }))
+    .filter((row) => row.source === source);
+
+  const monthMap = {};
+  const ensureMonth = (month) => {
+    if (!month) return null;
+    if (!monthMap[month]) {
+      monthMap[month] = {
+        month,
+        statementSpendPence: 0,
+        statementPaymentsPence: 0,
+        explicitInterestPence: 0,
+        refundsPence: 0,
+        monzoPaymentsPence: 0,
+      };
+    }
+    return monthMap[month];
+  };
+
+  for (const row of sourceRows) {
+    const dateMs = timestampToMs(row.postedAt, row.postedDateISO);
+    const month = monthKeyFromMs(dateMs);
+    const entry = ensureMonth(month);
+    if (!entry) continue;
+    const amountMinor = normalizeAmountMinor(row);
+    const absAmount = Math.abs(amountMinor);
+    const desc = String(row.description || row.merchantName || '').toLowerCase();
+    const isInterest = /interest|finance charge|service charge|late fee|fee charge/.test(desc);
+    const isRefund = /refund|chargeback|reversal|dispute|credit/.test(desc);
+    const isPayment = /payment|direct debit|dd payment|balance transfer|paid/.test(desc) || amountMinor > 0;
+
+    if (isInterest) entry.explicitInterestPence += absAmount;
+    if (isRefund) entry.refundsPence += absAmount;
+    if (isPayment) entry.statementPaymentsPence += absAmount;
+    if (amountMinor < 0 && !isPayment && !isRefund) entry.statementSpendPence += absAmount;
+  }
+
+  const paymentRegex = source === 'paypal'
+    ? /paypal/i
+    : /barclay|barclays|barclaycard/i;
+  for (const doc of monzoSnap.docs) {
+    const data = doc.data() || {};
+    const amountMinor = normalizeAmountMinor(data);
+    if (amountMinor >= 0) continue;
+    const text = `${data.merchant?.name || ''} ${data.counterparty?.name || ''} ${data.description || ''}`.toLowerCase();
+    if (!paymentRegex.test(text)) continue;
+    const dateMs = timestampToMs(data.createdAt, data.createdISO);
+    const month = monthKeyFromMs(dateMs);
+    const entry = ensureMonth(month);
+    if (!entry) continue;
+    entry.monzoPaymentsPence += Math.abs(amountMinor);
+  }
+
+  const perMonth = Object.values(monthMap)
+    .sort((a, b) => a.month.localeCompare(b.month))
+    .map((entry) => {
+      const interestFromPaymentDelta = Math.max(entry.monzoPaymentsPence - entry.statementSpendPence, 0);
+      const estimatedInterestPence = Math.max(entry.explicitInterestPence, interestFromPaymentDelta);
+      const principalRepaymentPence = Math.max(entry.monzoPaymentsPence - estimatedInterestPence, 0);
+      return {
+        ...entry,
+        estimatedInterestPence,
+        principalRepaymentPence,
+      };
+    });
+
+  const totals = perMonth.reduce((acc, item) => {
+    acc.statementSpendPence += item.statementSpendPence;
+    acc.statementPaymentsPence += item.statementPaymentsPence;
+    acc.explicitInterestPence += item.explicitInterestPence;
+    acc.refundsPence += item.refundsPence;
+    acc.monzoPaymentsPence += item.monzoPaymentsPence;
+    acc.estimatedInterestPence += item.estimatedInterestPence;
+    acc.principalRepaymentPence += item.principalRepaymentPence;
+    return acc;
+  }, {
+    statementSpendPence: 0,
+    statementPaymentsPence: 0,
+    explicitInterestPence: 0,
+    refundsPence: 0,
+    monzoPaymentsPence: 0,
+    estimatedInterestPence: 0,
+    principalRepaymentPence: 0,
+  });
+
+  await db.collection('finance_debt_service').doc(uid).set({
+    ownerUid: uid,
+    source,
+    perMonth,
+    totals,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }, { merge: true });
+
+  return { ok: true, source, perMonth, totals };
+});
+
+const generateFinanceActionInsights = httpsV2.onCall({ secrets: [GOOGLE_AI_STUDIO_API_KEY] }, async (req) => {
+  if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
+  const uid = req.auth.uid;
+  const source = normalizeExternalSource(req.data?.source || 'barclays');
+  const maxActions = Math.max(5, Math.min(Number(req.data?.maxActions || 12), 25));
+
+  const db = admin.firestore();
+  const [summarySnap, debtSnap, existingSnap] = await Promise.all([
+    db.collection('monzo_budget_summary').doc(uid).get(),
+    db.collection('finance_debt_service').doc(uid).get(),
+    db.collection('finance_action_insights').doc(uid).get(),
+  ]);
+  const summary = summarySnap.exists ? (summarySnap.data() || {}) : {};
+  const debt = debtSnap.exists ? (debtSnap.data() || {}) : {};
+  const existingActions = Array.isArray(existingSnap.data()?.actions) ? existingSnap.data().actions : [];
+  const statusById = new Map(existingActions.map((action) => [action.id, action]));
+
+  const recurring = Array.isArray(summary.recurringMerchants) ? summary.recurringMerchants : [];
+  const fallbackMerchants = Array.isArray(summary.merchantSummary) ? summary.merchantSummary : [];
+  const merchantCandidates = (recurring.length ? recurring : fallbackMerchants)
+    .filter((m) => Number(m.totalSpend || 0) > 0)
+    .slice(0, 120);
+
+  const heuristicActions = [];
+  for (const merchant of merchantCandidates) {
+    const merchantKey = merchant.merchantKey || normaliseMerchantName(merchant.merchantName || 'merchant');
+    const merchantName = merchant.merchantName || merchantKey;
+    const months = Math.max(1, Number(merchant.months || 1));
+    const totalSpend = Number(merchant.totalSpend || 0);
+    const monthlySpend = totalSpend / months;
+    const category = normalizeBucket(merchant.primaryCategoryType || 'optional');
+    if (!Number.isFinite(monthlySpend) || monthlySpend < 8) continue;
+
+    let type = 'review';
+    if (category === 'optional' && merchant.isRecurring && monthlySpend >= 20) type = 'cancel';
+    else if (category === 'optional') type = 'reduce';
+    else if (category === 'mandatory' && merchant.isRecurring && monthlySpend >= 30) type = 'review';
+    if (type === 'review' && category === 'income') continue;
+
+    const estimatedMonthlySavings = type === 'cancel'
+      ? monthlySpend
+      : type === 'reduce'
+        ? monthlySpend * 0.25
+        : monthlySpend * 0.1;
+    const confidence = type === 'cancel' ? 0.78 : type === 'reduce' ? 0.68 : 0.55;
+    heuristicActions.push({
+      merchantKey,
+      merchantName,
+      source: 'heuristic',
+      type,
+      title: type === 'cancel'
+        ? `Cancel or pause ${merchantName}`
+        : type === 'reduce'
+          ? `Reduce spend with ${merchantName}`
+          : `Review ${merchantName} charges`,
+      reason: `~£${monthlySpend.toFixed(2)}/month (${months} month pattern, ${category} spend).`,
+      estimatedMonthlySavings: Number(estimatedMonthlySavings.toFixed(2)),
+      confidence,
+    });
+  }
+
+  const debtEstimatedInterest = Number(debt?.totals?.estimatedInterestPence || 0) / 100;
+  if (debtEstimatedInterest > 0) {
+    heuristicActions.push({
+      merchantKey: `${source}_debt_interest`,
+      merchantName: source === 'barclays' ? 'Barclays Card' : source,
+      source: 'heuristic',
+      type: 'debt_optimization',
+      title: 'Reduce card debt servicing interest',
+      reason: `Estimated interest servicing is £${debtEstimatedInterest.toFixed(2)} across tracked months.`,
+      estimatedMonthlySavings: Number((debtEstimatedInterest / Math.max(1, Number(debt?.perMonth?.length || 1))).toFixed(2)),
+      confidence: 0.73,
+      reference: source,
+    });
+  }
+
+  let llmActions = null;
+  try {
+    llmActions = await callGeminiActionRefinement({
+      uid,
+      actions: heuristicActions.map((a) => ({
+        merchantKey: a.merchantKey,
+        merchantName: a.merchantName,
+        type: a.type,
+        title: a.title,
+        reason: a.reason,
+        estimatedMonthlySavings: a.estimatedMonthlySavings,
+        confidence: a.confidence,
+      })),
+    });
+  } catch (err) {
+    console.warn('[finance-actions] LLM refinement failed', err?.message || err);
+  }
+
+  const finalMap = new Map();
+  heuristicActions.forEach((action) => {
+    finalMap.set(`${action.merchantKey}|${action.type}`, action);
+  });
+  if (Array.isArray(llmActions)) {
+    llmActions.forEach((candidate) => {
+      const merchantKey = String(candidate.merchantKey || '').trim();
+      const type = String(candidate.type || '').trim().toLowerCase();
+      if (!merchantKey || !type) return;
+      const mapKey = `${merchantKey}|${type}`;
+      const fallback = finalMap.get(mapKey) || {
+        merchantKey,
+        merchantName: candidate.merchantName || merchantKey,
+        type,
+        title: candidate.title || `Review ${merchantKey}`,
+        reason: candidate.reason || '',
+        estimatedMonthlySavings: Number(candidate.estimatedMonthlySavings || 0) || 0,
+        confidence: Number(candidate.confidence || 0.5) || 0.5,
+        source: 'llm',
+      };
+      finalMap.set(mapKey, {
+        ...fallback,
+        merchantName: candidate.merchantName || fallback.merchantName,
+        title: candidate.title || fallback.title,
+        reason: candidate.reason || fallback.reason,
+        estimatedMonthlySavings: Number(candidate.estimatedMonthlySavings || fallback.estimatedMonthlySavings || 0) || 0,
+        confidence: Number(candidate.confidence || fallback.confidence || 0.5) || 0.5,
+        source: 'llm',
+      });
+    });
+  }
+
+  const actions = Array.from(finalMap.values())
+    .sort((a, b) => (b.estimatedMonthlySavings || 0) - (a.estimatedMonthlySavings || 0))
+    .slice(0, maxActions)
+    .map((action) => {
+      const id = buildActionId(action);
+      const existing = statusById.get(id) || {};
+      return {
+        id,
+        ...action,
+        status: existing.status || 'open',
+        storyId: existing.storyId || null,
+        convertedAt: existing.convertedAt || null,
+        generatedAt: new Date().toISOString(),
+      };
+    });
+
+  await db.collection('finance_action_insights').doc(uid).set({
+    ownerUid: uid,
+    source,
+    actions,
+    generatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    metadata: {
+      candidateCount: heuristicActions.length,
+      usedLlm: Array.isArray(llmActions) && llmActions.length > 0,
+      maxActions,
+    },
+  }, { merge: true });
+
+  return { ok: true, source, actions };
+});
+
+const convertFinanceActionToStory = httpsV2.onCall(async (req) => {
+  if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
+  const uid = req.auth.uid;
+  const actionId = String(req.data?.actionId || '').trim();
+  if (!actionId) throw new httpsV2.HttpsError('invalid-argument', 'actionId is required');
+
+  const db = admin.firestore();
+  const insightsRef = db.collection('finance_action_insights').doc(uid);
+  const insightsSnap = await insightsRef.get();
+  if (!insightsSnap.exists) throw new httpsV2.HttpsError('not-found', 'Finance actions not found');
+  const data = insightsSnap.data() || {};
+  const actions = Array.isArray(data.actions) ? data.actions : [];
+  const idx = actions.findIndex((a) => a.id === actionId);
+  if (idx < 0) throw new httpsV2.HttpsError('not-found', 'Action not found');
+  const action = actions[idx];
+
+  if (action.storyId) {
+    return { ok: true, storyId: action.storyId, storyPath: `/stories/${action.storyId}`, action };
+  }
+
+  const persona = String(req.data?.persona || 'personal').trim() || 'personal';
+  const goalId = req.data?.goalId ? String(req.data.goalId).trim() : null;
+  const title = req.data?.title
+    ? String(req.data.title).trim()
+    : action.title || `Finance action: ${action.merchantName || action.merchantKey || action.id}`;
+  const description = req.data?.description
+    ? String(req.data.description).trim()
+    : [
+      action.reason || 'Finance optimization action.',
+      action.estimatedMonthlySavings
+        ? `Estimated monthly savings: £${Number(action.estimatedMonthlySavings).toFixed(2)}.`
+        : null,
+      action.merchantName ? `Merchant: ${action.merchantName}.` : null,
+      action.type ? `Type: ${action.type}.` : null,
+    ].filter(Boolean).join(' ');
+
+  const storyRef = await db.collection('stories').add({
+    ref: `FIN-${Date.now()}`,
+    ownerUid: uid,
+    persona,
+    title,
+    description,
+    goalId: goalId || null,
+    sprintId: null,
+    status: 0,
+    priority: 2,
+    points: 2,
+    theme: 3,
+    orderIndex: Date.now(),
+    tags: ['finance', 'action'],
+    acceptanceCriteria: [],
+    source: 'finance_action_insight',
+    financeActionId: actionId,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  const updatedActions = [...actions];
+  updatedActions[idx] = {
+    ...action,
+    status: 'converted',
+    storyId: storyRef.id,
+    convertedAt: new Date().toISOString(),
+  };
+  await insightsRef.set({
+    ownerUid: uid,
+    actions: updatedActions,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }, { merge: true });
+
+  return {
+    ok: true,
+    storyId: storyRef.id,
+    storyPath: `/stories/${storyRef.id}`,
+    action: updatedActions[idx],
+  };
+});
+
+const upsertManualFinanceAccount = httpsV2.onCall(async (req) => {
+  if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
+  const uid = req.auth.uid;
+  const name = String(req.data?.name || '').trim();
+  if (!name) throw new httpsV2.HttpsError('invalid-argument', 'name is required');
+
+  const type = normalizeManualAccountType(req.data?.type);
+  const institution = String(req.data?.institution || '').trim() || null;
+  const notes = String(req.data?.notes || '').trim() || null;
+  const currency = String(req.data?.currency || 'GBP').trim().toUpperCase() || 'GBP';
+  const accountIdRaw = String(req.data?.accountId || '').trim();
+  const balancePenceRaw = req.data?.balancePence;
+  const balanceRaw = req.data?.balance;
+  let balancePence = 0;
+  if (Number.isFinite(Number(balancePenceRaw))) balancePence = Math.round(Number(balancePenceRaw));
+  else if (Number.isFinite(Number(balanceRaw))) balancePence = Math.round(Number(balanceRaw) * 100);
+
+  const db = admin.firestore();
+  const accountId = accountIdRaw || `${uid}_${Date.now()}_${crypto.randomBytes(3).toString('hex')}`;
+  const ref = db.collection('finance_manual_accounts').doc(accountId);
+  const existing = await ref.get();
+  if (existing.exists && existing.data()?.ownerUid !== uid) {
+    throw new httpsV2.HttpsError('permission-denied', 'Not your account record');
+  }
+
+  const payload = {
+    ownerUid: uid,
+    accountId,
+    name,
+    type,
+    institution,
+    notes,
+    currency,
+    balancePence,
+    balance: balancePence / 100,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAtMs: Date.now(),
+  };
+  if (!existing.exists) payload.createdAt = admin.firestore.FieldValue.serverTimestamp();
+  await ref.set(payload, { merge: true });
+
+  return {
+    ok: true,
+    account: {
+      accountId,
+      name,
+      type,
+      institution,
+      notes,
+      currency,
+      balancePence,
+      balance: balancePence / 100,
+      updatedAtMs: payload.updatedAtMs,
+    },
+  };
+});
+
+const deleteManualFinanceAccount = httpsV2.onCall(async (req) => {
+  if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
+  const uid = req.auth.uid;
+  const accountId = String(req.data?.accountId || '').trim();
+  if (!accountId) throw new httpsV2.HttpsError('invalid-argument', 'accountId is required');
+
+  const db = admin.firestore();
+  const ref = db.collection('finance_manual_accounts').doc(accountId);
+  const snap = await ref.get();
+  if (!snap.exists) return { ok: true, deleted: false };
+  if (snap.data()?.ownerUid !== uid) throw new httpsV2.HttpsError('permission-denied', 'Not your account record');
+  await ref.delete();
+  return { ok: true, deleted: true, accountId };
+});
+
+const fetchFinanceEnhancementData = httpsV2.onCall(async (req) => {
+  if (!req?.auth) throw new httpsV2.HttpsError('unauthenticated', 'Sign in required.');
+  const uid = req.auth.uid;
+  const startMs = Date.parse(String(req.data?.startDate || '2018-01-01T00:00:00.000Z'));
+  const endMs = Date.parse(String(req.data?.endDate || new Date().toISOString()));
+  const rangeStartMs = Number.isFinite(startMs) ? startMs : Date.parse('2018-01-01T00:00:00.000Z');
+  const rangeEndMs = Number.isFinite(endMs) ? endMs : Date.now();
+  const nowMs = Date.now();
+
+  const db = admin.firestore();
+  const [
+    monzoSnap,
+    summarySnap,
+    externalSnap,
+    matchesSnap,
+    debtSnap,
+    actionsSnap,
+    budgetV2Snap,
+    budgetLegacySnap,
+    categoriesSnap,
+    goalsSnap,
+    potsSnap,
+    manualAccountsSnap,
+  ] = await Promise.all([
+    db.collection('monzo_transactions').where('ownerUid', '==', uid).get(),
+    db.collection('monzo_budget_summary').doc(uid).get(),
+    db.collection('finance_external_transactions').where('ownerUid', '==', uid).get(),
+    db.collection('finance_transaction_matches').where('ownerUid', '==', uid).get(),
+    db.collection('finance_debt_service').doc(uid).get(),
+    db.collection('finance_action_insights').doc(uid).get(),
+    db.collection('finance_budgets_v2').doc(uid).get(),
+    db.collection('finance_budgets').doc(uid).get(),
+    db.collection('finance_categories').doc(uid).get(),
+    db.collection('goals').where('ownerUid', '==', uid).get(),
+    db.collection('monzo_pots').where('ownerUid', '==', uid).get(),
+    db.collection('finance_manual_accounts').where('ownerUid', '==', uid).get(),
+  ]);
+
+  const monthly = {};
+  const optionalMerchants = new Map();
+  const categorySpendInRange = {};
+  const analysisRows = [];
+  const potContributionMap = new Map();
+  let coverageStartMs = null;
+  let coverageEndMs = null;
+  let inRangeCount = 0;
+
+  const ensureMonth = (month) => {
+    if (!month) return null;
+    if (!monthly[month]) {
+      monthly[month] = {
+        month,
+        inflowPence: 0,
+        outflowPence: 0,
+        netPence: 0,
+        mandatoryPence: 0,
+        optionalPence: 0,
+        savingsPence: 0,
+        incomePence: 0,
+        totalSpendPence: 0,
+      };
+    }
+    return monthly[month];
+  };
+
+  monzoSnap.docs.forEach((doc) => {
+    const data = doc.data() || {};
+    const dateMs = timestampToMs(data.createdAt, data.createdISO);
+    if (!dateMs) return;
+    coverageStartMs = coverageStartMs === null ? dateMs : Math.min(coverageStartMs, dateMs);
+    coverageEndMs = coverageEndMs === null ? dateMs : Math.max(coverageEndMs, dateMs);
+
+    const amountMinor = normalizeAmountMinor(data);
+    const bucket = normalizeBucket(data.userCategoryType || data.aiBucket || data.defaultCategoryType);
+    const categoryKey = String(data.userCategoryKey || data.aiCategoryKey || data.category || 'uncategorized').trim() || 'uncategorized';
+    const categoryLabel = String(data.userCategoryLabel || data.aiCategoryLabel || categoryKey).trim() || categoryKey;
+    const merchantName = data.merchant?.name || data.counterparty?.name || data.description || 'Unknown';
+    const merchantKey = data.merchantKey || normaliseMerchantName(merchantName);
+    const month = monthKeyFromMs(dateMs);
+    const metadata = data.metadata && typeof data.metadata === 'object' ? data.metadata : {};
+    const destinationPotId = metadata.destination_pot_id || metadata.pot_id || null;
+    const sourcePotId = metadata.source_pot_id || null;
+
+    const applyPotContribution = (potId, deltaPence) => {
+      if (!potId || !Number.isFinite(deltaPence) || deltaPence === 0) return;
+      if (!potContributionMap.has(potId)) {
+        potContributionMap.set(potId, {
+          potId,
+          totalInPence: 0,
+          totalOutPence: 0,
+          netContributionPence: 0,
+          monthNet: {},
+        });
+      }
+      const entry = potContributionMap.get(potId);
+      if (deltaPence > 0) entry.totalInPence += deltaPence;
+      else entry.totalOutPence += Math.abs(deltaPence);
+      entry.netContributionPence += deltaPence;
+      if (month) {
+        entry.monthNet[month] = (entry.monthNet[month] || 0) + deltaPence;
+      }
+    };
+
+    // Pot transfer metadata is used for goal contribution forecasting.
+    if (destinationPotId) {
+      const inPence = amountMinor < 0 ? Math.abs(amountMinor) : Math.abs(amountMinor);
+      applyPotContribution(destinationPotId, inPence);
+    }
+    if (sourcePotId) {
+      const outPence = amountMinor > 0 ? Math.abs(amountMinor) : Math.abs(amountMinor);
+      applyPotContribution(sourcePotId, -outPence);
+    }
+
+    if (dateMs < rangeStartMs || dateMs > rangeEndMs) return;
+    inRangeCount += 1;
+    if (bucket === 'bank_transfer' || bucket === 'unknown') return;
+
+    const entry = ensureMonth(month);
+    if (!entry) return;
+    if (amountMinor >= 0) {
+      entry.inflowPence += amountMinor;
+      entry.incomePence += amountMinor;
+    } else {
+      const spend = Math.abs(amountMinor);
+      entry.outflowPence += spend;
+      entry.totalSpendPence += spend;
+      categorySpendInRange[categoryKey] = (categorySpendInRange[categoryKey] || 0) + spend;
+      if (bucket === 'mandatory') entry.mandatoryPence += spend;
+      else if (bucket === 'optional') entry.optionalPence += spend;
+      else if (bucket === 'savings') entry.savingsPence += spend;
+
+      if (bucket === 'optional') {
+        if (!optionalMerchants.has(merchantKey)) {
+          optionalMerchants.set(merchantKey, {
+            merchantKey,
+            merchantName,
+            totalSpendPence: 0,
+            transactions: 0,
+            months: new Set(),
+          });
+        }
+        const item = optionalMerchants.get(merchantKey);
+        item.totalSpendPence += spend;
+        item.transactions += 1;
+        if (month) item.months.add(month);
+      }
+
+      if (bucket !== 'income') {
+        analysisRows.push({
+          id: data.transactionId || doc.id,
+          dateISO: new Date(dateMs).toISOString(),
+          month: month || 'unknown',
+          bucket,
+          categoryKey,
+          categoryLabel,
+          merchantName,
+          merchantKey,
+          amountPence: spend,
+          isSubscription: !!data.isSubscription,
+        });
+      }
+    }
+    entry.netPence = entry.inflowPence - entry.outflowPence;
+  });
+
+  const spendTrackingSeries = Object.values(monthly).sort((a, b) => a.month.localeCompare(b.month));
+  const cashflowSeries = spendTrackingSeries.map((m) => ({
+    month: m.month,
+    inflowPence: m.inflowPence,
+    outflowPence: m.outflowPence,
+    netPence: m.netPence,
+  }));
+
+  const optionalSpendCards = Array.from(optionalMerchants.values())
+    .map((item) => {
+      const monthCount = Math.max(1, item.months.size);
+      return {
+        merchantKey: item.merchantKey,
+        merchantName: item.merchantName,
+        totalSpendPence: item.totalSpendPence,
+        avgMonthlySpendPence: Math.round(item.totalSpendPence / monthCount),
+        transactions: item.transactions,
+        activeMonths: item.months.size,
+        recurring: item.months.size >= 2,
+      };
+    })
+    .sort((a, b) => b.avgMonthlySpendPence - a.avgMonthlySpendPence)
+    .slice(0, 24);
+
+  const categoriesMerged = mergeFinanceCategories(Array.isArray(categoriesSnap.data()?.categories) ? categoriesSnap.data().categories : []);
+  const categoryMeta = new Map();
+  categoriesMerged.forEach((category) => {
+    if (!category?.key) return;
+    categoryMeta.set(category.key, {
+      key: category.key,
+      label: category.label || category.key,
+      bucket: normalizeBucket(category.bucket || 'unknown'),
+    });
+  });
+
+  const budgetV2 = budgetV2Snap.exists ? (budgetV2Snap.data() || {}) : {};
+  const budgetLegacy = budgetLegacySnap.exists ? (budgetLegacySnap.data() || {}) : {};
+  const mode = String(budgetV2.mode || 'percentage');
+  const monthlyIncomePence = Math.max(0, Math.round(Number(budgetV2.monthlyIncome || budgetLegacy.monthlyIncome || 0) * 100));
+  const categoryBudgets = budgetV2.categoryBudgets && typeof budgetV2.categoryBudgets === 'object'
+    ? budgetV2.categoryBudgets
+    : {};
+  const legacyByCategory = budgetLegacy.byCategory && typeof budgetLegacy.byCategory === 'object'
+    ? budgetLegacy.byCategory
+    : {};
+
+  const categoryBudgetRows = [];
+  const pushCategoryBudget = (categoryKey, amountPence, sourceLabel) => {
+    if (!categoryKey || !Number.isFinite(amountPence) || amountPence <= 0) return;
+    const meta = categoryMeta.get(categoryKey) || {
+      key: categoryKey,
+      label: categoryKey,
+      bucket: normalizeBucket('unknown'),
+    };
+    const actualPence = Number(categorySpendInRange[categoryKey] || 0);
+    const utilizationPct = amountPence > 0 ? Number(((actualPence / amountPence) * 100).toFixed(2)) : 0;
+    categoryBudgetRows.push({
+      categoryKey,
+      categoryLabel: meta.label,
+      bucket: meta.bucket,
+      budgetPence: Math.round(amountPence),
+      actualPence,
+      variancePence: Math.round(amountPence - actualPence),
+      utilizationPct,
+      source: sourceLabel,
+    });
+  };
+
+  Object.entries(categoryBudgets).forEach(([categoryKey, value]) => {
+    const amountRaw = Number(value?.amount);
+    const percentRaw = Number(value?.percent);
+    let amountPence = Number.isFinite(amountRaw) ? Math.round(amountRaw) : 0;
+    if (!amountPence && Number.isFinite(percentRaw) && percentRaw > 0 && monthlyIncomePence > 0) {
+      amountPence = Math.round((percentRaw / 100) * monthlyIncomePence);
+    }
+    pushCategoryBudget(categoryKey, amountPence, 'v2');
+  });
+
+  if (!categoryBudgetRows.length) {
+    Object.entries(legacyByCategory).forEach(([categoryKey, value]) => {
+      const amountPounds = Number(value || 0);
+      if (!Number.isFinite(amountPounds) || amountPounds <= 0) return;
+      pushCategoryBudget(categoryKey, Math.round(amountPounds * 100), 'legacy');
+    });
+  }
+
+  const budgetByBucketMap = {};
+  categoryBudgetRows.forEach((row) => {
+    const bucket = row.bucket || 'unknown';
+    if (!budgetByBucketMap[bucket]) {
+      budgetByBucketMap[bucket] = {
+        bucket,
+        budgetPence: 0,
+        actualPence: 0,
+        variancePence: 0,
+        utilizationPct: 0,
+      };
+    }
+    budgetByBucketMap[bucket].budgetPence += row.budgetPence;
+    budgetByBucketMap[bucket].actualPence += row.actualPence;
+  });
+  Object.values(budgetByBucketMap).forEach((row) => {
+    row.variancePence = row.budgetPence - row.actualPence;
+    row.utilizationPct = row.budgetPence > 0 ? Number(((row.actualPence / row.budgetPence) * 100).toFixed(2)) : 0;
+  });
+
+  const totalBudgetPence = categoryBudgetRows.reduce((sum, row) => sum + row.budgetPence, 0);
+  const totalActualPence = categoryBudgetRows.reduce((sum, row) => sum + row.actualPence, 0);
+  const budgetHealth = {
+    mode,
+    monthlyIncomePence,
+    totalBudgetPence,
+    totalActualPence,
+    variancePence: totalBudgetPence - totalActualPence,
+    utilizationPct: totalBudgetPence > 0 ? Number(((totalActualPence / totalBudgetPence) * 100).toFixed(2)) : 0,
+    byCategory: categoryBudgetRows.sort((a, b) => b.actualPence - a.actualPence),
+    byBucket: Object.values(budgetByBucketMap).sort((a, b) => b.actualPence - a.actualPence),
+  };
+
+  const externalSummaryBySource = {};
+  externalSnap.docs.forEach((doc) => {
+    const row = doc.data() || {};
+    const source = normalizeExternalSource(row.source || 'other');
+    if (!externalSummaryBySource[source]) {
+      externalSummaryBySource[source] = {
+        source,
+        rows: 0,
+        spendPence: 0,
+        inflowPence: 0,
+        firstDateISO: null,
+        lastDateISO: null,
+      };
+    }
+    const entry = externalSummaryBySource[source];
+    entry.rows += 1;
+    const amountMinor = normalizeAmountMinor(row);
+    if (amountMinor < 0) entry.spendPence += Math.abs(amountMinor);
+    if (amountMinor > 0) entry.inflowPence += amountMinor;
+    const dateMs = timestampToMs(row.postedAt, row.postedDateISO);
+    if (dateMs) {
+      const iso = new Date(dateMs).toISOString();
+      if (!entry.firstDateISO || iso < entry.firstDateISO) entry.firstDateISO = iso;
+      if (!entry.lastDateISO || iso > entry.lastDateISO) entry.lastDateISO = iso;
+    }
+  });
+
+  const matchSummaryBySource = {};
+  matchesSnap.docs.forEach((doc) => {
+    const row = doc.data() || {};
+    const source = normalizeExternalSource(row.source || 'other');
+    if (!matchSummaryBySource[source]) {
+      matchSummaryBySource[source] = { source, matched: 0, unmatched: 0 };
+    }
+    if (row.status === 'matched') matchSummaryBySource[source].matched += 1;
+    else matchSummaryBySource[source].unmatched += 1;
+  });
+
+  const actions = Array.isArray(actionsSnap.data()?.actions) ? actionsSnap.data().actions : [];
+  const openActions = actions.filter((a) => (a.status || 'open') !== 'converted');
+  const summaryDoc = summarySnap.exists ? (summarySnap.data() || {}) : {};
+  const debtDoc = debtSnap.exists ? (debtSnap.data() || {}) : null;
+
+  const potById = new Map();
+  potsSnap.docs.forEach((doc) => {
+    const row = doc.data() || {};
+    const potId = row.potId || doc.id;
+    if (!potId) return;
+    potById.set(potId, {
+      potId,
+      name: row.name || potId,
+      balancePence: Number(row.balance || 0),
+      currency: row.currency || 'GBP',
+      updatedAtMs: timestampToMs(row.updatedAt, row.updatedAtISO),
+    });
+  });
+
+  const goalForecasts = goalsSnap.docs
+    .map((doc) => ({ id: doc.id, ...(doc.data() || {}) }))
+    .filter((goal) => Number(goal.status || 0) !== 2)
+    .map((goal) => {
+      const linkedPotId = String(goal.linkedPotId || goal.potId || '').trim();
+      const linkedPot = linkedPotId ? potById.get(linkedPotId) : null;
+      const targetAmountRaw = Number(goal.estimatedCost || 0);
+      const targetAmountPence = Number.isFinite(targetAmountRaw) && targetAmountRaw > 0 ? Math.round(targetAmountRaw * 100) : 0;
+      const currentBalancePence = Number(linkedPot?.balancePence || 0);
+      const remainingPence = Math.max(targetAmountPence - currentBalancePence, 0);
+      const contribution = linkedPotId ? (potContributionMap.get(linkedPotId) || null) : null;
+      const contributionMonths = contribution ? Object.keys(contribution.monthNet || {}).sort() : [];
+      const rollingMonths = contributionMonths.slice(-6);
+      const rollingValues = rollingMonths.map((monthKey) => Number(contribution.monthNet[monthKey] || 0));
+      const monthlyContributionPence = rollingValues.length
+        ? Math.round(rollingValues.reduce((sum, value) => sum + value, 0) / rollingValues.length)
+        : 0;
+      const etaMonths = remainingPence > 0 && monthlyContributionPence > 0
+        ? Math.ceil(remainingPence / monthlyContributionPence)
+        : null;
+      const etaDateISO = etaMonths ? new Date(nowMs + (etaMonths * 30 * DAY_MS)).toISOString() : null;
+      const progressPct = targetAmountPence > 0
+        ? Number((Math.min(currentBalancePence / targetAmountPence, 1) * 100).toFixed(2))
+        : null;
+
+      return {
+        goalId: goal.id,
+        goalTitle: goal.title || goal.name || goal.id,
+        linkedPotId: linkedPotId || null,
+        linkedPotName: linkedPot?.name || null,
+        targetAmountPence,
+        currentBalancePence,
+        remainingPence,
+        progressPct,
+        monthlyContributionPence,
+        etaMonths,
+        etaDateISO,
+        contributionMonths: rollingMonths,
+        contributionSampleSize: rollingValues.length,
+      };
+    })
+    .sort((a, b) => (b.remainingPence || 0) - (a.remainingPence || 0));
+
+  const manualAccounts = manualAccountsSnap.docs
+    .map((doc) => {
+      const row = doc.data() || {};
+      const balancePence = Number.isFinite(Number(row.balancePence))
+        ? Math.round(Number(row.balancePence))
+        : Math.round(Number(row.balance || 0) * 100);
+      const updatedAtMs = timestampToMs(row.updatedAt, row.updatedAtISO) || Number(row.updatedAtMs || 0) || null;
+      const staleDays = updatedAtMs ? Math.floor((nowMs - updatedAtMs) / DAY_MS) : null;
+      const type = normalizeManualAccountType(row.type);
+      return {
+        accountId: row.accountId || doc.id,
+        name: row.name || 'Account',
+        institution: row.institution || null,
+        type,
+        currency: row.currency || 'GBP',
+        balancePence,
+        balance: balancePence / 100,
+        notes: row.notes || null,
+        updatedAtMs,
+        updatedAtISO: updatedAtMs ? new Date(updatedAtMs).toISOString() : null,
+        staleDays,
+        isStale: staleDays === null || staleDays > 30,
+      };
+    })
+    .sort((a, b) => (a.type === 'debt' ? 1 : 0) - (b.type === 'debt' ? 1 : 0));
+
+  const manualAccountSummary = manualAccounts.reduce((acc, account) => {
+    const absBalance = Math.abs(Number(account.balancePence || 0));
+    if (account.type === 'debt') acc.totalDebtPence += absBalance;
+    else acc.totalAssetPence += absBalance;
+    if (account.isStale) acc.staleCount += 1;
+    return acc;
+  }, { totalAssetPence: 0, totalDebtPence: 0, staleCount: 0, netWorthPence: 0 });
+  manualAccountSummary.netWorthPence = manualAccountSummary.totalAssetPence - manualAccountSummary.totalDebtPence;
+
+  return {
+    ok: true,
+    range: {
+      startDateISO: new Date(rangeStartMs).toISOString(),
+      endDateISO: new Date(rangeEndMs).toISOString(),
+    },
+    coverage: {
+      monzoCoverageStartISO: coverageStartMs ? new Date(coverageStartMs).toISOString() : null,
+      monzoCoverageEndISO: coverageEndMs ? new Date(coverageEndMs).toISOString() : null,
+      monzoTransactionsInRange: inRangeCount,
+      monzoTransactionsTotal: monzoSnap.size,
+    },
+    spendTrackingSeries,
+    cashflowSeries,
+    analysisRows: analysisRows
+      .sort((a, b) => a.dateISO.localeCompare(b.dateISO))
+      .slice(-25_000),
+    optionalSpendCards,
+    budgetHealth,
+    goalForecasts,
+    externalSummary: Object.values(externalSummaryBySource).sort((a, b) => a.source.localeCompare(b.source)),
+    matchSummary: Object.values(matchSummaryBySource).sort((a, b) => a.source.localeCompare(b.source)),
+    debtService: debtDoc,
+    actions: openActions,
+    allActions: actions,
+    manualAccounts,
+    manualAccountSummary,
+    recurringMerchants: Array.isArray(summaryDoc.recurringMerchants) ? summaryDoc.recurringMerchants : [],
+    topMerchants: Array.isArray(summaryDoc.allMerchants) ? summaryDoc.allMerchants.slice(0, 50) : [],
+    updatedAtISO: new Date().toISOString(),
+  };
+});
+
+module.exports = {
+  importExternalFinanceTransactions,
+  matchExternalToMonzoTransactions,
+  recomputeDebtServiceBreakdown,
+  generateFinanceActionInsights,
+  convertFinanceActionToStory,
+  upsertManualFinanceAccount,
+  deleteManualFinanceAccount,
+  fetchFinanceEnhancementData,
+};

--- a/react-app/src/components/finance/FinanceDashboardAdvanced.css
+++ b/react-app/src/components/finance/FinanceDashboardAdvanced.css
@@ -1,0 +1,21 @@
+.finance-dashboard-view-switch .btn-group {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.5rem;
+}
+
+.finance-dashboard-view-switch .btn {
+  white-space: nowrap;
+  border-radius: 0.5rem !important;
+}
+
+.finance-optional-card {
+  min-height: 190px;
+}
+
+@media (max-width: 768px) {
+  .finance-dashboard-view-switch .btn-group {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/react-app/src/components/finance/FinanceDashboardAdvanced.tsx
+++ b/react-app/src/components/finance/FinanceDashboardAdvanced.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Row, Col, Spinner, Alert, Form, Button, Badge, ButtonGroup } from 'react-bootstrap';
 import { httpsCallable } from 'firebase/functions';
 import { doc, getDoc } from 'firebase/firestore';
@@ -8,12 +8,67 @@ import { useAuth } from '../../contexts/AuthContext';
 import { PremiumCard } from '../common/PremiumCard';
 import ReactECharts from 'echarts-for-react';
 import {
-    TrendingUp, PieChart as PieIcon,
-    Calendar, RefreshCw, Filter, DollarSign,
-    ArrowUpRight, ArrowDownRight, CreditCard, Layers, Activity
+    TrendingUp,
+    PieChart as PieIcon,
+    Calendar,
+    RefreshCw,
+    DollarSign,
+    ArrowUpRight,
+    CreditCard,
+    Layers,
+    Activity,
+    Upload,
+    Link2,
+    Sparkles,
+    CheckCircle2,
+    Wallet,
+    Landmark,
+    AlertTriangle,
+    Target,
+    Trash2,
 } from 'lucide-react';
+import './FinanceDashboardAdvanced.css';
 
-const THEME_COLORS = ['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF', '#FF9F40', '#C9CBCF', '#FF6384', '#36A2EB', '#FFCE56'];
+type DateFilter = 'month' | 'quarter' | 'year' | 'all' | 'custom';
+type ViewMode = 'category' | 'bucket';
+type FinanceView = 'overview' | 'spend' | 'cashflow' | 'optional' | 'actions' | 'sources' | 'assets';
+type ExternalSource = 'barclays' | 'paypal' | 'other';
+type AnalysisDimension = 'bucket' | 'category' | 'merchant';
+type AnalysisChartType = 'trend' | 'pie' | 'breakdown';
+type ManualAccountType = 'asset' | 'debt' | 'investment' | 'cash' | 'savings';
+
+const THEME_COLORS = ['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF', '#FF9F40', '#C9CBCF', '#9B59B6', '#00C2A8', '#F39C12'];
+const EMPTY_LIST: any[] = [];
+
+const toPounds = (pence: number) => (Number.isFinite(pence) ? pence / 100 : 0);
+
+const parseTxDate = (tx: any): Date | null => {
+    const createdAt = tx?.createdAt;
+    if (createdAt?.toDate) return createdAt.toDate();
+    if (createdAt?._seconds) return new Date(createdAt._seconds * 1_000);
+    if (typeof createdAt === 'number') return new Date(createdAt);
+    if (typeof createdAt === 'string' && createdAt) return new Date(createdAt);
+    if (tx?.createdISO) return new Date(tx.createdISO);
+    return null;
+};
+
+const monthLabel = (monthKey: string) => {
+    const [year, month] = monthKey.split('-').map(Number);
+    if (!year || !month) return monthKey;
+    return new Date(Date.UTC(year, month - 1, 1)).toLocaleDateString('en-GB', {
+        month: 'short',
+        year: 'numeric',
+        timeZone: 'UTC',
+    });
+};
+
+const normalizeManualType = (type: string): ManualAccountType => {
+    const normalized = String(type || 'asset').toLowerCase();
+    if (['asset', 'debt', 'investment', 'cash', 'savings'].includes(normalized)) {
+        return normalized as ManualAccountType;
+    }
+    return 'asset';
+};
 
 const FinanceDashboardAdvanced: React.FC = () => {
     const { currentUser } = useAuth();
@@ -21,10 +76,15 @@ const FinanceDashboardAdvanced: React.FC = () => {
     const isDark = theme === 'dark';
 
     const [data, setData] = useState<any>(null);
+    const [enhancementData, setEnhancementData] = useState<any>(null);
     const [loading, setLoading] = useState(true);
     const [syncing, setSyncing] = useState(false);
+    const [busy, setBusy] = useState(false);
+    const [manualBusy, setManualBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [opsMessage, setOpsMessage] = useState<string | null>(null);
     const [lastSync, setLastSync] = useState<Date | null>(null);
-    const [filter, setFilter] = useState<'month' | 'quarter' | 'year'>('month');
+    const [filter, setFilter] = useState<DateFilter>('month');
     const [startDate, setStartDate] = useState<string>(() => {
         const now = new Date();
         return new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
@@ -33,28 +93,55 @@ const FinanceDashboardAdvanced: React.FC = () => {
         const now = new Date();
         return new Date(now.getFullYear(), now.getMonth() + 1, 0).toISOString().slice(0, 10);
     });
-    const [viewMode, setViewMode] = useState<'category' | 'bucket'>('category');
-    const [editingTx, setEditingTx] = useState<any>(null);
-    const [newCategory, setNewCategory] = useState('');
+    const [viewMode, setViewMode] = useState<ViewMode>('category');
+    const [activeView, setActiveView] = useState<FinanceView>('overview');
 
-    // Dynamic Theme Colors
+    const [externalSource, setExternalSource] = useState<ExternalSource>('barclays');
+    const [csvText, setCsvText] = useState('');
+    const [csvFileName, setCsvFileName] = useState('');
+    const [windowDays, setWindowDays] = useState(5);
+    const [amountTolerancePence, setAmountTolerancePence] = useState(150);
+    const [convertingActionId, setConvertingActionId] = useState<string | null>(null);
+
+    const [analysisDimension, setAnalysisDimension] = useState<AnalysisDimension>('bucket');
+    const [analysisChartType, setAnalysisChartType] = useState<AnalysisChartType>('trend');
+    const [analysisBucketFilter, setAnalysisBucketFilter] = useState('all');
+    const [analysisCategoryFilter, setAnalysisCategoryFilter] = useState('all');
+    const [analysisMerchantFilter, setAnalysisMerchantFilter] = useState('all');
+
+    const [editingManualAccountId, setEditingManualAccountId] = useState<string | null>(null);
+    const [manualForm, setManualForm] = useState<{
+        name: string;
+        institution: string;
+        type: ManualAccountType;
+        balance: string;
+        currency: string;
+    }>({
+        name: '',
+        institution: '',
+        type: 'asset',
+        balance: '',
+        currency: 'GBP',
+    });
+
     const colors = {
         text: isDark ? '#ffffff' : '#2c3e50',
         textMuted: isDark ? '#9a9a9a' : '#6c757d',
         grid: isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)',
-        primary: '#e14eca',
         success: '#00f2c3',
         danger: '#fd5d93',
         warning: '#ff8d72',
         info: '#1d8cf8',
-        cardBg: isDark ? '#27293d' : '#ffffff',
     };
 
-    const fetchData = async () => {
+    const formatCurrency = (val: number) =>
+        new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(val || 0);
+
+    const fetchData = useCallback(async () => {
         if (!currentUser) return;
         setLoading(true);
+        setError(null);
         try {
-            // Fetch Profile for Sync Status
             const profileSnap = await getDoc(doc(db, 'profiles', currentUser.uid));
             if (profileSnap.exists()) {
                 const p = profileSnap.data();
@@ -77,50 +164,247 @@ const FinanceDashboardAdvanced: React.FC = () => {
             } else if (filter === 'year') {
                 rangeStart = new Date(now.getFullYear(), 0, 1);
                 rangeEnd = new Date(now.getFullYear(), 11, 31);
+            } else if (filter === 'all') {
+                rangeStart = new Date('2018-01-01T00:00:00.000Z');
+                rangeEnd = new Date();
             }
 
             const fetchDashboardData = httpsCallable(functions, 'fetchDashboardData');
-            const result = await fetchDashboardData({
-                startDate: rangeStart.toISOString(),
-                endDate: rangeEnd.toISOString()
-            });
+            const fetchEnhancementData = httpsCallable(functions, 'fetchFinanceEnhancementData');
 
-            setData((result.data as any).data);
-        } catch (err) {
+            const [dashboardRes, enhancementRes] = await Promise.allSettled([
+                fetchDashboardData({
+                    startDate: rangeStart.toISOString(),
+                    endDate: rangeEnd.toISOString(),
+                }),
+                fetchEnhancementData({
+                    startDate: rangeStart.toISOString(),
+                    endDate: rangeEnd.toISOString(),
+                }),
+            ]);
+
+            if (dashboardRes.status !== 'fulfilled') {
+                throw dashboardRes.reason;
+            }
+
+            setData(((dashboardRes.value.data as any)?.data || dashboardRes.value.data) as any);
+            if (enhancementRes.status === 'fulfilled') {
+                setEnhancementData((enhancementRes.value.data as any) || null);
+            } else {
+                console.warn('fetchFinanceEnhancementData failed', enhancementRes.reason);
+                setEnhancementData(null);
+            }
+        } catch (err: any) {
             console.error(err);
+            setError(err?.message || 'Failed to load finance dashboard data');
         } finally {
             setLoading(false);
         }
-    };
+    }, [currentUser, filter, startDate, endDate]);
 
     useEffect(() => {
         fetchData();
-        // Legacy global hook for older UI buttons/modal expecting refreshMonzoData
         (window as any).refreshMonzoData = async () => {
             const fn = httpsCallable(functions, 'syncMonzoNow');
             await fn({});
             await fetchData();
         };
-    }, [filter, startDate, endDate, currentUser]);
+    }, [fetchData]);
 
     const handleSync = async () => {
         setSyncing(true);
+        setOpsMessage(null);
         try {
             const fn = httpsCallable(functions, 'syncMonzoNow');
-            await fn();
+            await fn({});
             await fetchData();
+            setOpsMessage('Monzo sync completed and dashboard refreshed.');
         } catch (e: any) {
-            alert('Sync failed: ' + e.message);
+            setError(e?.message || 'Sync failed');
         } finally {
             setSyncing(false);
         }
     };
 
-    const formatCurrency = (val: number) =>
-        new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(val);
+    const handleCsvFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
+        const text = await file.text();
+        setCsvText(text);
+        setCsvFileName(file.name);
+        setOpsMessage(`Loaded ${file.name}. Ready to import.`);
+    };
 
-    if (loading && !data) return <div className="p-5 text-center"><Spinner animation="border" variant="primary" /></div>;
-    if (!data) return <Alert variant="danger">Failed to load data.</Alert>;
+    const handleImportAndRebuild = async () => {
+        if (!csvText.trim()) {
+            setError('Select a CSV file before importing.');
+            return;
+        }
+
+        setBusy(true);
+        setError(null);
+        setOpsMessage(null);
+        try {
+            const importFn = httpsCallable(functions, 'importExternalFinanceTransactions');
+            const matchFn = httpsCallable(functions, 'matchExternalToMonzoTransactions');
+            const debtFn = httpsCallable(functions, 'recomputeDebtServiceBreakdown');
+            const actionsFn = httpsCallable(functions, 'generateFinanceActionInsights');
+
+            const importRes = (await importFn({ source: externalSource, csv: csvText })).data as any;
+            const matchRes = (await matchFn({
+                source: externalSource,
+                windowDays,
+                amountTolerancePence,
+            })).data as any;
+            await debtFn({ source: externalSource });
+            await actionsFn({ source: externalSource, maxActions: 12 });
+
+            await fetchData();
+
+            setOpsMessage(
+                `Imported ${importRes?.upserted || 0} rows, matched ${matchRes?.matched || 0}, and rebuilt debt/action insights.`
+            );
+        } catch (err: any) {
+            console.error(err);
+            setError(err?.message || 'Import pipeline failed');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleRematch = async () => {
+        setBusy(true);
+        setError(null);
+        setOpsMessage(null);
+        try {
+            const matchFn = httpsCallable(functions, 'matchExternalToMonzoTransactions');
+            const matchRes = (await matchFn({
+                source: externalSource,
+                windowDays,
+                amountTolerancePence,
+            })).data as any;
+            await fetchData();
+            setOpsMessage(`Matching complete: ${matchRes?.matched || 0} matched, ${matchRes?.unmatched || 0} unmatched.`);
+        } catch (err: any) {
+            console.error(err);
+            setError(err?.message || 'Matching failed');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleRegenerateActions = async () => {
+        setBusy(true);
+        setError(null);
+        setOpsMessage(null);
+        try {
+            const debtFn = httpsCallable(functions, 'recomputeDebtServiceBreakdown');
+            const actionsFn = httpsCallable(functions, 'generateFinanceActionInsights');
+            await debtFn({ source: externalSource });
+            const actionRes = (await actionsFn({ source: externalSource, maxActions: 12 })).data as any;
+            await fetchData();
+            setOpsMessage(`Generated ${Array.isArray(actionRes?.actions) ? actionRes.actions.length : 0} finance actions.`);
+        } catch (err: any) {
+            console.error(err);
+            setError(err?.message || 'Action generation failed');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleConvertActionToStory = async (actionId: string) => {
+        if (!actionId) return;
+        setConvertingActionId(actionId);
+        setError(null);
+        setOpsMessage(null);
+        try {
+            const fn = httpsCallable(functions, 'convertFinanceActionToStory');
+            const result = (await fn({ actionId })).data as any;
+            await fetchData();
+            setOpsMessage(`Action converted to story ${result?.storyId || ''}.`);
+        } catch (err: any) {
+            console.error(err);
+            setError(err?.message || 'Failed to convert action to story');
+        } finally {
+            setConvertingActionId(null);
+        }
+    };
+
+    const resetManualForm = () => {
+        setEditingManualAccountId(null);
+        setManualForm({
+            name: '',
+            institution: '',
+            type: 'asset',
+            balance: '',
+            currency: 'GBP',
+        });
+    };
+
+    const handleSaveManualAccount = async () => {
+        if (!manualForm.name.trim()) {
+            setError('Account name is required.');
+            return;
+        }
+        const balanceNum = Number(manualForm.balance || 0);
+        if (!Number.isFinite(balanceNum)) {
+            setError('Balance must be a valid number.');
+            return;
+        }
+
+        setManualBusy(true);
+        setError(null);
+        setOpsMessage(null);
+        try {
+            const upsertFn = httpsCallable(functions, 'upsertManualFinanceAccount');
+            await upsertFn({
+                accountId: editingManualAccountId || undefined,
+                name: manualForm.name,
+                institution: manualForm.institution,
+                type: manualForm.type,
+                currency: manualForm.currency,
+                balancePence: Math.round(balanceNum * 100),
+            });
+            await fetchData();
+            setOpsMessage(editingManualAccountId ? 'Account updated.' : 'Account added.');
+            resetManualForm();
+        } catch (err: any) {
+            console.error(err);
+            setError(err?.message || 'Failed to save account');
+        } finally {
+            setManualBusy(false);
+        }
+    };
+
+    const handleDeleteManualAccount = async (accountId: string) => {
+        if (!accountId) return;
+        setManualBusy(true);
+        setError(null);
+        setOpsMessage(null);
+        try {
+            const deleteFn = httpsCallable(functions, 'deleteManualFinanceAccount');
+            await deleteFn({ accountId });
+            await fetchData();
+            setOpsMessage('Account deleted.');
+            if (editingManualAccountId === accountId) resetManualForm();
+        } catch (err: any) {
+            console.error(err);
+            setError(err?.message || 'Failed to delete account');
+        } finally {
+            setManualBusy(false);
+        }
+    };
+
+    const startEditManualAccount = (account: any) => {
+        setEditingManualAccountId(account.accountId || null);
+        setManualForm({
+            name: account.name || '',
+            institution: account.institution || '',
+            type: normalizeManualType(account.type || 'asset'),
+            balance: (Number(account.balancePence || 0) / 100).toFixed(2),
+            currency: account.currency || 'GBP',
+        });
+    };
 
     const userBadge = (
         <div className="d-flex justify-content-end mb-2">
@@ -128,36 +412,35 @@ const FinanceDashboardAdvanced: React.FC = () => {
         </div>
     );
 
-    // Prepare Data
-    const bucketEntries = Object.entries(data.spendByBucket || {}).filter(([key]) => key !== 'bank_transfer' && key !== 'unknown');
+    const bucketEntries = Object.entries(data?.spendByBucket || {}).filter(([key]) => key !== 'bank_transfer' && key !== 'unknown');
     const bucketData = bucketEntries
         .map(([key, value]: [string, any]) => ({ name: key.charAt(0).toUpperCase() + key.slice(1), value: Math.abs(value) / 100 }))
-        .filter(d => d.value > 0);
+        .filter((entry) => entry.value > 0);
 
-    const categoryData = Object.entries(data.spendByCategory || {})
+    const categoryData = Object.entries(data?.spendByCategory || {})
         .filter(([key]) => key !== 'bank_transfer' && key !== 'unknown')
         .map(([key, value]: [string, any]) => ({ name: key, value: Math.abs(value) / 100 }))
         .sort((a, b) => b.value - a.value);
 
-    const timeSeriesSourceRaw = viewMode === 'bucket' ? data.timeSeriesByBucket : data.timeSeriesByCategory;
-    const timeSeriesSource = Object.fromEntries(
-        Object.entries(timeSeriesSourceRaw || {}).filter(([key]) => key !== 'bank_transfer')
-    );
+    const timeSeriesSourceRaw = viewMode === 'bucket' ? data?.timeSeriesByBucket : data?.timeSeriesByCategory;
+    const timeSeriesSource = Object.fromEntries(Object.entries(timeSeriesSourceRaw || {}).filter(([key]) => key !== 'bank_transfer'));
+
     const allMonths = new Set<string>();
-    Object.values(timeSeriesSource || {}).forEach((arr: any) => arr.forEach((d: any) => allMonths.add(d.month)));
+    Object.values(timeSeriesSource || {}).forEach((arr: any) => arr.forEach((entry: any) => allMonths.add(entry.month)));
     const sortedMonths = Array.from(allMonths).sort();
-    const trendData = sortedMonths.map(month => {
+
+    const trendData = sortedMonths.map((month) => {
         const row: any = { month };
         Object.entries(timeSeriesSource || {}).forEach(([key, arr]: [string, any]) => {
-            const entry = arr.find((d: any) => d.month === month);
+            const entry = arr.find((item: any) => item.month === month);
             if (entry) row[key] = Math.abs(entry.amount) / 100;
         });
         return row;
     });
-    const activeKeys = Object.keys(timeSeriesSource || {}).slice(0, 5);
 
-    const bankTransferAmount = (data.spendByBucket?.bank_transfer ?? 0);
-    const filteredTotalSpend = Math.abs((data.totalSpend || 0) - bankTransferAmount) / 100;
+    const activeKeys = Object.keys(timeSeriesSource || {}).slice(0, 5);
+    const bankTransferAmount = data?.spendByBucket?.bank_transfer ?? 0;
+    const filteredTotalSpend = Math.abs((data?.totalSpend || 0) - bankTransferAmount) / 100;
 
     const trendOption = {
         tooltip: { trigger: 'axis' },
@@ -173,7 +456,7 @@ const FinanceDashboardAdvanced: React.FC = () => {
             data: trendData.map((row: any) => Math.abs(row[key] || 0)),
             color: THEME_COLORS[idx % THEME_COLORS.length],
             smooth: true,
-            emphasis: { focus: 'series' }
+            emphasis: { focus: 'series' },
         })),
     };
 
@@ -185,23 +468,22 @@ const FinanceDashboardAdvanced: React.FC = () => {
                 type: 'pie',
                 radius: ['40%', '70%'],
                 label: { show: false },
-                data: bucketData.map((d: any, idx: number) => ({
-                    value: d.value,
-                    name: d.name,
+                data: bucketData.map((entry: any, idx: number) => ({
+                    value: entry.value,
+                    name: entry.name,
                     itemStyle: { color: THEME_COLORS[idx % THEME_COLORS.length] },
                 })),
             },
         ],
     };
 
-    // Local distribution override from transactions to reflect per-transaction overrides
-    const localDistribution = ((data.recentTransactions || []) as any[])
+    const localDistribution = ((data?.recentTransactions || []) as any[])
         .filter((tx) => {
-            const cat = (tx.aiCategoryKey || tx.userCategoryKey || tx.categoryKey || tx.categoryType || '').toLowerCase();
+            const cat = (tx.userCategoryKey || tx.aiCategoryKey || tx.categoryKey || tx.categoryType || '').toLowerCase();
             return cat && cat !== 'bank_transfer' && cat !== 'unknown';
         })
         .reduce((acc: Record<string, number>, tx: any) => {
-            const label = tx.aiCategoryLabel || tx.userCategoryLabel || tx.categoryLabel || tx.categoryKey || tx.categoryType || 'Uncategorised';
+            const label = tx.userCategoryLabel || tx.aiCategoryLabel || tx.categoryLabel || tx.categoryKey || tx.categoryType || 'Uncategorised';
             const rawAmt = typeof tx.amount === 'number' && Math.abs(tx.amount) < 10 ? tx.amount * 100 : tx.amount;
             const amt = Math.abs(rawAmt || 0) / 100;
             acc[label] = (acc[label] || 0) + amt;
@@ -210,9 +492,11 @@ const FinanceDashboardAdvanced: React.FC = () => {
 
     const distributionSource = (() => {
         const local = Object.entries(localDistribution).map(([name, value]) => ({ name, value }));
-        if (local.length) return local;
-        return viewMode === 'bucket' ? bucketData : categoryData;
+        const aggregate = viewMode === 'bucket' ? bucketData : categoryData;
+        if (aggregate.length) return aggregate;
+        return local;
     })();
+
     const distributionOption = {
         tooltip: { trigger: 'item', valueFormatter: (v: number) => `£${v}` },
         legend: { orient: 'horizontal', bottom: 0 },
@@ -223,95 +507,372 @@ const FinanceDashboardAdvanced: React.FC = () => {
                 avoidLabelOverlap: false,
                 itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
                 label: { show: false },
-                data: distributionSource.map((d: any, idx: number) => ({
-                    value: d.value,
-                    name: d.name,
+                data: distributionSource.map((entry: any, idx: number) => ({
+                    value: entry.value,
+                    name: entry.name,
                     itemStyle: { color: THEME_COLORS[idx % THEME_COLORS.length] },
                 })),
             },
         ],
     };
 
-    const filteredRecentTransactions = (data.recentTransactions || []).filter(
-        (tx: any) => {
-            const bucket = (tx.aiBucket || tx.categoryType || '').toLowerCase();
+    const filteredRecentTransactions = (data?.recentTransactions || [])
+        .filter((tx: any) => {
+            const bucket = (tx.userCategoryType || tx.aiBucket || tx.categoryType || '').toLowerCase();
             return bucket !== 'bank_transfer' && bucket !== 'unknown';
-        }
-    ).map((tx: any) => {
-        // Normalize amount if in minor units
-        const amt = typeof tx.amount === 'number' && Math.abs(tx.amount) < 10 ? tx.amount * 100 : tx.amount;
-        return { ...tx, amount: amt };
-    });
+        })
+        .map((tx: any) => {
+            const amt = typeof tx.amount === 'number' && Math.abs(tx.amount) < 10 ? tx.amount * 100 : tx.amount;
+            return { ...tx, amount: amt };
+        });
 
-    return (
-        <div className="container-fluid py-4" style={{ backgroundColor: isDark ? '#1e1e2f' : '#f4f5f7', minHeight: '100vh', color: colors.text }}>
-            {userBadge}
-            {/* Header */}
-            <div className="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-5 gap-3">
-                <div>
-                    <h2 className="fw-bold mb-1">Financial Overview</h2>
-                    <div className="d-flex align-items-center gap-2 text-muted">
-                        <Calendar size={16} />
-                        <span>{filter === 'month' ? 'This Month' : filter === 'quarter' ? 'This Quarter' : 'This Year'}</span>
-                        {lastSync && (
-                            <>
-                                <span className="mx-1">•</span>
-                                <RefreshCw size={14} className={syncing ? 'spin' : ''} />
-                                <small>Synced {lastSync.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</small>
-                            </>
-                        )}
-                    </div>
-                </div>
-                <div className="d-flex gap-2">
-                    <ButtonGroup>
-                        <Button variant={filter === 'month' ? 'primary' : 'outline-secondary'} onClick={() => setFilter('month')}>Month</Button>
-                        <Button variant={filter === 'quarter' ? 'primary' : 'outline-secondary'} onClick={() => setFilter('quarter')}>Quarter</Button>
-                        <Button variant={filter === 'year' ? 'primary' : 'outline-secondary'} onClick={() => setFilter('year')}>Year</Button>
-                    </ButtonGroup>
-                    <Form.Control type="date" size="sm" value={startDate} onChange={(e)=>setStartDate(e.target.value)} style={{ maxWidth: 150 }} />
-                    <Form.Control type="date" size="sm" value={endDate} onChange={(e)=>setEndDate(e.target.value)} style={{ maxWidth: 150 }} />
-                    <Button variant="outline-primary" onClick={handleSync} disabled={syncing}>
-                        {syncing ? <Spinner size="sm" animation="border" /> : <RefreshCw size={18} />}
-                    </Button>
-                </div>
-            </div>
+    const spendTrackingSeries = enhancementData?.spendTrackingSeries ?? EMPTY_LIST;
+    const cashflowSeries = enhancementData?.cashflowSeries ?? EMPTY_LIST;
+    const optionalSpendCards = enhancementData?.optionalSpendCards ?? EMPTY_LIST;
+    const actions = enhancementData?.actions ?? EMPTY_LIST;
+    const externalSummary = enhancementData?.externalSummary ?? EMPTY_LIST;
+    const matchSummary = enhancementData?.matchSummary ?? EMPTY_LIST;
+    const debtService = enhancementData?.debtService?.totals || null;
+    const analysisRows = enhancementData?.analysisRows ?? EMPTY_LIST;
+    const budgetHealth = enhancementData?.budgetHealth || null;
+    const goalForecasts = enhancementData?.goalForecasts ?? EMPTY_LIST;
+    const manualAccounts = enhancementData?.manualAccounts ?? EMPTY_LIST;
+    const manualAccountSummary = enhancementData?.manualAccountSummary || {
+        totalAssetPence: 0,
+        totalDebtPence: 0,
+        netWorthPence: 0,
+        staleCount: 0,
+    };
 
-            {/* Summary Cards */}
+    const matchBySource = useMemo(() => {
+        const map = new Map<string, any>();
+        matchSummary.forEach((item: any) => map.set(item.source, item));
+        return map;
+    }, [matchSummary]);
+
+    const spendTrackingOption = {
+        tooltip: { trigger: 'axis' },
+        legend: { data: ['Mandatory', 'Optional', 'Savings', 'Income'] },
+        grid: { left: 50, right: 15, top: 30, bottom: 30 },
+        xAxis: {
+            type: 'category',
+            data: spendTrackingSeries.map((item: any) => monthLabel(item.month)),
+        },
+        yAxis: {
+            type: 'value',
+            axisLabel: { formatter: (v: number) => `£${v}` },
+        },
+        series: [
+            {
+                name: 'Mandatory',
+                type: 'bar',
+                stack: 'spend',
+                itemStyle: { color: '#ff8d72' },
+                data: spendTrackingSeries.map((item: any) => toPounds(item.mandatoryPence || 0)),
+            },
+            {
+                name: 'Optional',
+                type: 'bar',
+                stack: 'spend',
+                itemStyle: { color: '#fd5d93' },
+                data: spendTrackingSeries.map((item: any) => toPounds(item.optionalPence || 0)),
+            },
+            {
+                name: 'Savings',
+                type: 'bar',
+                stack: 'spend',
+                itemStyle: { color: '#36A2EB' },
+                data: spendTrackingSeries.map((item: any) => toPounds(item.savingsPence || 0)),
+            },
+            {
+                name: 'Income',
+                type: 'line',
+                smooth: true,
+                symbolSize: 7,
+                itemStyle: { color: '#00f2c3' },
+                data: spendTrackingSeries.map((item: any) => toPounds(item.incomePence || 0)),
+            },
+        ],
+    };
+
+    const cashflowOption = {
+        tooltip: { trigger: 'axis' },
+        legend: { data: ['Inflow', 'Outflow', 'Net'] },
+        grid: { left: 50, right: 15, top: 30, bottom: 30 },
+        xAxis: {
+            type: 'category',
+            data: cashflowSeries.map((item: any) => monthLabel(item.month)),
+        },
+        yAxis: {
+            type: 'value',
+            axisLabel: { formatter: (v: number) => `£${v}` },
+        },
+        series: [
+            {
+                name: 'Inflow',
+                type: 'line',
+                smooth: true,
+                areaStyle: { opacity: 0.2 },
+                itemStyle: { color: '#00f2c3' },
+                data: cashflowSeries.map((item: any) => toPounds(item.inflowPence || 0)),
+            },
+            {
+                name: 'Outflow',
+                type: 'line',
+                smooth: true,
+                areaStyle: { opacity: 0.15 },
+                itemStyle: { color: '#fd5d93' },
+                data: cashflowSeries.map((item: any) => toPounds(item.outflowPence || 0)),
+            },
+            {
+                name: 'Net',
+                type: 'line',
+                smooth: true,
+                lineStyle: { width: 3 },
+                itemStyle: { color: '#36A2EB' },
+                data: cashflowSeries.map((item: any) => toPounds(item.netPence || 0)),
+            },
+        ],
+    };
+
+    const analysisBucketOptions = useMemo(() => {
+        const set = new Set<string>();
+        analysisRows.forEach((row: any) => set.add(row.bucket || 'unknown'));
+        return Array.from(set).sort((a, b) => a.localeCompare(b));
+    }, [analysisRows]);
+
+    const analysisCategoryOptions = useMemo(() => {
+        const set = new Set<string>();
+        analysisRows.forEach((row: any) => set.add(row.categoryKey || row.categoryLabel || 'uncategorized'));
+        return Array.from(set).sort((a, b) => a.localeCompare(b));
+    }, [analysisRows]);
+
+    const analysisMerchantOptions = useMemo(() => {
+        const set = new Set<string>();
+        analysisRows.forEach((row: any) => set.add(row.merchantName || 'Unknown'));
+        return Array.from(set).sort((a, b) => a.localeCompare(b));
+    }, [analysisRows]);
+
+    const filteredAnalysisRows = useMemo(() => {
+        return analysisRows.filter((row: any) => {
+            if (analysisBucketFilter !== 'all' && (row.bucket || 'unknown') !== analysisBucketFilter) return false;
+            const categoryKey = row.categoryKey || row.categoryLabel || 'uncategorized';
+            if (analysisCategoryFilter !== 'all' && categoryKey !== analysisCategoryFilter) return false;
+            if (analysisMerchantFilter !== 'all' && (row.merchantName || 'Unknown') !== analysisMerchantFilter) return false;
+            return true;
+        });
+    }, [analysisRows, analysisBucketFilter, analysisCategoryFilter, analysisMerchantFilter]);
+
+    const analysisStats = useMemo(() => {
+        const totalPence = filteredAnalysisRows.reduce((sum: number, row: any) => sum + Number(row.amountPence || 0), 0);
+        const count = filteredAnalysisRows.length;
+        const avgPence = count > 0 ? Math.round(totalPence / count) : 0;
+        return {
+            totalPence,
+            count,
+            avgPence,
+        };
+    }, [filteredAnalysisRows]);
+
+    const analysisGrouped = useMemo(() => {
+        const groupedTotals: Record<string, number> = {};
+        const groupedByMonth: Record<string, Record<string, number>> = {};
+        const monthsSet = new Set<string>();
+
+        filteredAnalysisRows.forEach((row: any) => {
+            const month = row.month || 'unknown';
+            const key = analysisDimension === 'bucket'
+                ? (row.bucket || 'unknown')
+                : analysisDimension === 'category'
+                    ? (row.categoryLabel || row.categoryKey || 'uncategorized')
+                    : (row.merchantName || 'Unknown');
+
+            const amount = Number(row.amountPence || 0);
+            groupedTotals[key] = (groupedTotals[key] || 0) + amount;
+            monthsSet.add(month);
+            if (!groupedByMonth[month]) groupedByMonth[month] = {};
+            groupedByMonth[month][key] = (groupedByMonth[month][key] || 0) + amount;
+        });
+
+        const groups = Object.entries(groupedTotals)
+            .map(([name, amountPence]) => ({ name, amountPence }))
+            .sort((a, b) => b.amountPence - a.amountPence);
+
+        const months = Array.from(monthsSet).sort();
+        return { groups, groupedByMonth, months };
+    }, [filteredAnalysisRows, analysisDimension]);
+
+    const analysisTrendOption = useMemo(() => {
+        const topGroups = analysisGrouped.groups.slice(0, 8);
+        return {
+            tooltip: { trigger: 'axis' },
+            legend: { data: topGroups.map((group) => group.name) },
+            grid: { left: 50, right: 15, top: 35, bottom: 35 },
+            xAxis: {
+                type: 'category',
+                data: analysisGrouped.months.map((month) => monthLabel(month)),
+            },
+            yAxis: {
+                type: 'value',
+                axisLabel: { formatter: (v: number) => `£${v}` },
+            },
+            series: topGroups.map((group, index) => ({
+                name: group.name,
+                type: 'line',
+                smooth: true,
+                symbolSize: 6,
+                itemStyle: { color: THEME_COLORS[index % THEME_COLORS.length] },
+                data: analysisGrouped.months.map((month) => toPounds(Number(analysisGrouped.groupedByMonth?.[month]?.[group.name] || 0))),
+            })),
+        };
+    }, [analysisGrouped]);
+
+    const analysisPieOption = useMemo(() => {
+        const groups = analysisGrouped.groups.slice(0, 12);
+        return {
+            tooltip: { trigger: 'item', valueFormatter: (v: number) => `£${v}` },
+            legend: { orient: 'horizontal', bottom: 0 },
+            series: [
+                {
+                    type: 'pie',
+                    radius: ['45%', '72%'],
+                    label: { show: false },
+                    data: groups.map((group, index) => ({
+                        name: group.name,
+                        value: toPounds(group.amountPence),
+                        itemStyle: { color: THEME_COLORS[index % THEME_COLORS.length] },
+                    })),
+                },
+            ],
+        };
+    }, [analysisGrouped]);
+
+    const analysisBreakdownOption = useMemo(() => {
+        const groups = analysisGrouped.groups.slice(0, 20);
+        return {
+            tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+            grid: { left: 180, right: 20, top: 20, bottom: 20 },
+            xAxis: {
+                type: 'value',
+                axisLabel: { formatter: (v: number) => `£${v}` },
+            },
+            yAxis: {
+                type: 'category',
+                data: groups.map((group) => group.name),
+            },
+            series: [
+                {
+                    type: 'bar',
+                    data: groups.map((group, index) => ({
+                        value: toPounds(group.amountPence),
+                        itemStyle: { color: THEME_COLORS[index % THEME_COLORS.length] },
+                    })),
+                },
+            ],
+        };
+    }, [analysisGrouped]);
+
+    const budgetBucketOption = useMemo(() => {
+        const rows = budgetHealth?.byBucket || [];
+        return {
+            tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+            legend: { data: ['Budget', 'Actual'] },
+            grid: { left: 50, right: 15, top: 30, bottom: 30 },
+            xAxis: {
+                type: 'category',
+                data: rows.map((row: any) => row.bucket),
+            },
+            yAxis: {
+                type: 'value',
+                axisLabel: { formatter: (v: number) => `£${v}` },
+            },
+            series: [
+                {
+                    name: 'Budget',
+                    type: 'bar',
+                    itemStyle: { color: '#36A2EB' },
+                    data: rows.map((row: any) => toPounds(row.budgetPence || 0)),
+                },
+                {
+                    name: 'Actual',
+                    type: 'bar',
+                    itemStyle: { color: '#fd5d93' },
+                    data: rows.map((row: any) => toPounds(row.actualPence || 0)),
+                },
+            ],
+        };
+    }, [budgetHealth]);
+
+    const totalActionSavings = actions.reduce((sum: number, action: any) => sum + Number(action.estimatedMonthlySavings || 0), 0);
+
+    const renderOverview = () => (
+        <>
             <Row className="g-4 mb-4">
-                <Col md={4}>
+                <Col md={3}>
                     <PremiumCard icon={DollarSign} title="Total Spend">
                         <h2 className="fw-bold mb-0" style={{ color: colors.danger }}>
                             {formatCurrency(filteredTotalSpend)}
                         </h2>
-                        <p className="text-muted mb-0 mt-2">
-                            <ArrowUpRight size={16} className="text-danger me-1" />
-                            vs last period (N/A)
-                        </p>
+                        <p className="text-muted mb-0 mt-2">View excludes bank transfers</p>
                     </PremiumCard>
                 </Col>
-                <Col md={4}>
+                <Col md={3}>
                     <PremiumCard icon={CreditCard} title="Discretionary">
                         <h2 className="fw-bold mb-0" style={{ color: colors.info }}>
-                            {formatCurrency(Math.abs(data.totalDiscretionarySpend || 0) / 100)}
+                            {formatCurrency(Math.abs(data?.totalDiscretionarySpend || 0) / 100)}
                         </h2>
-                        <p className="text-muted mb-0 mt-2">
-                            Safe to spend
-                        </p>
+                        <p className="text-muted mb-0 mt-2">Optional day-to-day spend</p>
                     </PremiumCard>
                 </Col>
-                <Col md={4}>
+                <Col md={3}>
                     <PremiumCard icon={Layers} title="Subscriptions">
                         <h2 className="fw-bold mb-0" style={{ color: colors.warning }}>
-                            {formatCurrency(Math.abs(data.totalSubscriptionSpend || 0) / 100)}
+                            {formatCurrency(Math.abs(data?.totalSubscriptionSpend || 0) / 100)}
                         </h2>
-                        <p className="text-muted mb-0 mt-2">
-                            Recurring costs
-                        </p>
+                        <p className="text-muted mb-0 mt-2">Recurring costs</p>
+                    </PremiumCard>
+                </Col>
+                <Col md={3}>
+                    <PremiumCard icon={Sparkles} title="Actions Potential">
+                        <h2 className="fw-bold mb-0" style={{ color: colors.success }}>
+                            {formatCurrency(totalActionSavings)}
+                        </h2>
+                        <p className="text-muted mb-0 mt-2">Estimated monthly savings ({actions.length} actions)</p>
                     </PremiumCard>
                 </Col>
             </Row>
 
-            {/* Main Charts */}
+            {budgetHealth && (
+                <Row className="g-4 mb-4">
+                    <Col md={3}>
+                        <PremiumCard icon={Wallet} title="Budget Set">
+                            <h3 className="fw-bold mb-0">{formatCurrency(toPounds(budgetHealth.totalBudgetPence || 0))}</h3>
+                            <p className="text-muted mb-0 mt-2">Configured category budget</p>
+                        </PremiumCard>
+                    </Col>
+                    <Col md={3}>
+                        <PremiumCard icon={Activity} title="Actual Spend">
+                            <h3 className="fw-bold mb-0" style={{ color: colors.danger }}>{formatCurrency(toPounds(budgetHealth.totalActualPence || 0))}</h3>
+                            <p className="text-muted mb-0 mt-2">In selected date range</p>
+                        </PremiumCard>
+                    </Col>
+                    <Col md={3}>
+                        <PremiumCard icon={TrendingUp} title="Variance">
+                            <h3 className="fw-bold mb-0" style={{ color: (budgetHealth.variancePence || 0) >= 0 ? colors.success : colors.warning }}>
+                                {formatCurrency(toPounds(budgetHealth.variancePence || 0))}
+                            </h3>
+                            <p className="text-muted mb-0 mt-2">Budget minus actual</p>
+                        </PremiumCard>
+                    </Col>
+                    <Col md={3}>
+                        <PremiumCard icon={Target} title="Budget Used">
+                            <h3 className="fw-bold mb-0">{Number(budgetHealth.utilizationPct || 0).toFixed(1)}%</h3>
+                            <p className="text-muted mb-0 mt-2">Utilization against set budget</p>
+                        </PremiumCard>
+                    </Col>
+                </Row>
+            )}
+
             <Row className="g-4 mb-4">
                 <Col lg={8}>
                     <PremiumCard title="Spend Trend" icon={TrendingUp} height={350}>
@@ -325,17 +886,16 @@ const FinanceDashboardAdvanced: React.FC = () => {
                         height={350}
                         action={
                             <ButtonGroup size="sm">
-                            <Button variant={viewMode === 'category' ? 'primary' : 'outline-secondary'} onClick={() => setViewMode('category')}>Cat</Button>
-                            <Button variant={viewMode === 'bucket' ? 'primary' : 'outline-secondary'} onClick={() => setViewMode('bucket')}>Bkt</Button>
-                        </ButtonGroup>
-                    }
+                                <Button variant={viewMode === 'category' ? 'primary' : 'outline-secondary'} onClick={() => setViewMode('category')}>Cat</Button>
+                                <Button variant={viewMode === 'bucket' ? 'primary' : 'outline-secondary'} onClick={() => setViewMode('bucket')}>Bkt</Button>
+                            </ButtonGroup>
+                        }
                     >
                         <ReactECharts option={distributionOption} style={{ height: '100%' }} />
                     </PremiumCard>
                 </Col>
             </Row>
 
-            {/* Bucket split */}
             <Row className="mb-4">
                 <Col>
                     <PremiumCard title="Spend by Bucket" icon={PieIcon} height={340}>
@@ -344,9 +904,8 @@ const FinanceDashboardAdvanced: React.FC = () => {
                 </Col>
             </Row>
 
-            {/* Transactions */}
-            <Row>
-                <Col>
+            <Row className="g-4">
+                <Col lg={8}>
                     <PremiumCard title="Recent Transactions" icon={CreditCard}>
                         <div className="table-responsive">
                             <table className="table table-hover align-middle mb-0" style={{ color: colors.text }}>
@@ -357,36 +916,36 @@ const FinanceDashboardAdvanced: React.FC = () => {
                                         <th>Pot</th>
                                         <th>Category</th>
                                         <th className="text-end">Amount</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {filteredRecentTransactions?.map((tx: any) => (
-                                <tr key={tx.id} style={{ borderColor: colors.grid }}>
-                                    <td>{new Date(tx.createdAt._seconds * 1000).toLocaleDateString()}</td>
-                                    <td>
-                                        <div className="fw-bold">{tx.merchantName}</div>
-                                        {tx.isSubscription && <Badge bg="warning" text="dark" className="mt-1">Sub</Badge>}
-                                            </td>
-                                            <td>{tx.potName || '—'}</td>
-                                            <td>
-                                                <Badge bg="light" text="dark" className="border">
-                                                    {tx.categoryLabel || tx.categoryKey}
-                                                </Badge>
-                                            </td>
-                                            <td className="text-end fw-bold" style={{ color: tx.amount < 0 ? colors.text : colors.success }}>
-                                                {formatCurrency(Math.abs(tx.amount) / 100)}
-                                            </td>
-                                        </tr>
-                                    ))}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {filteredRecentTransactions.map((tx: any) => {
+                                        const date = parseTxDate(tx);
+                                        return (
+                                            <tr key={tx.id || tx.transactionId} style={{ borderColor: colors.grid }}>
+                                                <td>{date ? date.toLocaleDateString('en-GB') : '—'}</td>
+                                                <td>
+                                                    <div className="fw-bold">{tx.merchantName || tx.merchant?.name || 'Unknown merchant'}</div>
+                                                    {tx.isSubscription && <Badge bg="warning" text="dark" className="mt-1">Sub</Badge>}
+                                                </td>
+                                                <td>{tx.potName || '—'}</td>
+                                                <td>
+                                                    <Badge bg="light" text="dark" className="border">
+                                                        {tx.userCategoryLabel || tx.aiCategoryLabel || tx.categoryLabel || tx.categoryKey || 'Uncategorised'}
+                                                    </Badge>
+                                                </td>
+                                                <td className="text-end fw-bold" style={{ color: tx.amount < 0 ? colors.text : colors.success }}>
+                                                    {formatCurrency(Math.abs(tx.amount || 0) / 100)}
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
                                 </tbody>
                             </table>
                         </div>
                     </PremiumCard>
                 </Col>
-            </Row>
-
-            <Row className="mt-4">
-                <Col>
+                <Col lg={4}>
                     <PremiumCard title="Spend Anomalies" icon={Activity}>
                         {Array.isArray(data?.anomalyTransactions) && data.anomalyTransactions.length ? (
                             <div className="table-responsive">
@@ -410,11 +969,798 @@ const FinanceDashboardAdvanced: React.FC = () => {
                                 </table>
                             </div>
                         ) : (
-                            <div className="text-muted small">No anomalies detected in the last 90 days.</div>
+                            <div className="text-muted small">No anomalies detected in the selected period.</div>
                         )}
                     </PremiumCard>
                 </Col>
             </Row>
+        </>
+    );
+
+    const renderSpendAnalysis = () => (
+        <>
+            <Row className="g-4 mb-4">
+                <Col md={4}>
+                    <PremiumCard icon={DollarSign} title="Filtered Spend">
+                        <h3 className="fw-bold mb-0">{formatCurrency(toPounds(analysisStats.totalPence || 0))}</h3>
+                        <p className="text-muted mb-0 mt-2">Based on active filters</p>
+                    </PremiumCard>
+                </Col>
+                <Col md={4}>
+                    <PremiumCard icon={Layers} title="Transactions">
+                        <h3 className="fw-bold mb-0">{analysisStats.count}</h3>
+                        <p className="text-muted mb-0 mt-2">Rows in analysis set</p>
+                    </PremiumCard>
+                </Col>
+                <Col md={4}>
+                    <PremiumCard icon={TrendingUp} title="Avg Transaction">
+                        <h3 className="fw-bold mb-0">{formatCurrency(toPounds(analysisStats.avgPence || 0))}</h3>
+                        <p className="text-muted mb-0 mt-2">Average spend per transaction</p>
+                    </PremiumCard>
+                </Col>
+            </Row>
+
+            <Row className="g-4 mb-4">
+                <Col lg={12}>
+                    <PremiumCard
+                        title="Spend Analysis"
+                        icon={PieIcon}
+                        action={
+                            <ButtonGroup size="sm">
+                                <Button variant={analysisChartType === 'trend' ? 'primary' : 'outline-secondary'} onClick={() => setAnalysisChartType('trend')}>Trend</Button>
+                                <Button variant={analysisChartType === 'pie' ? 'primary' : 'outline-secondary'} onClick={() => setAnalysisChartType('pie')}>Pie</Button>
+                                <Button variant={analysisChartType === 'breakdown' ? 'primary' : 'outline-secondary'} onClick={() => setAnalysisChartType('breakdown')}>Breakdown</Button>
+                            </ButtonGroup>
+                        }
+                    >
+                        <Row className="g-3 mb-3">
+                            <Col md={3}>
+                                <Form.Label>Group by</Form.Label>
+                                <Form.Select value={analysisDimension} onChange={(event) => setAnalysisDimension(event.target.value as AnalysisDimension)}>
+                                    <option value="bucket">Bucket</option>
+                                    <option value="category">Category</option>
+                                    <option value="merchant">Merchant</option>
+                                </Form.Select>
+                            </Col>
+                            <Col md={3}>
+                                <Form.Label>Bucket filter</Form.Label>
+                                <Form.Select value={analysisBucketFilter} onChange={(event) => setAnalysisBucketFilter(event.target.value)}>
+                                    <option value="all">All buckets</option>
+                                    {analysisBucketOptions.map((bucket) => (
+                                        <option key={bucket} value={bucket}>{bucket}</option>
+                                    ))}
+                                </Form.Select>
+                            </Col>
+                            <Col md={3}>
+                                <Form.Label>Category filter</Form.Label>
+                                <Form.Select value={analysisCategoryFilter} onChange={(event) => setAnalysisCategoryFilter(event.target.value)}>
+                                    <option value="all">All categories</option>
+                                    {analysisCategoryOptions.map((category) => (
+                                        <option key={category} value={category}>{category}</option>
+                                    ))}
+                                </Form.Select>
+                            </Col>
+                            <Col md={3}>
+                                <Form.Label>Merchant filter</Form.Label>
+                                <Form.Select value={analysisMerchantFilter} onChange={(event) => setAnalysisMerchantFilter(event.target.value)}>
+                                    <option value="all">All merchants</option>
+                                    {analysisMerchantOptions.map((merchant) => (
+                                        <option key={merchant} value={merchant}>{merchant}</option>
+                                    ))}
+                                </Form.Select>
+                            </Col>
+                        </Row>
+
+                        {analysisChartType === 'trend' && <ReactECharts option={analysisTrendOption} style={{ height: 360 }} />}
+                        {analysisChartType === 'pie' && <ReactECharts option={analysisPieOption} style={{ height: 360 }} />}
+                        {analysisChartType === 'breakdown' && <ReactECharts option={analysisBreakdownOption} style={{ height: 360 }} />}
+                    </PremiumCard>
+                </Col>
+            </Row>
+
+            <Row className="g-4 mb-4">
+                <Col lg={8}>
+                    <PremiumCard title="Multi-Year Spend Tracking" icon={TrendingUp} height={360}>
+                        <ReactECharts option={spendTrackingOption} style={{ height: '100%' }} />
+                    </PremiumCard>
+                </Col>
+                <Col lg={4}>
+                    <PremiumCard title="Coverage" icon={Calendar}>
+                        <div className="small text-muted mb-2">Monzo coverage</div>
+                        <div className="mb-2">
+                            <strong>From:</strong> {enhancementData?.coverage?.monzoCoverageStartISO ? new Date(enhancementData.coverage.monzoCoverageStartISO).toLocaleDateString('en-GB') : '—'}
+                        </div>
+                        <div className="mb-2">
+                            <strong>To:</strong> {enhancementData?.coverage?.monzoCoverageEndISO ? new Date(enhancementData.coverage.monzoCoverageEndISO).toLocaleDateString('en-GB') : '—'}
+                        </div>
+                        <div className="mb-2">
+                            <strong>Rows (range):</strong> {enhancementData?.coverage?.monzoTransactionsInRange || 0}
+                        </div>
+                        <div>
+                            <strong>Rows (total):</strong> {enhancementData?.coverage?.monzoTransactionsTotal || 0}
+                        </div>
+                    </PremiumCard>
+                </Col>
+            </Row>
+
+            {budgetHealth && (
+                <Row className="g-4 mb-4">
+                    <Col lg={7}>
+                        <PremiumCard title="Budget vs Actual" icon={Target} height={360}>
+                            <ReactECharts option={budgetBucketOption} style={{ height: '100%' }} />
+                        </PremiumCard>
+                    </Col>
+                    <Col lg={5}>
+                        <PremiumCard title="Budget Variance by Category" icon={Wallet}>
+                            <div className="table-responsive" style={{ maxHeight: 330, overflowY: 'auto' }}>
+                                <table className="table table-sm align-middle mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Category</th>
+                                            <th className="text-end">Budget</th>
+                                            <th className="text-end">Actual</th>
+                                            <th className="text-end">Used</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {(budgetHealth.byCategory || []).slice(0, 12).map((item: any) => (
+                                            <tr key={item.categoryKey}>
+                                                <td>{item.categoryLabel || item.categoryKey}</td>
+                                                <td className="text-end">{formatCurrency(toPounds(item.budgetPence || 0))}</td>
+                                                <td className="text-end">{formatCurrency(toPounds(item.actualPence || 0))}</td>
+                                                <td className="text-end">{Number(item.utilizationPct || 0).toFixed(0)}%</td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </PremiumCard>
+                    </Col>
+                </Row>
+            )}
+        </>
+    );
+
+    const renderCashflow = () => {
+        const totals = cashflowSeries.reduce((acc: any, item: any) => {
+            acc.inflow += item.inflowPence || 0;
+            acc.outflow += item.outflowPence || 0;
+            acc.net += item.netPence || 0;
+            return acc;
+        }, { inflow: 0, outflow: 0, net: 0 });
+
+        const months = Math.max(1, cashflowSeries.length);
+
+        return (
+            <>
+                <Row className="g-4 mb-4">
+                    <Col md={4}>
+                        <PremiumCard icon={ArrowUpRight} title="Avg Monthly Inflow">
+                            <h3 className="fw-bold mb-0" style={{ color: colors.success }}>
+                                {formatCurrency(toPounds(Math.round(totals.inflow / months)))}
+                            </h3>
+                        </PremiumCard>
+                    </Col>
+                    <Col md={4}>
+                        <PremiumCard icon={ArrowUpRight} title="Avg Monthly Outflow">
+                            <h3 className="fw-bold mb-0" style={{ color: colors.danger }}>
+                                {formatCurrency(toPounds(Math.round(totals.outflow / months)))}
+                            </h3>
+                        </PremiumCard>
+                    </Col>
+                    <Col md={4}>
+                        <PremiumCard icon={DollarSign} title="Avg Monthly Net">
+                            <h3 className="fw-bold mb-0" style={{ color: totals.net >= 0 ? colors.success : colors.warning }}>
+                                {formatCurrency(toPounds(Math.round(totals.net / months)))}
+                            </h3>
+                        </PremiumCard>
+                    </Col>
+                </Row>
+
+                <Row className="mb-4">
+                    <Col>
+                        <PremiumCard title="Cashflow Trend" icon={TrendingUp} height={380}>
+                            <ReactECharts option={cashflowOption} style={{ height: '100%' }} />
+                        </PremiumCard>
+                    </Col>
+                </Row>
+
+                <Row>
+                    <Col>
+                        <PremiumCard title="Goal Savings Forecast" icon={Target}>
+                            <div className="small text-muted mb-3">
+                                ETA is based on linked pot balance versus goal target and average net pot contributions over recent months.
+                            </div>
+                            <div className="table-responsive">
+                                <table className="table table-hover align-middle mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Goal</th>
+                                            <th>Linked pot</th>
+                                            <th className="text-end">Target</th>
+                                            <th className="text-end">Current</th>
+                                            <th className="text-end">Remaining</th>
+                                            <th className="text-end">Avg monthly in</th>
+                                            <th className="text-end">ETA</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {goalForecasts.length === 0 && (
+                                            <tr>
+                                                <td colSpan={7} className="text-center text-muted py-4">No linked goals found. Link goals to pots in Goal Linking.</td>
+                                            </tr>
+                                        )}
+                                        {goalForecasts.map((goal: any) => (
+                                            <tr key={goal.goalId}>
+                                                <td>{goal.goalTitle || goal.goalId}</td>
+                                                <td>{goal.linkedPotName || 'No linked pot'}</td>
+                                                <td className="text-end">{formatCurrency(toPounds(goal.targetAmountPence || 0))}</td>
+                                                <td className="text-end">{formatCurrency(toPounds(goal.currentBalancePence || 0))}</td>
+                                                <td className="text-end">{formatCurrency(toPounds(goal.remainingPence || 0))}</td>
+                                                <td className="text-end">{formatCurrency(toPounds(goal.monthlyContributionPence || 0))}</td>
+                                                <td className="text-end">
+                                                    {goal.etaMonths ? (
+                                                        <span>{goal.etaMonths} mo ({goal.etaDateISO ? new Date(goal.etaDateISO).toLocaleDateString('en-GB') : 'TBC'})</span>
+                                                    ) : (
+                                                        <span className="text-muted">Insufficient inflow</span>
+                                                    )}
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </PremiumCard>
+                    </Col>
+                </Row>
+            </>
+        );
+    };
+
+    const renderOptionalSpend = () => (
+        <>
+            <Row className="g-4 mb-4">
+                {optionalSpendCards.length === 0 && (
+                    <Col>
+                        <Alert variant="secondary" className="mb-0">No optional spend cards available for this range.</Alert>
+                    </Col>
+                )}
+                {optionalSpendCards.map((item: any) => (
+                    <Col key={item.merchantKey} xl={3} lg={4} md={6}>
+                        <PremiumCard title={item.merchantName} icon={Layers} className="finance-optional-card">
+                            <div className="d-flex justify-content-between small text-muted mb-2">
+                                <span>Monthly avg</span>
+                                <strong>{formatCurrency(toPounds(item.avgMonthlySpendPence || 0))}</strong>
+                            </div>
+                            <div className="d-flex justify-content-between small text-muted mb-2">
+                                <span>Total spend</span>
+                                <strong>{formatCurrency(toPounds(item.totalSpendPence || 0))}</strong>
+                            </div>
+                            <div className="d-flex justify-content-between small text-muted mb-3">
+                                <span>Transactions</span>
+                                <strong>{item.transactions || 0}</strong>
+                            </div>
+                            <div>
+                                {item.recurring ? (
+                                    <Badge bg="warning" text="dark">Recurring ({item.activeMonths} months)</Badge>
+                                ) : (
+                                    <Badge bg="secondary">Ad-hoc spend</Badge>
+                                )}
+                            </div>
+                        </PremiumCard>
+                    </Col>
+                ))}
+            </Row>
+        </>
+    );
+
+    const renderActions = () => (
+        <>
+            <Row className="g-4 mb-4">
+                <Col md={4}>
+                    <PremiumCard title="Open Actions" icon={Sparkles}>
+                        <h3 className="fw-bold mb-0">{actions.length}</h3>
+                    </PremiumCard>
+                </Col>
+                <Col md={4}>
+                    <PremiumCard title="Potential Monthly Savings" icon={DollarSign}>
+                        <h3 className="fw-bold mb-0" style={{ color: colors.success }}>{formatCurrency(totalActionSavings)}</h3>
+                    </PremiumCard>
+                </Col>
+                <Col md={4}>
+                    <PremiumCard title="Debt Interest (Estimated)" icon={CreditCard}>
+                        <h3 className="fw-bold mb-0" style={{ color: colors.warning }}>
+                            {formatCurrency(toPounds(debtService?.estimatedInterestPence || 0))}
+                        </h3>
+                    </PremiumCard>
+                </Col>
+            </Row>
+
+            <Row>
+                <Col>
+                    <PremiumCard
+                        title="Action-Oriented Optimizations"
+                        icon={CheckCircle2}
+                        action={
+                            <Button size="sm" variant="outline-primary" onClick={handleRegenerateActions} disabled={busy}>
+                                {busy ? 'Working…' : 'Regenerate'}
+                            </Button>
+                        }
+                    >
+                        <div className="small text-muted mb-3">
+                            Actions are generated from recurring spend + debt servicing signals, then optionally refined by AI.
+                        </div>
+                        <div className="table-responsive">
+                            <table className="table table-hover align-middle mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Action</th>
+                                        <th>Type</th>
+                                        <th className="text-end">Monthly saving</th>
+                                        <th className="text-end">Confidence</th>
+                                        <th>Status</th>
+                                        <th className="text-end">Story</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {actions.length === 0 && (
+                                        <tr>
+                                            <td colSpan={6} className="text-center text-muted py-4">No actions yet. Run action generation from Data Sources.</td>
+                                        </tr>
+                                    )}
+                                    {actions.map((action: any) => (
+                                        <tr key={action.id}>
+                                            <td>
+                                                <div className="fw-semibold">{action.title || action.merchantName || action.merchantKey}</div>
+                                                <div className="small text-muted">{action.reason || 'No detail provided.'}</div>
+                                            </td>
+                                            <td>
+                                                <Badge bg="light" text="dark" className="border text-uppercase">{action.type || 'review'}</Badge>
+                                            </td>
+                                            <td className="text-end fw-semibold">{formatCurrency(Number(action.estimatedMonthlySavings || 0))}</td>
+                                            <td className="text-end">{Math.round(Number(action.confidence || 0) * 100)}%</td>
+                                            <td>
+                                                {action.storyId ? (
+                                                    <Badge bg="success">Converted</Badge>
+                                                ) : (
+                                                    <Badge bg="secondary">Open</Badge>
+                                                )}
+                                            </td>
+                                            <td className="text-end">
+                                                {action.storyId ? (
+                                                    <a className="btn btn-sm btn-outline-secondary" href={`/stories/${action.storyId}`}>
+                                                        Open story
+                                                    </a>
+                                                ) : (
+                                                    <Button
+                                                        size="sm"
+                                                        variant="primary"
+                                                        onClick={() => handleConvertActionToStory(action.id)}
+                                                        disabled={convertingActionId === action.id}
+                                                    >
+                                                        {convertingActionId === action.id ? 'Converting…' : 'Convert to story'}
+                                                    </Button>
+                                                )}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    </PremiumCard>
+                </Col>
+            </Row>
+        </>
+    );
+
+    const renderDataSources = () => (
+        <>
+            <Row className="g-4 mb-4">
+                <Col lg={5}>
+                    <PremiumCard title="External Source Import" icon={Upload}>
+                        <Form.Group className="mb-3">
+                            <Form.Label>Source</Form.Label>
+                            <Form.Select value={externalSource} onChange={(event) => setExternalSource(event.target.value as ExternalSource)}>
+                                <option value="barclays">Barclays / Barclaycard</option>
+                                <option value="paypal">PayPal</option>
+                                <option value="other">Other</option>
+                            </Form.Select>
+                        </Form.Group>
+
+                        <Form.Group className="mb-3">
+                            <Form.Label>CSV file</Form.Label>
+                            <Form.Control type="file" accept=".csv,text/csv" onChange={handleCsvFileUpload} />
+                            <div className="small text-muted mt-1">
+                                {csvFileName ? `Loaded: ${csvFileName}` : 'Choose a source export CSV to import.'}
+                            </div>
+                        </Form.Group>
+
+                        <Row className="g-2 mb-3">
+                            <Col>
+                                <Form.Label>Date window (days)</Form.Label>
+                                <Form.Control
+                                    type="number"
+                                    min={1}
+                                    max={30}
+                                    value={windowDays}
+                                    onChange={(event) => setWindowDays(Number(event.target.value || 5))}
+                                />
+                            </Col>
+                            <Col>
+                                <Form.Label>Amount tolerance (pence)</Form.Label>
+                                <Form.Control
+                                    type="number"
+                                    min={1}
+                                    max={2_000}
+                                    value={amountTolerancePence}
+                                    onChange={(event) => setAmountTolerancePence(Number(event.target.value || 150))}
+                                />
+                            </Col>
+                        </Row>
+
+                        <div className="d-flex flex-wrap gap-2">
+                            <Button variant="primary" onClick={handleImportAndRebuild} disabled={busy}>
+                                {busy ? 'Running…' : 'Import + Match + Rebuild'}
+                            </Button>
+                            <Button variant="outline-secondary" onClick={handleRematch} disabled={busy}>
+                                Match only
+                            </Button>
+                            <Button variant="outline-secondary" onClick={handleRegenerateActions} disabled={busy}>
+                                Rebuild actions
+                            </Button>
+                        </div>
+                    </PremiumCard>
+                </Col>
+
+                <Col lg={7}>
+                    <PremiumCard title="Source Coverage & Matching" icon={Link2}>
+                        <div className="table-responsive">
+                            <table className="table table-hover align-middle mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Source</th>
+                                        <th className="text-end">Rows</th>
+                                        <th className="text-end">Spend</th>
+                                        <th className="text-end">Matched</th>
+                                        <th className="text-end">Unmatched</th>
+                                        <th>Coverage</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {externalSummary.length === 0 && (
+                                        <tr>
+                                            <td colSpan={6} className="text-center text-muted py-4">No external data imported yet.</td>
+                                        </tr>
+                                    )}
+                                    {externalSummary.map((sourceItem: any) => {
+                                        const matchItem = matchBySource.get(sourceItem.source) || {};
+                                        return (
+                                            <tr key={sourceItem.source}>
+                                                <td className="text-capitalize">{sourceItem.source}</td>
+                                                <td className="text-end">{sourceItem.rows || 0}</td>
+                                                <td className="text-end">{formatCurrency(toPounds(sourceItem.spendPence || 0))}</td>
+                                                <td className="text-end">{matchItem.matched || 0}</td>
+                                                <td className="text-end">{matchItem.unmatched || 0}</td>
+                                                <td className="small text-muted">
+                                                    {sourceItem.firstDateISO ? new Date(sourceItem.firstDateISO).toLocaleDateString('en-GB') : '—'}
+                                                    {' → '}
+                                                    {sourceItem.lastDateISO ? new Date(sourceItem.lastDateISO).toLocaleDateString('en-GB') : '—'}
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+                    </PremiumCard>
+                </Col>
+            </Row>
+
+            <Row>
+                <Col>
+                    <PremiumCard title="Debt Servicing Breakdown" icon={CreditCard}>
+                        {debtService ? (
+                            <Row className="g-4">
+                                <Col md={3}>
+                                    <div className="small text-muted">Card spend</div>
+                                    <div className="fw-semibold">{formatCurrency(toPounds(debtService.statementSpendPence || 0))}</div>
+                                </Col>
+                                <Col md={3}>
+                                    <div className="small text-muted">Monzo payments</div>
+                                    <div className="fw-semibold">{formatCurrency(toPounds(debtService.monzoPaymentsPence || 0))}</div>
+                                </Col>
+                                <Col md={3}>
+                                    <div className="small text-muted">Estimated interest</div>
+                                    <div className="fw-semibold">{formatCurrency(toPounds(debtService.estimatedInterestPence || 0))}</div>
+                                </Col>
+                                <Col md={3}>
+                                    <div className="small text-muted">Estimated principal</div>
+                                    <div className="fw-semibold">{formatCurrency(toPounds(debtService.principalRepaymentPence || 0))}</div>
+                                </Col>
+                            </Row>
+                        ) : (
+                            <div className="text-muted small">Debt service data will appear after import + matching.</div>
+                        )}
+                    </PremiumCard>
+                </Col>
+            </Row>
+        </>
+    );
+
+    const renderAssets = () => (
+        <>
+            <Row className="g-4 mb-4">
+                <Col md={3}>
+                    <PremiumCard title="Tracked Assets" icon={Landmark}>
+                        <h3 className="fw-bold mb-0" style={{ color: colors.success }}>
+                            {formatCurrency(toPounds(manualAccountSummary.totalAssetPence || 0))}
+                        </h3>
+                    </PremiumCard>
+                </Col>
+                <Col md={3}>
+                    <PremiumCard title="Tracked Debts" icon={CreditCard}>
+                        <h3 className="fw-bold mb-0" style={{ color: colors.danger }}>
+                            {formatCurrency(toPounds(manualAccountSummary.totalDebtPence || 0))}
+                        </h3>
+                    </PremiumCard>
+                </Col>
+                <Col md={3}>
+                    <PremiumCard title="Net Worth" icon={Wallet}>
+                        <h3 className="fw-bold mb-0" style={{ color: (manualAccountSummary.netWorthPence || 0) >= 0 ? colors.success : colors.warning }}>
+                            {formatCurrency(toPounds(manualAccountSummary.netWorthPence || 0))}
+                        </h3>
+                    </PremiumCard>
+                </Col>
+                <Col md={3}>
+                    <PremiumCard title="Stale Updates" icon={AlertTriangle}>
+                        <h3 className="fw-bold mb-0" style={{ color: manualAccountSummary.staleCount ? colors.warning : colors.success }}>
+                            {manualAccountSummary.staleCount || 0}
+                        </h3>
+                        <p className="text-muted mb-0 mt-2">Accounts older than 30 days</p>
+                    </PremiumCard>
+                </Col>
+            </Row>
+
+            <Row className="g-4 mb-4">
+                <Col lg={5}>
+                    <PremiumCard title={editingManualAccountId ? 'Update Account' : 'Add Account'} icon={Wallet}>
+                        <Form.Group className="mb-2">
+                            <Form.Label>Name</Form.Label>
+                            <Form.Control
+                                value={manualForm.name}
+                                onChange={(event) => setManualForm((prev) => ({ ...prev, name: event.target.value }))}
+                                placeholder="e.g. Hargreaves Lansdown ISA"
+                            />
+                        </Form.Group>
+                        <Form.Group className="mb-2">
+                            <Form.Label>Institution</Form.Label>
+                            <Form.Control
+                                value={manualForm.institution}
+                                onChange={(event) => setManualForm((prev) => ({ ...prev, institution: event.target.value }))}
+                                placeholder="e.g. Hargreaves Lansdown"
+                            />
+                        </Form.Group>
+                        <Row className="g-2 mb-2">
+                            <Col>
+                                <Form.Label>Type</Form.Label>
+                                <Form.Select
+                                    value={manualForm.type}
+                                    onChange={(event) => setManualForm((prev) => ({ ...prev, type: normalizeManualType(event.target.value) }))}
+                                >
+                                    <option value="asset">Asset</option>
+                                    <option value="investment">Investment</option>
+                                    <option value="cash">Cash / Savings</option>
+                                    <option value="savings">Savings goal</option>
+                                    <option value="debt">Debt / Liability</option>
+                                </Form.Select>
+                            </Col>
+                            <Col>
+                                <Form.Label>Currency</Form.Label>
+                                <Form.Control
+                                    value={manualForm.currency}
+                                    maxLength={3}
+                                    onChange={(event) => setManualForm((prev) => ({ ...prev, currency: event.target.value.toUpperCase() }))}
+                                />
+                            </Col>
+                        </Row>
+                        <Form.Group className="mb-3">
+                            <Form.Label>Balance</Form.Label>
+                            <Form.Control
+                                type="number"
+                                step="0.01"
+                                value={manualForm.balance}
+                                onChange={(event) => setManualForm((prev) => ({ ...prev, balance: event.target.value }))}
+                                placeholder="0.00"
+                            />
+                        </Form.Group>
+                        <div className="d-flex gap-2">
+                            <Button onClick={handleSaveManualAccount} disabled={manualBusy}>
+                                {manualBusy ? 'Saving…' : editingManualAccountId ? 'Update' : 'Add'}
+                            </Button>
+                            <Button variant="outline-secondary" onClick={resetManualForm} disabled={manualBusy}>
+                                Clear
+                            </Button>
+                        </div>
+                    </PremiumCard>
+                </Col>
+
+                <Col lg={7}>
+                    <PremiumCard title="Assets / Debts Register" icon={Landmark}>
+                        {manualAccountSummary.staleCount > 0 && (
+                            <Alert variant="warning" className="py-2">
+                                {manualAccountSummary.staleCount} account(s) have not been updated in over 30 days.
+                            </Alert>
+                        )}
+                        <div className="table-responsive">
+                            <table className="table table-hover align-middle mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Account</th>
+                                        <th>Type</th>
+                                        <th className="text-end">Balance</th>
+                                        <th>Last update</th>
+                                        <th className="text-end">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {manualAccounts.length === 0 && (
+                                        <tr>
+                                            <td colSpan={5} className="text-center text-muted py-4">
+                                                Add assets, debts, and investment accounts to track full financial health.
+                                            </td>
+                                        </tr>
+                                    )}
+                                    {manualAccounts.map((account: any) => (
+                                        <tr key={account.accountId}>
+                                            <td>
+                                                <div className="fw-semibold">{account.name}</div>
+                                                <div className="small text-muted">{account.institution || 'No institution'}</div>
+                                            </td>
+                                            <td>
+                                                <Badge bg={account.type === 'debt' ? 'danger' : 'info'} className="text-uppercase">
+                                                    {account.type}
+                                                </Badge>
+                                            </td>
+                                            <td className="text-end fw-semibold">{formatCurrency(toPounds(account.balancePence || 0))}</td>
+                                            <td>
+                                                {account.updatedAtISO ? new Date(account.updatedAtISO).toLocaleDateString('en-GB') : '—'}
+                                                {account.isStale && <Badge bg="warning" text="dark" className="ms-2">Stale</Badge>}
+                                            </td>
+                                            <td className="text-end">
+                                                <Button size="sm" variant="outline-secondary" className="me-2" onClick={() => startEditManualAccount(account)}>
+                                                    Edit
+                                                </Button>
+                                                <Button size="sm" variant="outline-danger" onClick={() => handleDeleteManualAccount(account.accountId)}>
+                                                    <Trash2 size={14} />
+                                                </Button>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    </PremiumCard>
+                </Col>
+            </Row>
+        </>
+    );
+
+    if (loading && !data) {
+        return (
+            <div className="p-5 text-center">
+                <Spinner animation="border" variant="primary" />
+            </div>
+        );
+    }
+
+    if (!data) {
+        return <Alert variant="danger">{error || 'Failed to load data.'}</Alert>;
+    }
+
+    const viewButtons: Array<{ key: FinanceView; label: string }> = [
+        { key: 'overview', label: 'Overview' },
+        { key: 'spend', label: 'Spend analysis' },
+        { key: 'cashflow', label: 'Cashflow + Goals' },
+        { key: 'optional', label: 'Optional spend' },
+        { key: 'actions', label: 'Actions' },
+        { key: 'sources', label: 'Data sources' },
+        { key: 'assets', label: 'Assets & Debts' },
+    ];
+
+    return (
+        <div className="container-fluid py-4" style={{ backgroundColor: isDark ? '#1e1e2f' : '#f4f5f7', minHeight: '100vh', color: colors.text }}>
+            {userBadge}
+
+            <div className="d-flex flex-column flex-xl-row justify-content-between align-items-xl-center mb-4 gap-3">
+                <div>
+                    <h2 className="fw-bold mb-1">Finance Intelligence Dashboard</h2>
+                    <div className="d-flex align-items-center gap-2 text-muted">
+                        <Calendar size={16} />
+                        <span>
+                            {filter === 'month' && 'This Month'}
+                            {filter === 'quarter' && 'This Quarter'}
+                            {filter === 'year' && 'This Year'}
+                            {filter === 'all' && 'All History (since 2018)'}
+                            {filter === 'custom' && 'Custom Range'}
+                        </span>
+                        {lastSync && (
+                            <>
+                                <span className="mx-1">•</span>
+                                <RefreshCw size={14} className={syncing ? 'spin' : ''} />
+                                <small>Synced {lastSync.toLocaleString('en-GB', { hour: '2-digit', minute: '2-digit' })}</small>
+                            </>
+                        )}
+                    </div>
+                </div>
+
+                <div className="d-flex flex-wrap gap-2 align-items-center">
+                    <ButtonGroup>
+                        <Button variant={filter === 'month' ? 'primary' : 'outline-secondary'} onClick={() => setFilter('month')}>Month</Button>
+                        <Button variant={filter === 'quarter' ? 'primary' : 'outline-secondary'} onClick={() => setFilter('quarter')}>Quarter</Button>
+                        <Button variant={filter === 'year' ? 'primary' : 'outline-secondary'} onClick={() => setFilter('year')}>Year</Button>
+                        <Button variant={filter === 'all' ? 'primary' : 'outline-secondary'} onClick={() => setFilter('all')}>All</Button>
+                        <Button variant={filter === 'custom' ? 'primary' : 'outline-secondary'} onClick={() => setFilter('custom')}>Custom</Button>
+                    </ButtonGroup>
+
+                    <Form.Control
+                        type="date"
+                        size="sm"
+                        value={startDate}
+                        onChange={(event) => {
+                            setFilter('custom');
+                            setStartDate(event.target.value);
+                        }}
+                        style={{ maxWidth: 150 }}
+                    />
+                    <Form.Control
+                        type="date"
+                        size="sm"
+                        value={endDate}
+                        onChange={(event) => {
+                            setFilter('custom');
+                            setEndDate(event.target.value);
+                        }}
+                        style={{ maxWidth: 150 }}
+                    />
+
+                    <Button variant="outline-primary" onClick={handleSync} disabled={syncing}>
+                        {syncing ? <Spinner size="sm" animation="border" /> : <RefreshCw size={18} />}
+                    </Button>
+                </div>
+            </div>
+
+            <div className="finance-dashboard-view-switch mb-4">
+                <ButtonGroup>
+                    {viewButtons.map((button) => (
+                        <Button
+                            key={button.key}
+                            variant={activeView === button.key ? 'primary' : 'outline-secondary'}
+                            onClick={() => setActiveView(button.key)}
+                        >
+                            {button.label}
+                        </Button>
+                    ))}
+                </ButtonGroup>
+            </div>
+
+            {error && (
+                <Alert variant="danger" className="mb-3">
+                    {error}
+                </Alert>
+            )}
+            {opsMessage && (
+                <Alert variant="success" className="mb-3">
+                    {opsMessage}
+                </Alert>
+            )}
+
+            {activeView === 'overview' && renderOverview()}
+            {activeView === 'spend' && renderSpendAnalysis()}
+            {activeView === 'cashflow' && renderCashflow()}
+            {activeView === 'optional' && renderOptionalSpend()}
+            {activeView === 'actions' && renderActions()}
+            {activeView === 'sources' && renderDataSources()}
+            {activeView === 'assets' && renderAssets()}
         </div>
     );
 };

--- a/react-app/src/components/finance/FinanceDashboardAdvanced.tsx
+++ b/react-app/src/components/finance/FinanceDashboardAdvanced.tsx
@@ -226,7 +226,12 @@ const FinanceDashboardAdvanced: React.FC = () => {
             await fetchData();
             setOpsMessage('Monzo sync completed and dashboard refreshed.');
         } catch (e: any) {
-            setError(e?.message || 'Sync failed');
+            const message = String(e?.message || 'Sync failed');
+            if (/monzo connection expired|missing monzo refresh token/i.test(message)) {
+                setError('Monzo connection expired. Reconnect Monzo in Integrations, then run sync again.');
+            } else {
+                setError(message);
+            }
         } finally {
             setSyncing(false);
         }

--- a/react-app/src/components/finance/MerchantMappings.css
+++ b/react-app/src/components/finance/MerchantMappings.css
@@ -1,13 +1,20 @@
+.finance-merchant-container {
+    max-width: 1880px;
+    padding-left: 20px;
+    padding-right: 20px;
+}
+
 .merchant-table {
     background: #f8fafc;
     border: 1px solid #e5e7eb;
     border-radius: 16px;
     overflow: hidden;
+    overflow-x: auto;
 }
 
 .merchant-header {
     display: grid;
-    grid-template-columns: 1.3fr 1fr 0.8fr 0.8fr 1.2fr 0.9fr 0.8fr 0.7fr 1.1fr;
+    grid-template-columns: 1.35fr 1fr 0.85fr 0.9fr 0.9fr 1.25fr 0.9fr 0.85fr 1.15fr;
     gap: 10px;
     padding: 12px 16px;
     background: #f1f5f9;
@@ -19,7 +26,7 @@
 
 .merchant-row {
     display: grid;
-    grid-template-columns: 1.35fr 1fr 0.8fr 0.8fr 1.2fr 0.9fr 0.8fr 0.7fr 1.1fr;
+    grid-template-columns: 1.35fr 1fr 0.85fr 0.9fr 0.9fr 1.25fr 0.9fr 0.85fr 1.15fr;
     gap: 10px;
     align-items: center;
     padding: 12px 16px;
@@ -55,6 +62,7 @@
     display: flex;
     gap: 6px;
     justify-content: flex-end;
+    flex-wrap: nowrap;
 }
 
 .merchant-chip {
@@ -88,4 +96,36 @@
 .merchant-subtext {
     font-size: 0.82rem;
     color: #6b7280;
+}
+
+.merchant-sort-header {
+    border: none;
+    background: transparent;
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 6px;
+    width: 100%;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #334155;
+    padding: 0;
+    cursor: pointer;
+}
+
+.merchant-sort-header--end {
+    justify-content: flex-end;
+}
+
+.merchant-sort-header.is-active {
+    color: #1d4ed8;
+}
+
+.merchant-sort-indicator {
+    font-size: 0.72rem;
+    color: #64748b;
+}
+
+.merchant-row .btn {
+    white-space: nowrap;
 }

--- a/react-app/src/components/finance/TransactionsList.css
+++ b/react-app/src/components/finance/TransactionsList.css
@@ -4,6 +4,12 @@
      padding: 12px 0 32px;
  }
 
+.finance-table-container {
+     max-width: 1880px;
+     padding-left: 20px;
+     padding-right: 20px;
+}
+
 .finance-filter-card {
      border: 1px solid #e5e7eb;
      border-radius: 16px;
@@ -25,6 +31,7 @@
 .finance-table-shell {
      background: #fff;
      position: relative;
+     overflow-x: auto;
  }
 
 .finance-empty {
@@ -35,11 +42,11 @@
 .finance-list-wrapper {
      height: 620px;
      width: 100%;
- }
+}
 
 .finance-grid-header {
     display: grid;
-    grid-template-columns: 1.05fr 1.2fr 1.55fr 1.05fr 1.4fr 0.85fr 0.95fr;
+    grid-template-columns: 1.1fr 1.3fr 1.8fr 1.05fr 1.7fr 0.95fr 1.25fr;
     gap: 12px;
     padding: 10px 16px;
     background: #f8fafc;
@@ -51,7 +58,7 @@
 
 .finance-row {
      display: grid;
-     grid-template-columns: 1.05fr 1.2fr 1.55fr 1.05fr 1.4fr 0.85fr 0.95fr;
+     grid-template-columns: 1.1fr 1.3fr 1.8fr 1.05fr 1.7fr 0.95fr 1.25fr;
      gap: 12px;
      align-items: center;
      padding: 14px 16px;
@@ -141,9 +148,11 @@
 
 .finance-actions {
      display: flex;
-     flex-direction: column;
-     gap: 6px;
+     flex-direction: row;
+     gap: 8px;
      align-items: flex-end;
+     justify-content: flex-end;
+     flex-wrap: nowrap;
  }
 
 .finance-btn-save {
@@ -151,6 +160,7 @@
      border: none;
      color: #fff;
      padding-inline: 12px;
+     white-space: nowrap;
  }
 
 .finance-btn-apply {
@@ -158,9 +168,37 @@
      border: 1px solid #e5e7eb;
      color: #0f172a;
      padding-inline: 12px;
+     white-space: nowrap;
  }
 
 .finance-btn-save:disabled,
 .finance-btn-apply:disabled {
      opacity: 0.65;
  }
+
+.finance-sort-header {
+     border: none;
+     background: transparent;
+     display: inline-flex;
+     align-items: center;
+     justify-content: flex-start;
+     gap: 6px;
+     width: 100%;
+     font-weight: 600;
+     color: #111827;
+     padding: 0;
+     cursor: pointer;
+}
+
+.finance-sort-header--end {
+     justify-content: flex-end;
+}
+
+.finance-sort-header.is-active {
+     color: #1d4ed8;
+}
+
+.finance-sort-indicator {
+     font-size: 0.75rem;
+     color: #64748b;
+}

--- a/react-app/src/components/finance/TransactionsList.css
+++ b/react-app/src/components/finance/TransactionsList.css
@@ -31,7 +31,7 @@
 .finance-table-shell {
      background: #fff;
      position: relative;
-     overflow-x: auto;
+     overflow-x: hidden;
  }
 
 .finance-empty {
@@ -47,7 +47,7 @@
 .finance-grid-header {
     display: grid;
     grid-template-columns: 1.1fr 1.3fr 1.8fr 1.05fr 1.7fr 0.95fr 1.25fr;
-    gap: 12px;
+    gap: 8px;
     padding: 10px 16px;
     background: #f8fafc;
     border-bottom: 1px solid #e5e7eb;
@@ -59,7 +59,7 @@
 .finance-row {
      display: grid;
      grid-template-columns: 1.1fr 1.3fr 1.8fr 1.05fr 1.7fr 0.95fr 1.25fr;
-     gap: 12px;
+     gap: 8px;
      align-items: center;
      padding: 14px 16px;
      border-bottom: 1px solid #edf1f5;
@@ -149,7 +149,7 @@
 .finance-actions {
      display: flex;
      flex-direction: row;
-     gap: 8px;
+     gap: 6px;
      align-items: flex-end;
      justify-content: flex-end;
      flex-wrap: nowrap;
@@ -159,7 +159,7 @@
      background: linear-gradient(90deg, #1d4ed8 0%, #2563eb 100%);
      border: none;
      color: #fff;
-     padding-inline: 12px;
+     padding-inline: 10px;
      white-space: nowrap;
  }
 
@@ -167,7 +167,7 @@
      background: #f8fafc;
      border: 1px solid #e5e7eb;
      color: #0f172a;
-     padding-inline: 12px;
+     padding-inline: 10px;
      white-space: nowrap;
  }
 

--- a/react-app/src/index.tsx
+++ b/react-app/src/index.tsx
@@ -35,6 +35,16 @@ if ('serviceWorker' in navigator) {
 installGlobalErrorHandlers();
 logger.info('global', 'BOB app booting...');
 
+// Keep deployment behavior deterministic: remove any stale service workers
+// so clients do not keep serving outdated bundles after hosting deploys.
+try {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations()
+      .then((registrations) => Promise.all(registrations.map((registration) => registration.unregister())))
+      .catch(() => {});
+  }
+} catch {}
+
 try {
   const params = new URLSearchParams(window.location.search);
   if (params.get('perf') === '1' || params.get('log') === '1') {


### PR DESCRIPTION
## Summary
- rebuild FinanceDashboardAdvanced into a multi-view finance intelligence hub (overview, spend analysis, cashflow+goals, optional spend, actions, data sources, assets/debts)
- add spend analysis filters and chart modes (trend/pie/breakdown) by bucket/category/merchant
- add budget health metrics and budget-vs-actual views
- add goal forecast ETA based on linked pot balance + recent contribution history
- add manual account tracking APIs/UI for assets, debts, and investments with stale (>30 days) indicators
- add all-history date range mode (since 2018)
- wire budget settings to monzoTransferPlan for dry-run simulation and live transfer execution
- improve merchant and transactions table UX (wider layout, sortable columns, action controls alignment)

## Backend
- new callable module: functions/finance/enhancements.js
- new exported callables:
  - importExternalFinanceTransactions
  - matchExternalToMonzoTransactions
  - recomputeDebtServiceBreakdown
  - generateFinanceActionInsights
  - convertFinanceActionToStory
  - upsertManualFinanceAccount
  - deleteManualFinanceAccount
  - fetchFinanceEnhancementData
- dashboard aggregation keeps user category precedence and transfer exclusion

## Validation
- node --check functions/finance/enhancements.js
- node --check functions/finance/dashboard.js
- node --check functions/index.js
- npm --prefix react-app run build (passes; existing repo-wide warnings remain)

## Deployment
- deployed to Firebase project: bob20250810
- deployed targets:
  - hosting
  - functions:fetchDashboardData
  - functions:importExternalFinanceTransactions
  - functions:matchExternalToMonzoTransactions
  - functions:recomputeDebtServiceBreakdown
  - functions:generateFinanceActionInsights
  - functions:convertFinanceActionToStory
  - functions:upsertManualFinanceAccount
  - functions:deleteManualFinanceAccount
  - functions:fetchFinanceEnhancementData

Hosting URL: https://bob20250810.web.app
