### PR TITLE
Mobile UX consistency, planner diagnostics, and calendar dedup

### DIFF
--- a/functions/calendarSync.js
+++ b/functions/calendarSync.js
@@ -11,9 +11,65 @@ const ALLOWED_ROUTINE_TYPES = new Set(['chore', 'routine', 'habit']);
 const TASK_TABLE_LIMIT = 12;
 const MAX_PRIVATE_TASK_REFS = 6;
 const GOOGLE_EVENT_COLORS_TTL_MS = 6 * 60 * 60 * 1000;
+const SYNC_LEASE_MS = 2 * 60 * 1000;
 
 let cachedGoogleEventColors = null;
 let cachedGoogleEventColorsAt = 0;
+
+function createSyncLeaseId(blockId, action) {
+  return `${action}-${blockId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function getCalendarSyncLeaseRef(blockId) {
+  return admin.firestore().collection('calendar_sync_leases').doc(String(blockId));
+}
+
+async function acquireCalendarSyncLease(blockId, uid, action) {
+  const leaseRef = getCalendarSyncLeaseRef(blockId);
+  const leaseId = createSyncLeaseId(blockId, action);
+  const now = Date.now();
+  const expiresAtMs = now + SYNC_LEASE_MS;
+  try {
+    await admin.firestore().runTransaction(async (tx) => {
+      const snap = await tx.get(leaseRef);
+      const data = snap.exists ? (snap.data() || {}) : {};
+      const currentLeaseId = String(data.leaseId || '').trim();
+      const currentExpiresAtMs = Number(data.expiresAtMs || 0);
+      if (currentLeaseId && currentExpiresAtMs > now) {
+        throw new Error('calendar_sync_lease_busy');
+      }
+      tx.set(leaseRef, {
+        blockId,
+        ownerUid: uid,
+        action,
+        leaseId,
+        acquiredAtMs: now,
+        expiresAtMs,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+    });
+    return { leaseId, leaseRef };
+  } catch (error) {
+    if (String(error?.message || '') === 'calendar_sync_lease_busy') return null;
+    throw error;
+  }
+}
+
+async function releaseCalendarSyncLease(blockId, leaseId) {
+  if (!blockId || !leaseId) return;
+  const leaseRef = getCalendarSyncLeaseRef(blockId);
+  try {
+    await admin.firestore().runTransaction(async (tx) => {
+      const snap = await tx.get(leaseRef);
+      if (!snap.exists) return;
+      const data = snap.data() || {};
+      if (String(data.leaseId || '') !== String(leaseId)) return;
+      tx.delete(leaseRef);
+    });
+  } catch (error) {
+    console.warn('[calendarSync] failed to release sync lease', blockId, error?.message || error);
+  }
+}
 
 // Legacy numeric theme index mapping (1-based order in DEFAULT_THEMES)
 const NUMERIC_THEME_MAP = {
@@ -691,6 +747,26 @@ async function findExistingEventByPrivateProp(calendar, { key, value, timeMin, t
   return events.find((ev) => ev && ev.id) || null;
 }
 
+function getBobPrivateProps(event) {
+  return event?.extendedProperties?.private || {};
+}
+
+function getBobBlockIdFromEvent(event) {
+  const priv = getBobPrivateProps(event);
+  return String(priv['bob-block-id'] || priv['bobBlockId'] || '').trim();
+}
+
+function isConfidentBobCreatedEvent(event) {
+  const priv = getBobPrivateProps(event);
+  return Boolean(
+    getBobBlockIdFromEvent(event)
+      || priv['bob-entity-type']
+      || priv['bob-story-id']
+      || priv['bob-task-id']
+      || priv['bob-deeplink']
+  );
+}
+
 function parseEventTime(timeObj) {
   if (!timeObj) return null;
   if (timeObj.dateTime) return new Date(timeObj.dateTime).getTime();
@@ -729,6 +805,7 @@ async function getActiveSprintId(uid) {
 async function syncBlockToGoogle(blockId, action, uid, blockData = null) {
   let block = blockData;
   let eventId = null;
+  let syncLease = null;
   const errorContext = {};
   const debugLogs = [];
   const testMode = !!process.env.CALENDAR_SYNC_TEST_MODE;
@@ -739,6 +816,32 @@ async function syncBlockToGoogle(blockId, action, uid, blockData = null) {
       const snap = await admin.firestore().collection('calendar_blocks').doc(blockId).get();
       if (!snap.exists) throw new Error('Block not found');
       block = snap.data();
+    }
+
+    if (action === 'create' || action === 'update') {
+      syncLease = await acquireCalendarSyncLease(blockId, uid, action);
+      if (!syncLease) {
+        debugLogs.push({ step: 'sync_skipped', reason: 'sync_lease_busy' });
+        await logCalendarIntegration(uid, {
+          action: 'push',
+          direction: action,
+          status: 'skipped',
+          blockId,
+          blockTitle: block?.title || null,
+          reason: 'sync_lease_busy',
+        });
+        return { skipped: true, reason: 'sync_lease_busy' };
+      }
+      const freshSnap = await admin.firestore().collection('calendar_blocks').doc(blockId).get();
+      if (!freshSnap.exists) {
+        debugLogs.push({ step: 'sync_skipped', reason: 'block_missing_after_lease' });
+        return { skipped: true, reason: 'block_missing_after_lease' };
+      }
+      block = freshSnap.data();
+      if (action === 'create' && block?.googleEventId) {
+        debugLogs.push({ step: 'sync_skipped', reason: 'google_event_already_linked', eventId: block.googleEventId });
+        return { skipped: true, reason: 'google_event_already_linked', eventId: block.googleEventId };
+      }
     }
 
     if (block && block.syncToGoogle === false && action !== 'delete') {
@@ -1651,8 +1754,133 @@ async function syncBlockToGoogle(blockId, action, uid, blockData = null) {
       debug: debugLogs,
     });
     throw err;
+  } finally {
+    if (syncLease?.leaseId) {
+      await releaseCalendarSyncLease(blockId, syncLease.leaseId);
+    }
   }
 }
+
+exports.repairDuplicateCalendarEvents = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'Must be authenticated');
+  }
+  const uid = context.auth.uid;
+  const dryRun = data?.dryRun !== false;
+  const lookbackDays = Math.max(1, Math.min(Number(data?.lookbackDays || 21), 180));
+  const forwardDays = Math.max(1, Math.min(Number(data?.forwardDays || 90), 365));
+  const now = Date.now();
+  const timeMin = new Date(now - (lookbackDays * MS_IN_DAY)).toISOString();
+  const timeMax = new Date(now + (forwardDays * MS_IN_DAY)).toISOString();
+
+  await logCalendarIntegration(uid, {
+    action: 'repair_duplicates',
+    status: 'started',
+    dryRun,
+    timeMin,
+    timeMax,
+  });
+
+  try {
+    const { calendar } = await getCalendarClientForUser(uid);
+    const events = await listAllEvents(calendar, { timeMin, timeMax });
+    const duplicateGroups = new Map();
+    events.forEach((event) => {
+      if (!isConfidentBobCreatedEvent(event)) return;
+      const blockId = getBobBlockIdFromEvent(event);
+      if (!blockId) return;
+      const list = duplicateGroups.get(blockId) || [];
+      list.push(event);
+      duplicateGroups.set(blockId, list);
+    });
+
+    let groupsFound = 0;
+    let eventsDeleted = 0;
+    let blocksRelinked = 0;
+    let skipped = 0;
+    const repairs = [];
+
+    for (const [blockId, group] of duplicateGroups.entries()) {
+      if (!Array.isArray(group) || group.length <= 1) continue;
+      groupsFound += 1;
+      const blockRef = admin.firestore().collection('calendar_blocks').doc(String(blockId));
+      const blockSnap = await blockRef.get().catch(() => null);
+      const block = blockSnap && blockSnap.exists ? (blockSnap.data() || {}) : null;
+      const linkedGoogleEventId = String(block?.googleEventId || '').trim();
+      const sortedGroup = [...group].sort((a, b) => {
+        const aUpdated = Date.parse(String(a?.updated || '')) || 0;
+        const bUpdated = Date.parse(String(b?.updated || '')) || 0;
+        return bUpdated - aUpdated;
+      });
+      const survivor = sortedGroup.find((event) => String(event?.id || '') === linkedGoogleEventId) || sortedGroup[0];
+      if (!survivor?.id) {
+        skipped += group.length;
+        continue;
+      }
+      const duplicates = sortedGroup.filter((event) => String(event?.id || '') !== String(survivor.id));
+      repairs.push({
+        blockId,
+        survivorEventId: survivor.id,
+        duplicateEventIds: duplicates.map((event) => event.id).filter(Boolean),
+      });
+
+      if (!dryRun && blockSnap && blockSnap.exists && linkedGoogleEventId !== String(survivor.id)) {
+        await blockRef.set({
+          googleEventId: survivor.id,
+          externalLink: survivor.htmlLink || block?.externalLink || admin.firestore.FieldValue.delete(),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        }, { merge: true });
+        blocksRelinked += 1;
+      } else if (dryRun && linkedGoogleEventId !== String(survivor.id)) {
+        blocksRelinked += 1;
+      }
+
+      for (const duplicate of duplicates) {
+        if (!duplicate?.id) {
+          skipped += 1;
+          continue;
+        }
+        if (!dryRun) {
+          await calendar.events.delete({ calendarId: 'primary', eventId: duplicate.id });
+        }
+        eventsDeleted += 1;
+      }
+    }
+
+    await logCalendarIntegration(uid, {
+      action: 'repair_duplicates',
+      status: 'success',
+      dryRun,
+      timeMin,
+      timeMax,
+      groupsFound,
+      eventsDeleted,
+      blocksRelinked,
+      skipped,
+      repairs: repairs.slice(0, 50),
+    });
+
+    return {
+      ok: true,
+      dryRun,
+      groupsFound,
+      eventsDeleted,
+      blocksRelinked,
+      skipped,
+      repairs,
+    };
+  } catch (error) {
+    await logCalendarIntegration(uid, {
+      action: 'repair_duplicates',
+      status: 'error',
+      dryRun,
+      timeMin,
+      timeMax,
+      error: error?.message || String(error),
+    });
+    throw new functions.https.HttpsError('internal', error?.message || 'Failed to repair duplicate calendar events');
+  }
+});
 
 exports._syncBlockToGoogle = syncBlockToGoogle;
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -94,11 +94,11 @@ try {
   if (calendarSync) {
     exports.syncCalendarBlock = calendarSync.syncCalendarBlock;
     exports.onCalendarBlockWrite = calendarSync.onCalendarBlockWrite;
-    exports.onStoryCalendarAutoLink = calendarSync.onStoryCalendarAutoLink;
     exports.syncFromGoogleCalendar = calendarSync.syncFromGoogleCalendar;
     exports.syncCalendarNow = calendarSync.syncCalendarNow;
     exports.scheduledCalendarSync = calendarSync.scheduledCalendarSync;
     exports.gcalLinkUnlinkedEvents = calendarSync.gcalLinkUnlinkedEvents;
+    exports.repairDuplicateCalendarEvents = calendarSync.repairDuplicateCalendarEvents;
   }
 } catch (e) {
   console.warn('[init] calendarSync not loaded', e?.message || e);
@@ -253,9 +253,6 @@ try {
     if (nightlyOrchestration.deltaPriorityRescore) {
       exports.deltaPriorityRescore = nightlyOrchestration.deltaPriorityRescore;
     }
-    if (nightlyOrchestration.applyEveningPullForward) {
-      exports.applyEveningPullForward = nightlyOrchestration.applyEveningPullForward;
-    }
   }
 } catch (e) {
   console.warn('[init] nightlyOrchestration not loaded', e?.message || e);
@@ -293,221 +290,10 @@ exports.updateGoalTargetYears = schedulerV2.onSchedule(
   });
 
 // Nightly fitness KPI sync: updates goal KPI progress from Strava/HealthKit workouts
-const buildWeeklySnapshotKey = (dt) => {
-  const resolved = DateTime.isDateTime(dt) ? dt : DateTime.fromJSDate(new Date(dt || Date.now()));
-  return `${resolved.weekYear}-W${String(resolved.weekNumber).padStart(2, '0')}`;
-};
-
-const parseWeeklySnapshotKey = (weekKey, zone = DEFAULT_TIMEZONE) => {
-  const match = /^(\d{4})-W(\d{2})$/.exec(String(weekKey || '').trim());
-  if (!match) return null;
-  const weekYear = Number(match[1]);
-  const weekNumber = Number(match[2]);
-  if (!Number.isFinite(weekYear) || !Number.isFinite(weekNumber)) return null;
-  const dt = DateTime.fromObject({ weekYear, weekNumber, weekday: 1 }, { zone });
-  return dt.isValid ? dt.startOf('day') : null;
-};
-
-const buildBackfilledResolvedKpis = (leafSummary = {}) => {
-  const topKpis = Array.isArray(leafSummary?.topKpis) ? leafSummary.topKpis : [];
-  return topKpis.map((kpi, index) => {
-    const progressPct = Number(kpi?.progressPct);
-    const healthy = kpi?.healthy === true;
-    return {
-      index,
-      id: String(kpi?.id || `${leafSummary.goalId || 'goal'}_${index}`),
-      name: String(kpi?.name || `KPI ${index + 1}`),
-      currentDisplay: kpi?.currentDisplay ?? null,
-      progressPct: Number.isFinite(progressPct) ? progressPct : null,
-      healthy,
-      stale: !healthy,
-      backfilled: true,
-      source: 'weekly_checkin_focus_summary',
-      snapshotQuality: 'summary_only',
-    };
-  });
-};
-
-const snapshotGoalKpiMetricsForUser = async (uid, { reason = 'manual', now = null } = {}) => {
-  const db = admin.firestore();
-  const profile = await loadProfile(db, uid).catch(() => ({ id: uid }));
-  const zone = resolveTimezone(profile, DEFAULT_TIMEZONE);
-  const snapshotDt = (DateTime.isDateTime(now)
-    ? now
-    : now
-      ? DateTime.fromJSDate(new Date(now))
-      : DateTime.now()).setZone(zone);
-  const weekKey = buildWeeklySnapshotKey(snapshotDt);
-  const metricsSnap = await db.collection('goal_kpi_metrics').where('ownerUid', '==', uid).get();
-  if (metricsSnap.empty) {
-    return { uid, zone, weekKey, snapshotCount: 0 };
-  }
-
-  let batch = db.batch();
-  let pendingWrites = 0;
-  let snapshotCount = 0;
-  const commitBatch = async () => {
-    if (pendingWrites === 0) return;
-    await batch.commit();
-    batch = db.batch();
-    pendingWrites = 0;
-  };
-
-  for (const docSnap of metricsSnap.docs) {
-    const data = docSnap.data() || {};
-    const goalId = String(data.goalId || '').trim();
-    if (!goalId) continue;
-    const snapshotRef = db.collection('weekly_goal_kpi_snapshots').doc(`${uid}_${weekKey}_${goalId}`);
-    batch.set(snapshotRef, {
-      ownerUid: uid,
-      goalId,
-      goalRef: data.goalRef || null,
-      goalTitle: data.goalTitle || null,
-      resolvedKpis: Array.isArray(data.resolvedKpis) ? data.resolvedKpis : [],
-      weekKey,
-      snapshotType: 'weekly',
-      snapshotReason: reason,
-      snapshotTimeZone: zone,
-      sourceUpdatedAt: data.updatedAt || null,
-      snapshotAt: admin.firestore.FieldValue.serverTimestamp(),
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    }, { merge: true });
-    pendingWrites += 1;
-    snapshotCount += 1;
-    if (pendingWrites >= 400) {
-      await commitBatch();
-    }
-  }
-
-  await commitBatch();
-  return { uid, zone, weekKey, snapshotCount };
-};
-
-const backfillWeeklyGoalKpiSnapshotsForUser = async (uid, { maxWeeks = 26, overwrite = false } = {}) => {
-  const db = admin.firestore();
-  const profile = await loadProfile(db, uid).catch(() => ({ id: uid }));
-  const zone = resolveTimezone(profile, DEFAULT_TIMEZONE);
-  const boundedMaxWeeks = Math.max(1, Math.min(Number(maxWeeks) || 26, 104));
-
-  const [weeklyCheckinsSnap, existingSnapshotsSnap] = await Promise.all([
-    db.collection('weekly_checkins').where('ownerUid', '==', uid).get(),
-    db.collection('weekly_goal_kpi_snapshots').where('ownerUid', '==', uid).get(),
-  ]);
-
-  const existingSnapshotIds = new Set(existingSnapshotsSnap.docs.map((docSnap) => docSnap.id));
-  const candidateWeeks = weeklyCheckinsSnap.docs
-    .map((docSnap) => {
-      const data = docSnap.data() || {};
-      const weekKey = String(data.weekKey || '').trim();
-      const weekDt = parseWeeklySnapshotKey(weekKey, zone);
-      const focusSummary = data?.metrics?.focusSummary || null;
-      const leafGoals = Array.isArray(focusSummary?.leafGoals) ? focusSummary.leafGoals : [];
-      return {
-        id: docSnap.id,
-        weekKey,
-        weekDt,
-        updatedAt: data.updatedAt || data.createdAt || null,
-        leafGoals,
-      };
-    })
-    .filter((entry) => entry.weekDt && entry.leafGoals.length > 0)
-    .sort((a, b) => b.weekDt.toMillis() - a.weekDt.toMillis())
-    .slice(0, boundedMaxWeeks);
-
-  let batch = db.batch();
-  let pendingWrites = 0;
-  let snapshotsWritten = 0;
-  let snapshotsSkipped = 0;
-
-  const commitBatch = async () => {
-    if (pendingWrites === 0) return;
-    await batch.commit();
-    batch = db.batch();
-    pendingWrites = 0;
-  };
-
-  for (const weekly of candidateWeeks) {
-    for (const leafGoal of weekly.leafGoals) {
-      const goalId = String(leafGoal?.goalId || '').trim();
-      if (!goalId) continue;
-      const snapshotId = `${uid}_${weekly.weekKey}_${goalId}`;
-      if (!overwrite && existingSnapshotIds.has(snapshotId)) {
-        snapshotsSkipped += 1;
-        continue;
-      }
-      const snapshotRef = db.collection('weekly_goal_kpi_snapshots').doc(snapshotId);
-      batch.set(snapshotRef, {
-        ownerUid: uid,
-        goalId,
-        goalRef: null,
-        goalTitle: leafGoal?.title || null,
-        resolvedKpis: buildBackfilledResolvedKpis(leafGoal),
-        weekKey: weekly.weekKey,
-        snapshotType: 'weekly',
-        snapshotReason: 'backfillWeeklyGoalKpiSnapshots',
-        snapshotTimeZone: zone,
-        sourceUpdatedAt: weekly.updatedAt || null,
-        snapshotAt: admin.firestore.FieldValue.serverTimestamp(),
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        backfilled: true,
-        snapshotQuality: 'summary_only',
-        backfilledFromWeeklyCheckinId: weekly.id,
-        totalKpis: Number(leafGoal?.totalKpis || 0) || 0,
-        healthyKpis: Number(leafGoal?.healthyKpis || 0) || 0,
-        staleKpis: Number(leafGoal?.staleKpis || 0) || 0,
-      }, { merge: true });
-      existingSnapshotIds.add(snapshotId);
-      snapshotsWritten += 1;
-      pendingWrites += 1;
-      if (pendingWrites >= 400) {
-        await commitBatch();
-      }
-    }
-  }
-
-  await commitBatch();
-  const currentWeekSnapshot = await snapshotGoalKpiMetricsForUser(uid, { reason: 'backfillWeeklyGoalKpiSnapshots_current' });
-
-  return {
-    uid,
-    zone,
-    weeksScanned: candidateWeeks.length,
-    snapshotsWritten,
-    snapshotsSkipped,
-    currentWeekSnapshotsWritten: Number(currentWeekSnapshot?.snapshotCount || 0),
-    currentWeekKey: currentWeekSnapshot?.weekKey || buildWeeklySnapshotKey(DateTime.now().setZone(zone)),
-  };
-};
-
 const syncFitnessKpis = async () => {
   try {
-    const [fitnessResult, usersSnap] = await Promise.all([
-      syncAllUsersFitnessKpis(),
-      admin.firestore().collection('profiles').get(),
-    ]);
-
-    let metricsDocsUpdated = 0;
-    let weeklySnapshotsUpdated = 0;
-    for (const userDoc of usersSnap.docs) {
-      const uid = String(userDoc.id || '').trim();
-      if (!uid) continue;
-      const rows = await computeGoalFitnessKpisForUser(uid, { persist: true });
-      metricsDocsUpdated += Array.isArray(rows) ? rows.length : 0;
-      const snapshotResult = await snapshotGoalKpiMetricsForUser(uid, { reason: 'syncFitnessKpisNightly' });
-      weeklySnapshotsUpdated += Number(snapshotResult?.snapshotCount || 0);
-    }
-
-    const result = {
-      ...fitnessResult,
-      metricsDocsUpdated,
-      weeklySnapshotsUpdated,
-    };
-
-    console.log(
-      `✅ Fitness KPI sync completed: ${result.totalSynced} goals updated, ` +
-      `${metricsDocsUpdated} goal_kpi_metrics docs refreshed, ` +
-      `${weeklySnapshotsUpdated} weekly KPI snapshots written`
-    );
+    const result = await syncAllUsersFitnessKpis();
+    console.log(`✅ Fitness KPI sync completed: ${result.totalSynced} goals updated`);
     return result;
   } catch (e) {
     console.error('[fitnessKpiSync] failed', e?.message || e);
@@ -527,36 +313,11 @@ exports.syncFitnessKpisNow = httpsV2.onCall({ region: 'europe-west2' }, async (r
     throw new httpsV2.HttpsError('unauthenticated', 'Sign in required');
   }
   try {
-    const [result, metricsRows] = await Promise.all([
-      syncUserFitnessKpis(uid),
-      computeGoalFitnessKpisForUser(uid, { persist: true }),
-    ]);
-    const snapshotResult = await snapshotGoalKpiMetricsForUser(uid, { reason: 'syncFitnessKpisNow' });
-    return {
-      ok: true,
-      ...result,
-      metricsDocsUpdated: Array.isArray(metricsRows) ? metricsRows.length : 0,
-      weeklySnapshotsUpdated: Number(snapshotResult?.snapshotCount || 0),
-    };
+    const result = await syncUserFitnessKpis(uid);
+    return { ok: true, ...result };
   } catch (e) {
     console.error('[fitnessKpiSync] user sync failed:', e);
     throw new httpsV2.HttpsError('internal', e?.message || 'Sync failed');
-  }
-});
-
-exports.backfillWeeklyGoalKpiSnapshots = httpsV2.onCall({ region: 'europe-west2' }, async (req) => {
-  const uid = req?.auth?.uid;
-  if (!uid) {
-    throw new httpsV2.HttpsError('unauthenticated', 'Sign in required');
-  }
-  const maxWeeks = Math.max(1, Math.min(Number(req?.data?.maxWeeks) || 26, 104));
-  const overwrite = req?.data?.overwrite === true;
-  try {
-    const result = await backfillWeeklyGoalKpiSnapshotsForUser(uid, { maxWeeks, overwrite });
-    return { ok: true, ...result };
-  } catch (e) {
-    console.error('[weekly-kpi-backfill] failed', { uid, maxWeeks, overwrite, error: e });
-    throw new httpsV2.HttpsError('internal', e?.message || 'Weekly KPI snapshot backfill failed');
   }
 });
 
@@ -902,36 +663,6 @@ function applyTimeOfDay(day, timeMs) {
   return d.getTime();
 }
 
-const CHORE_TIMEZONE = 'Europe/London';
-
-function extractZoneHourMinute(ms, timeZone = CHORE_TIMEZONE) {
-  const d = new Date(ms);
-  const parts = new Intl.DateTimeFormat('en-GB', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-    timeZone,
-  }).formatToParts(d);
-  const hour = Number(parts.find((p) => p.type === 'hour')?.value || '0');
-  const minute = Number(parts.find((p) => p.type === 'minute')?.value || '0');
-  return { hour, minute };
-}
-
-function formatDueTime(ms) {
-  const { hour, minute } = extractZoneHourMinute(ms);
-  const hh = String(hour).padStart(2, '0');
-  const mm = String(minute).padStart(2, '0');
-  return `${hh}:${mm}`;
-}
-
-function classifyTimeOfDay(ms) {
-  const { hour, minute } = extractZoneHourMinute(ms);
-  const minutes = hour * 60 + minute;
-  if (minutes >= (5 * 60) && minutes < (12 * 60)) return 'morning';
-  if (minutes >= (12 * 60) && minutes < (17 * 60)) return 'afternoon';
-  return 'evening';
-}
-
 function durationMinutesFromTask(task) {
   const points = Number(task?.points || 0);
   const estimateMin = Number(task?.estimateMin || 0);
@@ -995,7 +726,7 @@ async function findSlotForDay(db, ownerUid, dayStartMs, dayEndMs, durationMs) {
   return null;
 }
 
-async function upsertChoreBlocksForTask(db, task, lookaheadDays = 28) {
+async function upsertChoreBlocksForTask(db, task, lookaheadDays = 14) {
   if (!task?.ownerUid || !task?.id) return { created: 0, updated: 0 };
   const ownerUid = task.ownerUid;
   const today = startOfDay(new Date());
@@ -1064,50 +795,6 @@ async function upsertChoreBlocksForTask(db, task, lookaheadDays = 28) {
     }
     return null;
   };
-
-  const findSlotFromDay = async (startDay, existingDocId = null, preferredMs = null) => {
-    for (const candidateDay of iterateNextDays(startDay, lookaheadDays)) {
-      const candidateStartMs = startOfDay(candidateDay).getTime();
-      if (snoozedUntil && candidateStartMs < startOfDay(new Date(snoozedUntil)).getTime()) continue;
-      const candidateKey = toDayKey(candidateDay);
-      const candidateDayStartMs = candidateStartMs;
-      const candidateDayEndMs = candidateDayStartMs + (24 * 60 * 60 * 1000) - 1;
-      const candidateCtx = await loadDayCtx(candidateDayStartMs, candidateDayEndMs, candidateKey);
-      if (!candidateCtx.windows.length) continue;
-      const occupiedWithoutSelf = candidateCtx.occupied.filter((o) => o.id !== existingDocId);
-
-      if (preferredMs && startOfDay(new Date(preferredMs)).getTime() === candidateDayStartMs) {
-        const preferredEnd = preferredMs + durationMs;
-        if (
-          fitsInWindows(preferredMs, preferredEnd, candidateCtx.windows) &&
-          !overlapsAny(preferredMs, preferredEnd, occupiedWithoutSelf)
-        ) {
-          return {
-            startMs: preferredMs,
-            endMs: preferredEnd,
-            dayCtx: candidateCtx,
-            dayKey: candidateKey,
-            day: candidateDay,
-            occupiedWithoutSelf,
-          };
-        }
-      }
-
-      const slot = findSlotInWindows(candidateCtx.windows, occupiedWithoutSelf, durationMs);
-      if (slot != null) {
-        return {
-          startMs: slot,
-          endMs: slot + durationMs,
-          dayCtx: candidateCtx,
-          dayKey: candidateKey,
-          day: candidateDay,
-          occupiedWithoutSelf,
-        };
-      }
-    }
-    return null;
-  };
-
   for (const day of iterateNextDays(today, lookaheadDays)) {
     if (snoozedUntil && day.getTime() < startOfDay(new Date(snoozedUntil)).getTime()) continue;
     if (!shouldScheduleOnDay(task, day)) continue;
@@ -1155,23 +842,15 @@ async function upsertChoreBlocksForTask(db, task, lookaheadDays = 28) {
 
     if (startMs == null) {
       const slot = findSlotInWindows(dayCtx.windows, occupiedWithoutSelf, durationMs);
-      if (slot != null) {
-        startMs = slot;
-        endMs = slot + durationMs;
-      }
-    }
-
-    if (startMs == null) {
-      const fallback = await findSlotFromDay(day, docId, taskDueMs && dueHasTime ? applyTimeOfDay(day, taskDueMs) : null);
-      if (!fallback) {
+      if (!slot) {
         if (snap.exists) {
           await ref.delete();
           dayCtx.occupied = occupiedWithoutSelf;
         }
         continue;
       }
-      startMs = fallback.startMs;
-      endMs = fallback.endMs;
+      startMs = slot;
+      endMs = slot + durationMs;
     }
 
     if (startMs >= nowMs && (nextStartMs == null || startMs < nextStartMs)) {
@@ -1218,23 +897,16 @@ async function upsertChoreBlocksForTask(db, task, lookaheadDays = 28) {
 
   if (nextStartMs && isRecurringChoreTask(task) && !isTaskLocked(task)) {
     const dueMs = toMillis(task?.dueDate || task?.dueDateMs || task?.targetDate);
-    const nextDueTime = formatDueTime(nextStartMs);
-    const nextTimeOfDay = classifyTimeOfDay(nextStartMs);
-    const currentDueTime = String(task?.dueTime || '').trim();
-    const currentTimeOfDay = String(task?.timeOfDay || '').trim().toLowerCase();
     const isMissing = !dueMs;
     const isOverdueBeyondGrace = !!dueMs && dueMs < (nowMs - CHORE_DUE_ROLLOVER_MS);
     const isFutureMismatch = !!dueMs && dueMs >= nowMs && Math.abs(dueMs - nextStartMs) > (5 * MS_IN_MINUTE);
-    const isTimeMismatch = currentDueTime !== nextDueTime || currentTimeOfDay !== nextTimeOfDay;
-    if (isMissing || isOverdueBeyondGrace || isFutureMismatch || isTimeMismatch) {
+    if (isMissing || isOverdueBeyondGrace || isFutureMismatch) {
       const hasStory = !!(task?.storyId || (task?.parentType === 'story' && task?.parentId));
       const sprintId = hasStory
         ? (task?.sprintId || null)
         : await resolveSprintIdForDate(db, ownerUid, task?.persona || null, nextStartMs, sprintCache);
       await db.collection('tasks').doc(task.id).set({
         dueDate: nextStartMs,
-        dueTime: nextDueTime,
-        timeOfDay: nextTimeOfDay,
         sprintId: sprintId ?? null,
         dueDateReason: isOverdueBeyondGrace ? 'chore_rollover' : 'chore_block',
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -2984,7 +2656,6 @@ exports.priorityNow = httpsV2.onRequest({ invoker: 'public', secrets: [GOOGLE_AI
       await recordAiLog(uid, 'priority_now_trace', 'success', 'Priority now response generated', {
         ...priorityTraceBase,
         parseStatus: llmText ? 'ok' : 'ok_empty',
-        rawOutput: String(llmText || '').slice(0, 12000),
         rawOutputText: String(llmText || '').slice(0, 12000),
         rawOutputLength: String(llmText || '').length,
         latencyMs: Date.now() - priorityStartedAtMs,
@@ -2996,7 +2667,6 @@ exports.priorityNow = httpsV2.onRequest({ invoker: 'public', secrets: [GOOGLE_AI
       await recordAiLog(uid, 'priority_now_trace', 'warning', 'Priority now LLM parse/runtime failure', {
         ...priorityTraceBase,
         parseStatus: 'failed',
-        rawOutput: String(llmText || '').slice(0, 12000),
         rawOutputText: String(llmText || '').slice(0, 12000),
         rawOutputLength: String(llmText || '').length,
         error: String(error?.message || error || 'unknown'),
@@ -11024,7 +10694,7 @@ exports.suggestTaskStoryConversions = httpsV2.onCall({ secrets: [GOOGLE_AI_STUDI
   };
 });
 
-exports.monzoGoalPotRefLinker = schedulerV2.onSchedule('every 12 hours', async () => {
+exports.monzoGoalPotRefLinker = schedulerV2.onSchedule('every 30 minutes', async () => {
   const db = admin.firestore();
   const tokens = await db.collection('tokens').where('provider', '==', 'monzo').get();
   let usersChecked = 0;
@@ -11069,134 +10739,6 @@ exports.monzoGoalPotRefLinker = schedulerV2.onSchedule('every 12 hours', async (
     totalLinked,
     totalTimedOut,
     totalPending,
-  };
-});
-
-function normalizeSprintFocusGoalIds(value) {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((goalId) => String(goalId || '').trim())
-    .filter((goalId) => !!goalId);
-}
-
-function normalizeAlignmentMode(value) {
-  const normalized = String(value || 'warn').trim().toLowerCase();
-  return normalized === 'strict' ? 'strict' : 'warn';
-}
-
-exports.enforceSprintFocusAlignment = firestoreV2.onDocumentWritten('stories/{storyId}', async (event) => {
-  const afterSnap = event.data?.after;
-  if (!afterSnap?.exists) return;
-
-  const storyId = String(event.params?.storyId || '').trim();
-  const story = afterSnap.data() || {};
-  const sprintId = String(story.sprintId || '').trim();
-  if (!sprintId) return;
-
-  const ownerUid = String(story.ownerUid || '').trim();
-  if (!ownerUid) return;
-
-  const db = admin.firestore();
-  const sprintSnap = await db.collection('sprints').doc(sprintId).get();
-  if (!sprintSnap.exists) return;
-
-  const sprint = sprintSnap.data() || {};
-  const mode = normalizeAlignmentMode(sprint.alignmentMode);
-  if (mode !== 'strict') return;
-
-  const focusGoalIds = normalizeSprintFocusGoalIds(sprint.focusGoalIds);
-  if (!focusGoalIds.length) return;
-
-  const goalId = String(story.goalId || '').trim();
-  const aligned = !!goalId && focusGoalIds.includes(goalId);
-  if (aligned) return;
-
-  await afterSnap.ref.set({
-    sprintId: null,
-    sprintAlignmentViolation: {
-      sprintId,
-      alignmentMode: 'strict',
-      reason: 'goal_not_in_sprint_focus_goals',
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    },
-    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-  }, { merge: true });
-
-  await db.collection('integration_logs').add({
-    integration: 'sprint_alignment',
-    type: 'strict_enforcement',
-    status: 'blocked',
-    userId: ownerUid,
-    storyId,
-    sprintId,
-    goalId: goalId || null,
-    reason: 'goal_not_in_sprint_focus_goals',
-    timestamp: admin.firestore.FieldValue.serverTimestamp(),
-  });
-});
-
-exports.sprintAlignmentAuditNightly = schedulerV2.onSchedule('every day 03:10', async () => {
-  const db = admin.firestore();
-  const activeSprintSnap = await db.collection('sprints').where('status', '==', 1).get();
-  let sprintsChecked = 0;
-  let sprintsWithRules = 0;
-  let totalUnaligned = 0;
-
-  for (const sprintDoc of activeSprintSnap.docs) {
-    const sprint = sprintDoc.data() || {};
-    const focusGoalIds = normalizeSprintFocusGoalIds(sprint.focusGoalIds);
-    if (!focusGoalIds.length) continue;
-
-    sprintsChecked += 1;
-    sprintsWithRules += 1;
-    const focusGoalSet = new Set(focusGoalIds);
-    const ownerUid = String(sprint.ownerUid || '').trim();
-    const persona = String(sprint.persona || 'personal');
-
-    if (!ownerUid) continue;
-
-    const storiesSnap = await db.collection('stories')
-      .where('ownerUid', '==', ownerUid)
-      .where('persona', '==', persona)
-      .where('sprintId', '==', sprintDoc.id)
-      .get();
-
-    const totalStories = storiesSnap.size;
-    const unalignedStories = storiesSnap.docs.filter((docSnap) => {
-      const row = docSnap.data() || {};
-      const goalId = String(row.goalId || '').trim();
-      return !goalId || !focusGoalSet.has(goalId);
-    }).length;
-    totalUnaligned += unalignedStories;
-
-    await db.collection('sprint_alignment_audit').doc(`${ownerUid}_${sprintDoc.id}`).set({
-      ownerUid,
-      sprintId: sprintDoc.id,
-      sprintName: sprint.name || sprint.ref || sprintDoc.id,
-      persona,
-      alignmentMode: normalizeAlignmentMode(sprint.alignmentMode),
-      focusGoalIds,
-      totalStories,
-      unalignedStories,
-      alignedStories: Math.max(totalStories - unalignedStories, 0),
-      alignmentPct: totalStories > 0
-        ? Math.max(0, Math.round(((totalStories - unalignedStories) / totalStories) * 100))
-        : 100,
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    }, { merge: true });
-  }
-
-  console.log('[sprintAlignmentAuditNightly] complete', {
-    sprintsChecked,
-    sprintsWithRules,
-    totalUnaligned,
-  });
-
-  return {
-    ok: true,
-    sprintsChecked,
-    sprintsWithRules,
-    totalUnaligned,
   };
 });
 
@@ -12146,20 +11688,6 @@ async function buildDailySummaryAiFocus({ summaryData, userId }) {
         timezone: zone,
         activeWorkContext: context,
         calendarContext,
-        healthContext: {
-          source: ['authorized', 'synced'].includes(String(summaryData?.profile?.healthkitStatus || '').toLowerCase()) ? 'healthkit' : 'manual',
-          stepsToday: Number(summaryData?.profile?.healthkitStepsToday ?? summaryData?.profile?.manualStepsToday ?? 0) || null,
-          workoutMinutesToday: Number(summaryData?.profile?.healthkitWorkoutMinutesToday ?? summaryData?.profile?.manualWorkoutMinutesToday ?? 0) || null,
-          bodyFatPct: Number(summaryData?.profile?.healthkitBodyFatPct ?? summaryData?.profile?.manualBodyFatPct ?? 0) || null,
-          macroTargetsPresent: !!(
-            summaryData?.profile?.targetProteinG
-            || summaryData?.profile?.dailyProteinTargetG
-            || summaryData?.profile?.healthTargetProteinG
-            || summaryData?.profile?.targetCaloriesKcal
-            || summaryData?.profile?.dailyCaloriesTargetKcal
-            || summaryData?.profile?.healthTargetCaloriesKcal
-          ),
-        },
       },
     };
 
@@ -12180,7 +11708,6 @@ async function buildDailySummaryAiFocus({ summaryData, userId }) {
       await recordAiLog(userId, 'daily_summary_focus_trace', 'warning', 'Daily summary focus parse failure', {
         ...llmTraceBase,
         parseStatus: 'failed',
-        rawOutput: String(raw || '').slice(0, 12000),
         rawOutputText: String(raw || '').slice(0, 12000),
         rawOutputLength: String(raw || '').length,
         parseError: String(error?.message || error || 'unknown'),
@@ -12250,7 +11777,6 @@ async function buildDailySummaryAiFocus({ summaryData, userId }) {
       await recordAiLog(userId, 'daily_summary_focus_trace', 'warning', 'Daily summary focus returned no actionable items', {
         ...llmTraceBase,
         parseStatus: 'ok_empty',
-        rawOutput: String(raw || '').slice(0, 12000),
         rawOutputText: String(raw || '').slice(0, 12000),
         rawOutputLength: String(raw || '').length,
         latencyMs: Date.now() - startedAtMs,
@@ -12273,7 +11799,6 @@ async function buildDailySummaryAiFocus({ summaryData, userId }) {
     await recordAiLog(userId, 'daily_summary_focus_trace', 'success', 'Daily summary focus generated', {
       ...llmTraceBase,
       parseStatus: 'ok',
-      rawOutput: String(raw || '').slice(0, 12000),
       rawOutputText: String(raw || '').slice(0, 12000),
       rawOutputLength: String(raw || '').length,
       resultItemCount: result.items.length,
@@ -12573,13 +12098,13 @@ function assembleDailyChecklist(summaryData) {
       await ref.set(patch, { merge: true });
     }
 
-    // Materialize chore/routine calendar blocks for next 28 days (active only)
+    // Materialize chore/routine calendar blocks for next 14 days (active only)
     const type = effectiveType;
     const effectiveStatus = Number(patch?.status ?? afterStatus);
     const active = Number(effectiveStatus) !== 2;
     if (isChoreLike && active) {
       const task = { id, ...(after || {}), ...(patch || {}) };
-      await upsertChoreBlocksForTask(db, task, 28);
+      await upsertChoreBlocksForTask(db, task, 14);
     }
 
     // If just completed, mark nearest block done and update lastDoneAt
@@ -12707,7 +12232,7 @@ function assembleDailyChecklist(summaryData) {
       const snap = await db.collection('tasks').where('type', '==', t).where('status', '==', 0).get();
       for (const doc of snap.docs) {
         scanned++;
-        const res = await upsertChoreBlocksForTask(db, { id: doc.id, ...(doc.data() || {}) }, 28);
+        const res = await upsertChoreBlocksForTask(db, { id: doc.id, ...(doc.data() || {}) }, 14);
         created += res.created; updated += res.updated;
       }
     }
@@ -17387,15 +16912,6 @@ exports.onStoryDueDateAutoSprint = functionsV2.firestore.onDocumentUpdated("stor
   if (!ownerUid) return;
   const persona = afterData.persona || beforeData.persona || null;
   const db = admin.firestore();
-  const profileSnap = await db.collection('profiles').doc(ownerUid).get().catch(() => null);
-  const profile = profileSnap && profileSnap.exists ? (profileSnap.data() || {}) : {};
-  // Safety guard: due-date based sprint mapping is opt-in only.
-  if (profile.autoMapStorySprintFromDueDate !== true) return;
-
-  // Never overwrite an existing sprint from due-date churn.
-  const currentSprintId = afterData.sprintId || null;
-  if (currentSprintId && afterDue) return;
-
   const sprintId = afterDue
     ? await resolveSprintIdForDate(db, ownerUid, persona, afterDue, new Map())
     : null;
@@ -18163,30 +17679,10 @@ async function recordAiLog(uid, event, status, message, metadata = {}) {
     const level = status === 'error' ? 'error' : (status === 'warning' ? 'warning' : 'info');
     const expiresAt = createExpiryTimestamp();
     const now = admin.firestore.FieldValue.serverTimestamp();
-    const randomSuffix = Math.random().toString(36).slice(2, 8);
-    const traceIdRaw = metadata.traceId || metadata.trace_id || metadata.correlationId || metadata.correlation_id;
-    const traceId = String(traceIdRaw || `${String(event || 'ai_event')}_${Date.now()}_${randomSuffix}`).trim();
-    const promptTemplateId = String(metadata.promptTemplateId || metadata.templateId || metadata.template || '').trim() || null;
-    const parseStatus = String(metadata.parseStatus || (status === 'error' ? 'runtime_error' : 'ok')).trim().toLowerCase() || null;
-    const latencyRaw = Number(metadata.latencyMs ?? metadata.durationMs ?? metadata.latency ?? NaN);
-    const latencyMs = Number.isFinite(latencyRaw) && latencyRaw >= 0 ? Math.round(latencyRaw) : null;
-    const tokenRaw = Number(metadata.tokenCount ?? metadata.tokens ?? metadata.totalTokens ?? NaN);
-    const tokenCount = Number.isFinite(tokenRaw) && tokenRaw >= 0 ? Math.round(tokenRaw) : null;
-    const promptText = metadata.promptText || metadata.prompt || null;
-    const inputPayload = metadata.inputPayload || metadata.input || null;
-    const rawOutput = metadata.rawOutput || metadata.output || null;
     await ref.set({
       id: ref.id,
       ownerUid: uid,
       event,
-      traceId,
-      promptTemplateId,
-      parseStatus,
-      latencyMs,
-      tokenCount,
-      prompt: promptText,
-      input: inputPayload,
-      output: rawOutput,
       status,
       level,
       message,
@@ -19825,7 +19321,6 @@ async function buildFinanceCommentary({ summary, userId, windowLabel }) {
       await recordAiLog(userId, 'finance_commentary_trace', 'warning', 'Finance commentary returned empty output', {
         ...llmTraceBase,
         parseStatus: 'ok_empty',
-        rawOutput: '',
         rawOutputText: '',
         rawOutputLength: 0,
         latencyMs: Date.now() - startedAtMs,
@@ -19837,7 +19332,6 @@ async function buildFinanceCommentary({ summary, userId, windowLabel }) {
     await recordAiLog(userId, 'finance_commentary_trace', 'success', 'Finance commentary generated', {
       ...llmTraceBase,
       parseStatus: 'ok',
-      rawOutput: String(text).slice(0, 12000),
       rawOutputText: String(text).slice(0, 12000),
       rawOutputLength: String(text).length,
       outputLength: normalised.length,

--- a/functions/nightlyOrchestration.js
+++ b/functions/nightlyOrchestration.js
@@ -25,6 +25,15 @@ const {
   groupTasksByStory,
   writeScheduledTimesToSources,
 } = require('./scheduler/syncToFirestore');
+const {
+  buildDayLoadPointsMap,
+  nextWeekendDateByCapacity,
+  inferItemPoints,
+  deriveSprintCapacityPoints,
+} = require('./services/capacityService');
+const {
+  schedulePlannerItemMutation,
+} = require('./services/schedulingService');
 
 // Secrets
 const GOOGLE_AI_STUDIO_API_KEY = defineSecret('GOOGLEAISTUDIOAPIKEY');
@@ -572,6 +581,12 @@ function normalizeUserPriority(value) {
   return null;
 }
 
+function getManualPriorityRank(value) {
+  const explicit = Number(value?.userPriorityRank);
+  if (explicit === 1 || explicit === 2 || explicit === 3) return explicit;
+  return value?.userPriorityFlag === true ? 1 : null;
+}
+
 function priorityBoostFor(level) {
   switch (level) {
     case 'critical':
@@ -850,7 +865,7 @@ async function collectStoryTop3CandidateDocs(db, ownerUid, pageSize = 400) {
 
 function storyForcesTop3Tasks(storyData) {
   if (!storyData) return false;
-  if (storyData.userPriorityFlag === true) return true;
+  if (getManualPriorityRank(storyData)) return true;
   const level = normalizeUserPriority(storyData.userPriority || storyData.priority || storyData.priorityLabel);
   return level === 'critical';
 }
@@ -872,8 +887,18 @@ function selectTopStoriesFresh(items) {
     selectedIds.add(entry.id);
   };
 
-  const manualStories = sorted.filter((story) => story?.data?.userPriorityFlag === true);
-  if (manualStories.length) pick(manualStories[0]);
+  const manualStories = sorted
+    .filter((story) => getManualPriorityRank(story?.data))
+    .sort((a, b) => {
+      const ar = getManualPriorityRank(a?.data) || 99;
+      const br = getManualPriorityRank(b?.data) || 99;
+      if (ar !== br) return ar - br;
+      return scoreCreatedSort(a, b);
+    });
+  manualStories.forEach((story) => {
+    if (selected.length >= 3) return;
+    pick(story);
+  });
 
   const criticalStories = sorted.filter((story) => storyForcesTop3Tasks(story?.data));
   for (const story of criticalStories) {
@@ -901,11 +926,18 @@ function selectTopTasksFresh(items, storyMap = new Map()) {
     selectedIds.add(entry.id);
   };
 
-  const manualTasks = sorted.filter((task) => task?.data?.userPriorityFlag === true);
-  if (manualTasks.length) {
-    // Explicit user #1 flag always owns rank 1.
-    pick(manualTasks[0]);
-  }
+  const manualTasks = sorted
+    .filter((task) => getManualPriorityRank(task?.data))
+    .sort((a, b) => {
+      const ar = getManualPriorityRank(a?.data) || 99;
+      const br = getManualPriorityRank(b?.data) || 99;
+      if (ar !== br) return ar - br;
+      return scoreCreatedSort(a, b);
+    });
+  manualTasks.forEach((task) => {
+    if (selected.length >= 3) return;
+    pick(task);
+  });
 
   const storyDrivenTasks = sorted.filter((task) => {
     const storyId = task?.data?.storyId;
@@ -1011,40 +1043,8 @@ function nextOccurrenceForRecurring(entity, nowLocal) {
   return base.plus({ days: interval }).endOf('day').toMillis();
 }
 
-function nextWeekendDateByCapacity(nowLocal, dayLoadHours = new Map(), maxHours = 6) {
-  const base = (nowLocal || DateTime.now()).startOf('day');
-  let fallback = null;
-  for (let offset = 1; offset <= 56; offset += 1) {
-    const candidate = base.plus({ days: offset });
-    if (![6, 7].includes(candidate.weekday)) continue;
-    if (!fallback) fallback = candidate;
-    const key = candidate.toISODate();
-    const load = Number(dayLoadHours.get(key) || 0);
-    if (load < maxHours) {
-      return candidate.endOf('day').toMillis();
-    }
-  }
-  return (fallback || base.plus({ days: 6 })).endOf('day').toMillis();
-}
-
 async function buildDayLoadHoursMap(db, userId, startMs, endMs) {
-  const map = new Map();
-  const snap = await db.collection('calendar_blocks')
-    .where('ownerUid', '==', userId)
-    .where('start', '>=', startMs)
-    .where('start', '<=', endMs)
-    .get()
-    .catch(() => ({ docs: [] }));
-  for (const doc of (snap.docs || [])) {
-    const data = doc.data() || {};
-    const start = Number(data.start || 0);
-    const end = Number(data.end || 0);
-    if (!(start > 0) || !(end > start)) continue;
-    const key = DateTime.fromMillis(start).toISODate();
-    const hours = Math.max(0.25, (end - start) / (60 * 60 * 1000));
-    map.set(key, (map.get(key) || 0) + hours);
-  }
-  return map;
+  return buildDayLoadPointsMap(db, userId, startMs, endMs);
 }
 
 function entityIsCritical({
@@ -1056,7 +1056,7 @@ function entityIsCritical({
 }) {
   if (!entity) return false;
   if (isTop) return true;
-  if (entity.userPriorityFlag === true) return true;
+  if (getManualPriorityRank(entity)) return true;
   const level = normalizeUserPriority(entity.userPriority || entity.priority || entity.priorityLabel);
   if (level === 'critical') return true;
   const score = Number(entity.aiCriticalityScore || 0);
@@ -1064,7 +1064,7 @@ function entityIsCritical({
   const goalId = String(entity.goalId || '').trim();
   if (goalId && focusGoalIds?.has(goalId)) return true;
   if (entityType === 'task' && parentStory) {
-    if (parentStory.userPriorityFlag === true) return true;
+    if (getManualPriorityRank(parentStory)) return true;
     const parentLevel = normalizeUserPriority(parentStory.userPriority || parentStory.priority || parentStory.priorityLabel);
     if (parentLevel === 'critical') return true;
     const parentScore = Number(parentStory.aiCriticalityScore || 0);
@@ -1321,6 +1321,10 @@ async function applyAggressiveDueDateReplanForUser({
  * No max cap — the scheduler fills available slots up to this total.
  */
 function estimateRequiredMinutes(candidate, kind) {
+  const pointsRemaining = Number(candidate?.pointsRemaining);
+  if (Number.isFinite(pointsRemaining) && pointsRemaining > 0) {
+    return Math.max(kind === 'task' ? 30 : 60, Math.round(pointsRemaining * 60));
+  }
   const points = Number(candidate?.points) || 0;
   const rawProgress = candidate?.progressPct ?? candidate?.progress ?? candidate?.completionPct ?? 0;
   const progressPct = Math.min(100, Math.max(0, Number(rawProgress || 0)));
@@ -1365,9 +1369,9 @@ function sortPlannerCandidates(items, {
   extraPriorityFn,
 }) {
   return [...(items || [])].sort((a, b) => {
-    const aManual = a?.userPriorityFlag === true ? 1 : 0;
-    const bManual = b?.userPriorityFlag === true ? 1 : 0;
-    if (aManual !== bManual) return bManual - aManual;
+    const aManual = getManualPriorityRank(a);
+    const bManual = getManualPriorityRank(b);
+    if ((aManual || 99) !== (bManual || 99)) return (aManual || 99) - (bManual || 99);
 
     const aExtra = extraPriorityFn?.(a) ? 1 : 0;
     const bExtra = extraPriorityFn?.(b) ? 1 : 0;
@@ -1412,7 +1416,7 @@ function buildUnifiedPlacementQueue({
     ...stories.map((story) => ({
       kind: 'story',
       candidate: story,
-      manual: story?.userPriorityFlag === true ? 1 : 0,
+      manual: getManualPriorityRank(story) || 99,
       extra: storyForcesTop3Tasks(story) ? 1 : 0,
       top: isTopStory?.(story) ? 1 : 0,
       rank: Number(story?.aiFocusStoryRank || 0) || 99,
@@ -1426,7 +1430,7 @@ function buildUnifiedPlacementQueue({
       return {
         kind: 'task',
         candidate: task,
-        manual: task?.userPriorityFlag === true ? 1 : 0,
+        manual: getManualPriorityRank(task) || 99,
         extra: storyForcesTop3Tasks(parentStory) ? 1 : 0,
         top: isTopTask?.(task) ? 1 : 0,
         rank: Number(task?.aiPriorityRank || 0) || 99,
@@ -1439,7 +1443,7 @@ function buildUnifiedPlacementQueue({
   ];
 
   rows.sort((a, b) => {
-    if (a.manual !== b.manual) return b.manual - a.manual;
+    if (a.manual !== b.manual) return a.manual - b.manual;
     if (a.extra !== b.extra) return b.extra - a.extra;
     if (a.top !== b.top) return b.top - a.top;
     if (a.rank !== b.rank) return a.rank - b.rank;
@@ -1517,6 +1521,269 @@ function buildPlannerCoverageSummary({ stories, tasks, scheduledMinutesByEntity 
     shortfallMinutes: storyShortfallMinutes + taskShortfallMinutes,
     unscheduledStories,
     unscheduledTasks,
+  };
+}
+
+function plannerWeekStart(dt) {
+  return dt.startOf('week').startOf('day');
+}
+
+function buildSprintWeekBuckets({
+  sprintMap,
+  windowStart,
+  windowEnd,
+  defaultWeeklyCapacityPoints = 20,
+}) {
+  const bucketsBySprintId = new Map();
+  const fallbackBuckets = [];
+
+  const createBuckets = ({ sprintId = null, sprintMeta = null, startMs, endMs }) => {
+    const start = DateTime.fromMillis(startMs, { zone: windowStart.zoneName }).startOf('day');
+    const end = DateTime.fromMillis(endMs, { zone: windowStart.zoneName }).endOf('day');
+    if (end < start) return [];
+    const weekStarts = [];
+    let cursor = plannerWeekStart(start);
+    while (cursor.toMillis() <= end.toMillis()) {
+      const bucketEnd = cursor.plus({ days: 6 }).endOf('day');
+      const effectiveStartMs = Math.max(cursor.toMillis(), start.toMillis());
+      const effectiveEndMs = Math.min(bucketEnd.toMillis(), end.toMillis());
+      if (effectiveEndMs >= effectiveStartMs) {
+        weekStarts.push({
+          sprintId,
+          weekKey: cursor.toISODate(),
+          startMs: effectiveStartMs,
+          endMs: effectiveEndMs,
+          plannedPoints: 0,
+          capacityPoints: 0,
+        });
+      }
+      cursor = cursor.plus({ weeks: 1 });
+    }
+    const sprintCapacityPoints = deriveSprintCapacityPoints(sprintMeta || {}, defaultWeeklyCapacityPoints);
+    const perWeekCapacity = weekStarts.length > 0
+      ? sprintCapacityPoints / weekStarts.length
+      : defaultWeeklyCapacityPoints;
+    weekStarts.forEach((bucket) => {
+      bucket.capacityPoints = perWeekCapacity;
+    });
+    return weekStarts;
+  };
+
+  for (const [sprintId, sprintMeta] of sprintMap.entries()) {
+    const sprintStart = toMillis(sprintMeta?.start);
+    const sprintEnd = toMillis(sprintMeta?.end);
+    if (!Number.isFinite(sprintStart) || !Number.isFinite(sprintEnd)) continue;
+    const boundedStartMs = Math.max(sprintStart, windowStart.toMillis());
+    const boundedEndMs = Math.min(sprintEnd, windowEnd.toMillis());
+    if (boundedEndMs < boundedStartMs) continue;
+    bucketsBySprintId.set(sprintId, createBuckets({
+      sprintId,
+      sprintMeta,
+      startMs: boundedStartMs,
+      endMs: boundedEndMs,
+    }));
+  }
+
+  fallbackBuckets.push(...createBuckets({
+    sprintId: null,
+    sprintMeta: null,
+    startMs: windowStart.toMillis(),
+    endMs: windowEnd.toMillis(),
+  }));
+
+  return { bucketsBySprintId, fallbackBuckets };
+}
+
+function seedWeekBucketLoads({
+  bucketsBySprintId,
+  fallbackBuckets,
+  existingBlocks,
+}) {
+  const addLoadToBuckets = (buckets, startMs, points) => {
+    if (!Array.isArray(buckets) || !buckets.length) return false;
+    const bucket = buckets.find((entry) => startMs >= entry.startMs && startMs <= entry.endMs);
+    if (!bucket) return false;
+    bucket.plannedPoints += points;
+    return true;
+  };
+
+  (existingBlocks || []).forEach((block) => {
+    if (!(block?.storyId || block?.taskId)) return;
+    const startMs = toMillis(block.start);
+    const endMs = toMillis(block.end);
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return;
+    const points = Math.max(0.25, (endMs - startMs) / (60 * 60 * 1000));
+    const sprintId = String(block.sprintId || '').trim() || null;
+    if (sprintId && addLoadToBuckets(bucketsBySprintId.get(sprintId) || [], startMs, points)) return;
+    addLoadToBuckets(fallbackBuckets, startMs, points);
+  });
+}
+
+function chooseSprintWeekBucket({
+  candidate,
+  kind,
+  isTop,
+  parentStory,
+  storyWeekById,
+  sprintMap,
+  bucketsBySprintId,
+  fallbackBuckets,
+  windowStart,
+}) {
+  const candidateSprintId = String(candidate?.sprintId || parentStory?.sprintId || '').trim() || null;
+  const buckets = (candidateSprintId && bucketsBySprintId.get(candidateSprintId)?.length)
+    ? bucketsBySprintId.get(candidateSprintId)
+    : fallbackBuckets;
+  if (!Array.isArray(buckets) || buckets.length === 0) return null;
+
+  if (kind === 'task' && candidate?.storyId && storyWeekById.has(candidate.storyId)) {
+    const parentWeekKey = storyWeekById.get(candidate.storyId);
+    const sameWeek = buckets.find((bucket) => bucket.weekKey === parentWeekKey);
+    if (sameWeek) return sameWeek;
+  }
+
+  const candidatePoints = inferItemPoints(kind, candidate);
+  const dueMs = getDueDateMs(candidate);
+  const currentWeekKey = plannerWeekStart(windowStart).toISODate();
+  const currentWeekBucket = buckets.find((bucket) => bucket.weekKey === currentWeekKey) || buckets[0];
+
+  if (isTop && currentWeekBucket) {
+    currentWeekBucket.plannedPoints += candidatePoints;
+    return currentWeekBucket;
+  }
+
+  let preferredBucket = null;
+  if (Number.isFinite(dueMs)) {
+    preferredBucket = buckets.find((bucket) => dueMs >= bucket.startMs && dueMs <= bucket.endMs) || null;
+  }
+  const ordered = preferredBucket
+    ? [preferredBucket, ...buckets.filter((bucket) => bucket !== preferredBucket)]
+    : buckets;
+
+  const fitting = ordered.find((bucket) => (bucket.capacityPoints - bucket.plannedPoints) >= candidatePoints);
+  const chosen = fitting || ordered
+    .slice()
+    .sort((a, b) => {
+      const overA = a.plannedPoints - a.capacityPoints;
+      const overB = b.plannedPoints - b.capacityPoints;
+      if (overA !== overB) return overA - overB;
+      return a.startMs - b.startMs;
+    })[0];
+  if (!chosen) return null;
+  chosen.plannedPoints += candidatePoints;
+  return chosen;
+}
+
+async function schedulePlacementQueueWithCanonicalScheduler({
+  db,
+  userId,
+  placementQueue,
+  storyMap,
+  sprintMap,
+  existingBlocks,
+  windowStart,
+  windowEnd,
+  planningMode = 'smart',
+  source = 'nightly_calendar_planner',
+}) {
+  const scheduledMinutesByEntity = collectScheduledMinutesByEntity(existingBlocks);
+  const manuallyScheduledEntityKeys = new Set(
+    (existingBlocks || [])
+      .filter((block) => {
+        const isAi = block.aiGenerated === true || block.isAiGenerated === true || block.createdBy === 'ai';
+        return !isAi && (block.storyId || block.taskId);
+      })
+      .map((block) => (block.storyId ? getEntityKey('story', block.storyId) : getEntityKey('task', block.taskId)))
+      .filter(Boolean),
+  );
+
+  const { bucketsBySprintId, fallbackBuckets } = buildSprintWeekBuckets({
+    sprintMap,
+    windowStart,
+    windowEnd,
+  });
+  seedWeekBucketLoads({ bucketsBySprintId, fallbackBuckets, existingBlocks });
+
+  const storyWeekById = new Map();
+  let created = 0;
+  let blocked = 0;
+
+  for (const entry of placementQueue) {
+    const { kind, candidate } = entry;
+    const entityKey = getEntityKey(kind, candidate?.id);
+    if (!entityKey || manuallyScheduledEntityKeys.has(entityKey)) continue;
+
+    const totalNeededMs = estimateRequiredMinutes(candidate, kind) * 60000;
+    const alreadyMs = (scheduledMinutesByEntity.get(entityKey) || 0) * 60000;
+    if (alreadyMs >= totalNeededMs) continue;
+
+    const rawScore = Number(candidate?.aiCriticalityScore || 0);
+    const isCriticalPriority = Number(candidate?.priority || 0) >= 4;
+    const isTop = candidate?.aiTop3ForDay === true;
+    if (rawScore > 0 && rawScore < 40 && !isCriticalPriority && !isTop) {
+      continue;
+    }
+
+    const parentStory = kind === 'task' && candidate?.storyId ? storyMap.get(candidate.storyId) : null;
+    const bucket = chooseSprintWeekBucket({
+      candidate,
+      kind,
+      isTop,
+      parentStory,
+      storyWeekById,
+      sprintMap,
+      bucketsBySprintId,
+      fallbackBuckets,
+      windowStart,
+    });
+    if (!bucket) {
+      blocked += 1;
+      continue;
+    }
+
+    const targetStartMs = Math.max(bucket.startMs, windowStart.toMillis());
+    const targetSprintId = String(candidate?.sprintId || parentStory?.sprintId || bucket.sprintId || '').trim() || null;
+    const remainingDays = Math.max(
+      1,
+      Math.floor((windowEnd.toMillis() - targetStartMs) / (24 * 60 * 60 * 1000)) + 1,
+    );
+
+    try {
+      const result = await schedulePlannerItemMutation({
+        db,
+        userId,
+        itemType: kind,
+        itemId: candidate.id,
+        targetDateMs: targetStartMs,
+        targetBucket: candidate.timeOfDay || null,
+        intent: 'move',
+        source,
+        rationale: `Nightly sprint placement for week of ${bucket.weekKey}`,
+        linkedBlockId: null,
+        targetSprintId,
+        durationMinutes: estimateRequiredMinutes(candidate, kind),
+        planningMode,
+        searchDays: remainingDays,
+        allowSplit: true,
+      });
+      created += 1;
+      addScheduledMinutes(
+        scheduledMinutesByEntity,
+        kind,
+        candidate.id,
+        Math.max(15, Math.round(Number(result.scheduledMinutes || 0) || 0)),
+      );
+      if (kind === 'story') storyWeekById.set(candidate.id, String(result.appliedWeekKey || bucket.weekKey));
+    } catch (error) {
+      console.warn(`[${source}] failed to schedule ${kind}:${candidate.id}`, error?.message || error);
+      blocked += 1;
+    }
+  }
+
+  return {
+    created,
+    blocked,
+    scheduledMinutesByEntity,
   };
 }
 
@@ -3253,7 +3520,7 @@ async function runCalendarPlannerJob() {
     if (dedupeResult.removed > 0) {
       console.log(`[calendar-planner] removed ${dedupeResult.removed} duplicate blocks for ${userId}`);
     }
-    const existingBlocks = dedupeResult.blocks;
+    let existingBlocks = dedupeResult.blocks;
 
     const fitnessBlocksAutoCreate = profile?.fitnessBlocksAutoCreate !== false;
     const plannerBlockResult = await materializePlannerThemeBlocks({
@@ -3267,6 +3534,13 @@ async function runCalendarPlannerJob() {
     });
     if (plannerBlockResult.created > 0) {
       console.log(`[calendar-planner] planner blocks created for ${userId}: ${plannerBlockResult.created}`);
+      const refreshedBlocksSnap = await db.collection('calendar_blocks')
+        .where('ownerUid', '==', userId)
+        .where('start', '>=', windowStart.toMillis())
+        .where('start', '<=', windowEnd.toMillis())
+        .get()
+        .catch(() => ({ docs: [] }));
+      existingBlocks = refreshedBlocksSnap.docs.map((d) => ({ id: d.id, ...(d.data() || {}) }));
     }
 
     const rescheduleResult = await replanExistingBlocksForUser({
@@ -3395,30 +3669,6 @@ async function runCalendarPlannerJob() {
       }
     }
 
-    const scheduledMinutesByEntity = collectScheduledMinutesByEntity(remainingBlocks);
-    const manuallyScheduledEntityKeys = new Set(
-      remainingBlocks
-        .filter((block) => {
-          const isAi = block.aiGenerated === true || block.isAiGenerated === true || block.createdBy === 'ai';
-          return !isAi && (block.storyId || block.taskId);
-        })
-        .map((block) => (block.storyId ? getEntityKey('story', block.storyId) : getEntityKey('task', block.taskId)))
-    );
-
-    const mainGigBlocks = []; // Track main gig planner blocks separately
-    remainingBlocks.forEach((b) => {
-      if (b.start && b.end) {
-        const blockTheme = b.theme || b.category || '';
-        if (isMainGigBlock(b)) {
-          mainGigBlocks.push({ start: b.start, end: b.end, theme: blockTheme });
-          busyPersonal.push({ start: b.start, end: b.end });
-        } else {
-          busyPersonal.push({ start: b.start, end: b.end });
-          busyWork.push({ start: b.start, end: b.end });
-        }
-      }
-    });
-
     const placementQueue = buildUnifiedPlacementQueue({
       stories: storyQueue,
       tasks: taskQueue,
@@ -3427,150 +3677,23 @@ async function runCalendarPlannerJob() {
       storyMap,
     });
 
-    let created = 0;
-    let blocked = 0;
-
-    // Greedy multi-block scheduler: fills all available free time until total needed is covered
-    const placeEntry = async (candidate, kind) => {
-      const sprint = candidate.sprintId ? sprintMap.get(candidate.sprintId) : null;
-      const sprintStart = sprint?.start ? toMillis(sprint.start) : null;
-      const sprintEnd = sprint?.end ? toMillis(sprint.end) : null;
-      const isWorkPersona = String(candidate?.persona || '').toLowerCase() === 'work';
-      const busyList = isWorkPersona ? busyWork : busyPersonal;
-
-      const totalNeededMs = estimateRequiredMinutes(candidate, kind) * 60000;
-      const entityKey = getEntityKey(kind, candidate.id);
-      const alreadyScheduledMs = (scheduledMinutesByEntity.get(entityKey) || 0) * 60000;
-      let stillNeededMs = totalNeededMs - alreadyScheduledMs;
-      if (stillNeededMs <= 0) return { created: 0, blocked: 0 };
-
-      const MIN_BLOCK_MS = 30 * 60000;
-      const title = candidate.title;
-      const basePayload = {
-        ownerUid: userId,
-        title,
-        entityType: kind,
-        taskId: kind === 'task' ? candidate.id : null,
-        storyId: kind === 'story' ? candidate.id : null,
-        sprintId: candidate.sprintId || null,
-        theme: candidate.theme || null,
-        goalId: candidate.goalId || null,
-        status: 'planned',
-        aiGenerated: true,
-        aiScore: candidate.aiScore || null,
-        aiReason: candidate.aiCriticalityReason || null,
-        placementReason: 'Nightly planner: greedy fill for remaining work',
-        calendarMatchSource: 'calendar_event_created_via_planner',
-        calendarMatchNote: 'Calendar event created via planner',
-        deepLink: buildEntityUrl(kind === 'story' ? 'story' : 'task', candidate.id, candidate.ref || null),
-        persona: candidate.persona || (isWorkPersona ? 'work' : 'personal'),
-        createdAt: admin.firestore.FieldValue.serverTimestamp(),
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-      };
-
-      let created = 0;
-
-      if (isWorkPersona) {
-        if (!mainGigBlocks.length) return { created: 0, blocked: 1 };
-        const sortedMainGig = mainGigBlocks.filter((mg) => mg.start && mg.end).sort((a, b) => a.start - b.start);
-        for (const mg of sortedMainGig) {
-          if (stillNeededMs <= 0) break;
-          if (sprintStart && mg.end < sprintStart) continue;
-          if (sprintEnd && mg.start > sprintEnd) continue;
-          const gaps = findFreeGapsInSlot(mg.start, mg.end, busyList, MIN_BLOCK_MS);
-          for (const gap of gaps) {
-            if (stillNeededMs <= 0) break;
-            const blockMs = Math.min(gap.end - gap.start, stillNeededMs);
-            if (blockMs < MIN_BLOCK_MS) continue;
-            const blockRef = db.collection('calendar_blocks').doc();
-            const payload = { ...basePayload, start: gap.start, end: gap.start + blockMs };
-            await blockRef.set(payload);
-            busyPersonal.push({ start: payload.start, end: payload.end });
-            busyWork.push({ start: payload.start, end: payload.end });
-            const minutesAdded = Math.round(blockMs / 60000);
-            addScheduledMinutes(scheduledMinutesByEntity, kind, candidate.id, minutesAdded);
-            stillNeededMs -= blockMs;
-            created++;
-            const slotDt = DateTime.fromMillis(gap.start, { zone: windowStart.zoneName });
-            await db.collection('activity_stream').add(activityPayload({
-              ownerUid: userId,
-              entityId: candidate.id,
-              entityType: kind,
-              activityType: 'calendar_insertion',
-              description: `Calendar block created (${slotDt.toISODate()} ${slotDt.toFormat('HH:mm')}–${DateTime.fromMillis(gap.start + blockMs, { zone: windowStart.zoneName }).toFormat('HH:mm')})`,
-              metadata: { blockId: blockRef.id, reason: payload.placementReason, theme: payload.theme || null, goalId: payload.goalId || null },
-            }));
-          }
-        }
-        return { created, blocked: stillNeededMs > MIN_BLOCK_MS ? 1 : 0 };
-      }
-
-      for (let offset = 0; offset < planningDays && stillNeededMs > MIN_BLOCK_MS; offset++) {
-        const day = windowStart.plus({ days: offset });
-        const dayStartMs = day.toMillis();
-        const dayEndMs = day.endOf('day').toMillis();
-        if ((sprintStart && dayEndMs < sprintStart) || (sprintEnd && dayStartMs > sprintEnd)) continue;
-
-        const allSlots = pickSlots(candidate.theme || candidate.goal || null, day);
-        const slots = filterSlotsByTimeOfDay(allSlots, candidate.timeOfDay || null);
-        for (const slot of slots) {
-          if (stillNeededMs <= 0) break;
-          if (isMainGigLabel(slot.label)) continue;
-          const slotDays = slot.days || [1, 2, 3, 4, 5, 6, 7];
-          if (!slotDays.includes(day.weekday)) continue;
-          const slotStart = day.set({ hour: Math.floor(slot.start), minute: Math.round((slot.start % 1) * 60), second: 0, millisecond: 0 });
-          const slotEnd = day.set({ hour: Math.floor(slot.end), minute: Math.round((slot.end % 1) * 60), second: 0, millisecond: 0 });
-          if (sprintStart && slotEnd.toMillis() < sprintStart) continue;
-          if (sprintEnd && slotStart.toMillis() > sprintEnd) continue;
-
-          const gaps = findFreeGapsInSlot(slotStart.toMillis(), slotEnd.toMillis(), busyList, MIN_BLOCK_MS);
-          for (const gap of gaps) {
-            if (stillNeededMs <= 0) break;
-            if (mainGigBlocks.some((mg) => mg.end > gap.start && mg.start < gap.end)) continue;
-            const blockMs = Math.min(gap.end - gap.start, stillNeededMs);
-            if (blockMs < MIN_BLOCK_MS) continue;
-            const blockRef = db.collection('calendar_blocks').doc();
-            const payload = { ...basePayload, start: gap.start, end: gap.start + blockMs };
-            await blockRef.set(payload);
-            busyPersonal.push({ start: payload.start, end: payload.end });
-            busyWork.push({ start: payload.start, end: payload.end });
-            const minutesAdded = Math.round(blockMs / 60000);
-            addScheduledMinutes(scheduledMinutesByEntity, kind, candidate.id, minutesAdded);
-            stillNeededMs -= blockMs;
-            created++;
-            const slotDt = DateTime.fromMillis(gap.start, { zone: windowStart.zoneName });
-            await db.collection('activity_stream').add(activityPayload({
-              ownerUid: userId,
-              entityId: candidate.id,
-              entityType: kind,
-              activityType: 'calendar_insertion',
-              description: `Calendar block created (${slotDt.toISODate()} ${slotDt.toFormat('HH:mm')}–${DateTime.fromMillis(gap.start + blockMs, { zone: windowStart.zoneName }).toFormat('HH:mm')})`,
-              metadata: { blockId: blockRef.id, reason: payload.placementReason, theme: payload.theme || null, goalId: payload.goalId || null },
-            }));
-          }
-        }
-      }
-      return { created, blocked: stillNeededMs > MIN_BLOCK_MS ? 1 : 0 };
-    };
-
-    for (const entry of placementQueue) {
-      const { kind, candidate } = entry;
-      const entityKey = getEntityKey(kind, candidate?.id);
-      if (manuallyScheduledEntityKeys.has(entityKey)) {
-        continue;
-      }
-      const totalNeededMs = estimateRequiredMinutes(candidate, kind) * 60000;
-      const alreadyMs = (scheduledMinutesByEntity.get(entityKey) || 0) * 60000;
-      if (alreadyMs >= totalNeededMs) continue; // fully covered
-      const res = await placeEntry(candidate, kind);
-      created += res.created || 0;
-      blocked += res.blocked || 0;
-    }
+    const plannerScheduleResult = await schedulePlacementQueueWithCanonicalScheduler({
+      db,
+      userId,
+      placementQueue,
+      storyMap,
+      sprintMap,
+      existingBlocks: remainingBlocks,
+      windowStart,
+      windowEnd,
+      planningMode: 'smart',
+      source: 'nightly_calendar_planner',
+    });
 
     const coverage = buildPlannerCoverageSummary({
       stories: storyQueue,
       tasks: taskQueue,
-      scheduledMinutesByEntity,
+      scheduledMinutesByEntity: plannerScheduleResult.scheduledMinutesByEntity,
     });
 
     await writePlannerStats({
@@ -3580,8 +3703,8 @@ async function runCalendarPlannerJob() {
       windowStart,
       windowEnd,
       result: {
-        created,
-        blocked,
+        created: plannerScheduleResult.created || 0,
+        blocked: plannerScheduleResult.blocked || 0,
         rescheduled: rescheduleResult.rescheduled || 0,
         replaced: dedupeResult.removed || 0,
         totalMovable: rescheduleResult.totalMovable || 0,
@@ -3974,7 +4097,7 @@ exports.replanCalendarNow = onCall({
     .where('start', '<=', windowEnd.toMillis())
     .get()
     .catch(() => ({ docs: [] }));
-  const existingBlocks = blocksSnap.docs.map((d) => ({ id: d.id, ...(d.data() || {}) }));
+  let existingBlocks = blocksSnap.docs.map((d) => ({ id: d.id, ...(d.data() || {}) }));
 
   let storiesSnap = { docs: [] };
   try {
@@ -4182,175 +4305,54 @@ exports.replanCalendarNow = onCall({
     existingBlocks: remainingBlocks,
     fitnessBlocksAutoCreate,
   });
-
-  const scheduledMinutesByEntity = collectScheduledMinutesByEntity(remainingBlocks);
-
-  const busyPersonal = [];
-  const busyWork = [];
-  const mainGigBlocks = []; // Track main gig planner blocks separately
-  const addBusyPersonal = (start, end) => {
-    if (start && end) busyPersonal.push({ start, end });
-  };
-  const addBusyWork = (start, end) => {
-    if (start && end) busyWork.push({ start, end });
-  };
-
-  remainingBlocks.forEach((b) => {
-    // In smart mode only hard-busy blocks (user GCal / work / fitness) block time.
-    // In strict mode every remaining block blocks time.
-    if (planningMode === 'smart' && !isHardBusy(b)) return;
-
-    if (isMainGigBlock(b)) {
-      mainGigBlocks.push({ start: b.start, end: b.end, theme: b.theme || b.category || '' });
-      addBusyPersonal(b.start, b.end);
-    } else {
-      addBusyPersonal(b.start, b.end);
-      addBusyWork(b.start, b.end);
-    }
-  });
-
-  const { pickSlots } = buildPickSlots(themeAllocations);
-
-  /**
-   * Schedule a candidate greedily across multiple free slots/days until the
-   * total remaining time is covered.  Blocks fill all available free time in
-   * each slot (no hard per-block cap), split across as many days as needed.
-   */
-  const placeEntry = async (candidate, kind) => {
-    const sprint = candidate.sprintId ? sprintMap.get(candidate.sprintId) : null;
-    const sprintStart = sprint?.start ? toMillis(sprint.start) : null;
-    const sprintEnd = sprint?.end ? toMillis(sprint.end) : null;
-    const isWorkPersona = String(candidate?.persona || '').toLowerCase() === 'work';
-    const busyList = isWorkPersona ? busyWork : busyPersonal;
-
-    const totalNeededMs = estimateRequiredMinutes(candidate, kind) * 60000;
-    const entityKey = getEntityKey(kind, candidate.id);
-    const alreadyScheduledMs = (scheduledMinutesByEntity.get(entityKey) || 0) * 60000;
-    let stillNeededMs = totalNeededMs - alreadyScheduledMs;
-    if (stillNeededMs <= 0) return { created: 0, blocked: 0 };
-
-      // Skip low-scored items — only schedule if Top 3, critical priority, or score >= 40
-      const rawScore = Number(candidate?.aiCriticalityScore || 0);
-      const isCriticalPriority = Number(candidate?.priority || 0) >= 4;
-      const isTop = candidate?.aiTop3ForDay === true;
-      if (rawScore > 0 && rawScore < 40 && !isCriticalPriority && !isTop) {
-        return { created: 0, blocked: 0 };
-      }
-
-    const MIN_BLOCK_MS = 30 * 60000; // 30-minute minimum useful block
-    const title = candidate.title;
-    const basePayload = {
-      ownerUid: uid,
-      title,
-      entityType: kind,
-      taskId: kind === 'task' ? candidate.id : null,
-      storyId: kind === 'story' ? candidate.id : null,
-      sprintId: candidate.sprintId || null,
-      theme: candidate.theme || null,
-      goalId: candidate.goalId || null,
-      status: 'planned',
-      aiGenerated: true,
-      aiScore: candidate.aiScore || null,
-      aiReason: candidate.aiCriticalityReason || null,
-      placementReason: 'Replan: greedy fill for remaining work',
-      deepLink: buildEntityUrl(kind === 'story' ? 'story' : 'task', candidate.id, candidate.ref || null),
-      persona: candidate.persona || (isWorkPersona ? 'work' : 'personal'),
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    };
-
-    let created = 0;
-
-    if (isWorkPersona) {
-      if (!mainGigBlocks.length) return { created: 0, blocked: 1 };
-      const sortedMainGig = mainGigBlocks.filter((mg) => mg.start && mg.end).sort((a, b) => a.start - b.start);
-      for (const mg of sortedMainGig) {
-        if (stillNeededMs <= 0) break;
-        if (sprintStart && mg.end < sprintStart) continue;
-        if (sprintEnd && mg.start > sprintEnd) continue;
-        const gaps = findFreeGapsInSlot(mg.start, mg.end, busyList, MIN_BLOCK_MS);
-        for (const gap of gaps) {
-          if (stillNeededMs <= 0) break;
-          const blockMs = Math.min(gap.end - gap.start, stillNeededMs);
-          if (blockMs < MIN_BLOCK_MS) continue;
-          const blockRef = db.collection('calendar_blocks').doc();
-          const payload = { ...basePayload, start: gap.start, end: gap.start + blockMs };
-          await blockRef.set(payload);
-          busyPersonal.push({ start: payload.start, end: payload.end });
-          busyWork.push({ start: payload.start, end: payload.end });
-          const minutesAdded = Math.round(blockMs / 60000);
-          addScheduledMinutes(scheduledMinutesByEntity, kind, candidate.id, minutesAdded);
-          stillNeededMs -= blockMs;
-          created++;
+  {
+    const refreshedBlocksSnap = await db.collection('calendar_blocks')
+      .where('ownerUid', '==', uid)
+      .where('start', '>=', windowStart.toMillis())
+      .where('start', '<=', windowEnd.toMillis())
+      .get()
+      .catch(() => ({ docs: [] }));
+    existingBlocks = refreshedBlocksSnap.docs.map((d) => ({ id: d.id, ...(d.data() || {}) }));
+    const retainedIds = new Set(remainingBlocks.map((block) => block.id));
+    for (const block of existingBlocks) {
+      if (retainedIds.has(block.id)) continue;
+      const isAi = isAiPlannerBlock(block);
+      const key = block.storyId ? getEntityKey('story', block.storyId) : block.taskId ? getEntityKey('task', block.taskId) : null;
+      if (planningMode === 'smart') {
+        if (isHardBusy(block)) {
+          remainingBlocks.push(block);
+          retainedIds.add(block.id);
         }
-      }
-      return { created, blocked: stillNeededMs > MIN_BLOCK_MS ? 1 : 0 };
-    }
-
-    for (let offset = 0; offset < planningDays && stillNeededMs > MIN_BLOCK_MS; offset++) {
-      const day = windowStart.plus({ days: offset });
-      const dayStartMs = day.toMillis();
-      const dayEndMs = day.endOf('day').toMillis();
-      if ((sprintStart && dayEndMs < sprintStart) || (sprintEnd && dayStartMs > sprintEnd)) continue;
-
-      const allSlots = pickSlots(candidate.theme || candidate.goal || null, day);
-      const slots = filterSlotsByTimeOfDay(allSlots, candidate.timeOfDay || null);
-      for (const slot of slots) {
-        if (stillNeededMs <= 0) break;
-        if (isMainGigLabel(slot.label)) continue;
-        const slotDays = slot.days || [1, 2, 3, 4, 5, 6, 7];
-        if (!slotDays.includes(day.weekday)) continue;
-        const slotStart = day.set({ hour: Math.floor(slot.start), minute: Math.round((slot.start % 1) * 60), second: 0, millisecond: 0 });
-        const slotEnd = day.set({ hour: Math.floor(slot.end), minute: Math.round((slot.end % 1) * 60), second: 0, millisecond: 0 });
-        if (sprintStart && slotEnd.toMillis() < sprintStart) continue;
-        if (sprintEnd && slotStart.toMillis() > sprintEnd) continue;
-
-        const gaps = findFreeGapsInSlot(slotStart.toMillis(), slotEnd.toMillis(), busyList, MIN_BLOCK_MS);
-        for (const gap of gaps) {
-          if (stillNeededMs <= 0) break;
-          // Never place in main gig overlap
-          if (mainGigBlocks.some((mg) => mg.end > gap.start && mg.start < gap.start + Math.min(gap.end - gap.start, stillNeededMs))) continue;
-          const blockMs = Math.min(gap.end - gap.start, stillNeededMs);
-          if (blockMs < MIN_BLOCK_MS) continue;
-          const blockRef = db.collection('calendar_blocks').doc();
-          const payload = { ...basePayload, start: gap.start, end: gap.start + blockMs };
-          await blockRef.set(payload);
-          busyPersonal.push({ start: payload.start, end: payload.end });
-          busyWork.push({ start: payload.start, end: payload.end });
-          const minutesAdded = Math.round(blockMs / 60000);
-          addScheduledMinutes(scheduledMinutesByEntity, kind, candidate.id, minutesAdded);
-          stillNeededMs -= blockMs;
-          created++;
-        }
+      } else if (!(isAi && key && !candidateIds.has(key))) {
+        remainingBlocks.push(block);
+        retainedIds.add(block.id);
       }
     }
-    return { created, blocked: stillNeededMs > MIN_BLOCK_MS ? 1 : 0 };
-  };
-
-  let created = 0;
-  let blocked = 0;
-  let gcalLinks = [];
-
-  for (const entry of placementQueue) {
-    const { kind, candidate } = entry;
-    const entityKey = getEntityKey(kind, candidate?.id);
-    const totalNeededMs = estimateRequiredMinutes(candidate, kind) * 60000;
-    const alreadyMs = (scheduledMinutesByEntity.get(entityKey) || 0) * 60000;
-    if (alreadyMs >= totalNeededMs) continue; // fully covered already
-    const res = await placeEntry(candidate, kind);
-    created += res.created || 0;
-    blocked += res.blocked || 0;
   }
+
+  const plannerScheduleResult = await schedulePlacementQueueWithCanonicalScheduler({
+    db,
+    userId: uid,
+    placementQueue,
+    storyMap,
+    sprintMap,
+    existingBlocks: remainingBlocks,
+    windowStart,
+    windowEnd,
+    planningMode,
+    source: 'replan_calendar',
+  });
+  let gcalLinks = [];
 
   const coverage = buildPlannerCoverageSummary({
     stories: storyQueue,
     tasks: taskQueue,
-    scheduledMinutesByEntity,
+    scheduledMinutesByEntity: plannerScheduleResult.scheduledMinutesByEntity,
   });
 
   const result = {
-    created,
-    blocked,
+    created: plannerScheduleResult.created || 0,
+    blocked: plannerScheduleResult.blocked || 0,
     rescheduled: 0,
     replaced,
     gcalLinks,
@@ -4436,6 +4438,58 @@ exports.replanCalendarNow = onCall({
     ok: true,
     ...result,
   };
+});
+
+exports.schedulePlannerItem = onCall({
+  region: 'europe-west2',
+  memory: '512MiB',
+}, async (req) => {
+  const uid = req?.auth?.uid;
+  if (!uid) throw new https.HttpsError('unauthenticated', 'Sign in required');
+  const itemType = String(req?.data?.itemType || '').trim().toLowerCase();
+  const itemId = String(req?.data?.itemId || '').trim();
+  if (!itemId || (itemType !== 'task' && itemType !== 'story')) {
+    throw new https.HttpsError('invalid-argument', 'A valid task or story target is required.');
+  }
+
+  const db = ensureFirestore();
+  try {
+    const result = await schedulePlannerItemMutation({
+      db,
+      userId: uid,
+      itemType,
+      itemId,
+      targetDateMs: req?.data?.targetDateMs,
+      targetBucket: req?.data?.targetBucket || null,
+      intent: req?.data?.intent || 'move',
+      source: req?.data?.source || 'planner',
+      rationale: req?.data?.rationale || null,
+      linkedBlockId: req?.data?.linkedBlockId || null,
+      targetSprintId: req?.data?.targetSprintId || null,
+      durationMinutes: req?.data?.durationMinutes || null,
+      planningMode: req?.data?.planningMode || null,
+      searchDays: req?.data?.searchDays || null,
+      maxTargetDateMs: req?.data?.maxTargetDateMs || null,
+      allowSplit: req?.data?.allowSplit === true,
+      debugRequestId: req?.data?.debugRequestId || null,
+    });
+    return result;
+  } catch (error) {
+    const message = error?.message || 'Failed to schedule planner item';
+    console.error('[schedulePlannerItem] failure', {
+      debugRequestId: req?.data?.debugRequestId || null,
+      uid,
+      itemType,
+      itemId,
+      intent: req?.data?.intent || 'move',
+      source: req?.data?.source || 'planner',
+      targetDateMs: req?.data?.targetDateMs || null,
+      targetBucket: req?.data?.targetBucket || null,
+      linkedBlockId: req?.data?.linkedBlockId || null,
+      error: message,
+    });
+    throw new https.HttpsError('failed-precondition', message);
+  }
 });
 
 // Manual trigger to run the nightly chain (pointing → conversions → scoring+Top3 → calendar)
@@ -4616,6 +4670,7 @@ exports.deltaPriorityRescore = onCall({
       aiTop3Date: admin.firestore.FieldValue.delete(),
       aiTop3Reason: admin.firestore.FieldValue.delete(),
       userPriorityFlag: false,
+      userPriorityRank: admin.firestore.FieldValue.delete(),
       userPriorityFlagAt: admin.firestore.FieldValue.delete(),
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       syncState: 'dirty',
@@ -4662,10 +4717,11 @@ exports.deltaPriorityRescore = onCall({
 
   const isHobbyTheme = effectiveTheme && String(effectiveTheme).toLowerCase().includes('hobb');
 
-  // User #1 priority flag gives massive boost
-  if (entity.userPriorityFlag === true) {
-    bonus += 1000;
-    bonusReasons.push('User #1 priority flag');
+  const manualPriorityRank = getManualPriorityRank(entity);
+  if (manualPriorityRank != null) {
+    const manualBoost = manualPriorityRank === 1 ? 1000 : manualPriorityRank === 2 ? 900 : 800;
+    bonus += manualBoost;
+    bonusReasons.push(`User manual priority #${manualPriorityRank}`);
   }
 
   if (entityType === 'task' && !entity.storyId) {
@@ -4751,10 +4807,25 @@ async function _deltaTop3ForPersona(db, userId, persona) {
   const topTasks = selectTopTasksFresh(taskCandidates, storyMap);
   const topTaskIds = new Set(topTasks.map((task) => task.id));
   const topStoryIds = new Set(topStories.map((story) => story.id));
+  const forcedStoryTaskCandidates = taskCandidates.filter((task) => {
+    const storyId = task?.data?.storyId;
+    if (!storyId) return false;
+    const parentStory = storyMap.get(storyId);
+    return !!getManualPriorityRank(parentStory?.data);
+  });
+  const promotedTasks = [
+    ...topTasks,
+    ...forcedStoryTaskCandidates.filter((task) => !topTaskIds.has(task.id)),
+  ];
+  const promotedTaskIds = new Set(promotedTasks.map((task) => task.id));
 
   const promoteTaskBatch = db.batch();
-  topTasks.forEach((task, idx) => {
-    const reason = ['Top 3 priority', `score=${Math.round(task.score || 0)}`].filter(Boolean).join(' | ');
+  promotedTasks.forEach((task, idx) => {
+    const parentStory = task?.data?.storyId ? storyMap.get(task.data.storyId) : null;
+    const parentManualRank = getManualPriorityRank(parentStory?.data);
+    const reason = parentManualRank
+      ? [`Manual story priority #${parentManualRank}`, `score=${Math.round(task.score || 0)}`].filter(Boolean).join(' | ')
+      : ['Top 3 priority', `score=${Math.round(task.score || 0)}`].filter(Boolean).join(' | ');
     const patch = {
       aiFlaggedTop: true,
       aiPriorityRank: idx + 1,
@@ -4773,12 +4844,12 @@ async function _deltaTop3ForPersona(db, userId, persona) {
     }
     promoteTaskBatch.set(task.refObj, patch, { merge: true });
   });
-  if (topTasks.length > 0) await promoteTaskBatch.commit();
+  if (promotedTasks.length > 0) await promoteTaskBatch.commit();
 
   const demoteTaskMap = await collectTaskTop3CandidateDocs(db, userId, 200);
   const demoteTaskWriter = db.bulkWriter();
   demoteTaskMap.forEach((doc) => {
-    if (topTaskIds.has(doc.id)) return;
+    if (promotedTaskIds.has(doc.id)) return;
     const data = doc.data() || {};
     if (resolvePersona(data.persona) !== persona) return;
     const cleanedTags = stripTop3Tags(data.tags);

--- a/functions/services/capacityService.js
+++ b/functions/services/capacityService.js
@@ -1,0 +1,116 @@
+const { DateTime } = require('luxon');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function toMillis(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value?.toMillis === 'function') return value.toMillis();
+  if (typeof value?.toDate === 'function') return value.toDate().getTime();
+  if (typeof value?.seconds === 'number') return value.seconds * 1000;
+  const parsed = Date.parse(String(value));
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function startOfDayMs(ts = Date.now()) {
+  const d = new Date(ts);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+function toDayKey(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function inferItemPoints(itemType, data) {
+  const normalizedType = String(itemType || '').trim().toLowerCase();
+  if (normalizedType === 'task') {
+    const direct = Number(data?.points || 0);
+    if (Number.isFinite(direct) && direct > 0) return direct;
+    const estimateMin = Number(data?.estimateMin || 0);
+    if (Number.isFinite(estimateMin) && estimateMin > 0) return Math.max(0.25, estimateMin / 60);
+    return 1;
+  }
+  if (normalizedType === 'story') {
+    const direct = Number(data?.points || 0);
+    if (Number.isFinite(direct) && direct > 0) return direct;
+    const estimateMin = Number(data?.estimateMin || 0);
+    if (Number.isFinite(estimateMin) && estimateMin > 0) return Math.max(0.5, estimateMin / 60);
+    return 2;
+  }
+  return 1;
+}
+
+function summarizeCapacity(plannedPoints, capacityPoints) {
+  const safeCapacity = Math.max(1, Number(capacityPoints || 0) || 1);
+  const planned = Number(plannedPoints || 0);
+  const remainingPoints = safeCapacity - planned;
+  const utilizationPct = Math.round((planned / safeCapacity) * 100);
+  return {
+    capacityPoints: safeCapacity,
+    plannedPoints: planned,
+    remainingPoints,
+    utilizationPct,
+    overCapacity: remainingPoints < 0,
+  };
+}
+
+async function buildDayLoadPointsMap(db, userId, startMs, endMs) {
+  const map = new Map();
+  const snap = await db.collection('calendar_blocks')
+    .where('ownerUid', '==', userId)
+    .where('start', '>=', startMs)
+    .where('start', '<=', endMs)
+    .get()
+    .catch(() => ({ docs: [] }));
+  for (const doc of (snap.docs || [])) {
+    const data = doc.data() || {};
+    const start = Number(data.start || 0);
+    const end = Number(data.end || 0);
+    if (!(start > 0) || !(end > start)) continue;
+    const key = toDayKey(start);
+    const points = Math.max(0.25, (end - start) / (60 * 60 * 1000));
+    map.set(key, (map.get(key) || 0) + points);
+  }
+  return map;
+}
+
+function nextWeekendDateByCapacity(nowLocal, dayLoadPoints = new Map(), maxPoints = 6) {
+  const base = (nowLocal || DateTime.now()).startOf('day');
+  let fallback = null;
+  for (let offset = 1; offset <= 56; offset += 1) {
+    const candidate = base.plus({ days: offset });
+    if (![6, 7].includes(candidate.weekday)) continue;
+    if (!fallback) fallback = candidate;
+    const key = candidate.toISODate();
+    const load = Number(dayLoadPoints.get(key) || 0);
+    if (load < maxPoints) {
+      return candidate.endOf('day').toMillis();
+    }
+  }
+  return (fallback || base.plus({ days: 6 })).endOf('day').toMillis();
+}
+
+function deriveSprintCapacityPoints(sprint, weeklyCapacityPoints = 20) {
+  const explicit = Number(sprint?.capacityPoints || 0);
+  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+  const startMs = toMillis(sprint?.startDate || sprint?.start);
+  const endMs = toMillis(sprint?.endDate || sprint?.end);
+  if (Number.isFinite(startMs) && Number.isFinite(endMs) && endMs >= startMs) {
+    const sprintWeeks = Math.max(1, Math.ceil((endMs - startMs + DAY_MS) / (7 * DAY_MS)));
+    return sprintWeeks * weeklyCapacityPoints;
+  }
+  return weeklyCapacityPoints;
+}
+
+module.exports = {
+  DAY_MS,
+  toMillis,
+  startOfDayMs,
+  toDayKey,
+  inferItemPoints,
+  summarizeCapacity,
+  buildDayLoadPointsMap,
+  nextWeekendDateByCapacity,
+  deriveSprintCapacityPoints,
+};

--- a/functions/services/schedulingService.js
+++ b/functions/services/schedulingService.js
@@ -1,0 +1,666 @@
+const admin = require('firebase-admin');
+const { DateTime } = require('luxon');
+const { normalizeThemeAllocationPlan, resolveThemeAllocationsForDate } = require('../lib/themeAllocations');
+const { inferItemPoints, startOfDayMs, toMillis } = require('./capacityService');
+
+const DEFAULT_ZONE = 'Europe/London';
+const MIN_BLOCK_MS = 15 * 60 * 1000;
+const DEFAULT_SEARCH_DAYS = 14;
+
+const THEME_RULES = [
+  { match: ['growth'], slots: [{ days: [1, 2, 3, 4, 5], start: 7, end: 9, label: 'Growth AM' }, { days: [1, 2, 3, 4, 5], start: 17, end: 19, label: 'Growth PM' }] },
+  { match: ['finance', 'wealth'], slots: [{ days: [1, 2, 3, 4, 5], start: 18, end: 21, label: 'Wealth weekday evening' }, { days: [6, 7], start: 9, end: 12, label: 'Wealth weekend AM' }, { days: [6, 7], start: 13, end: 17, label: 'Wealth weekend PM' }] },
+  { match: ['side gig', 'side-gig', 'sidegig'], slots: [{ days: [1, 2, 3, 4, 5], start: 18, end: 22, label: 'Side gig evenings' }, { days: [6, 7], start: 10, end: 16, label: 'Side gig weekend' }] },
+  { match: ['hobby', 'hobbies'], slots: [{ days: [1, 2, 3, 4, 5, 6, 7], start: 18, end: 22, label: 'Hobbies evenings' }] },
+  { match: ['game', 'gaming', 'tv'], slots: [{ days: [5, 6], start: 19, end: 23, label: 'Gaming/TV Fri/Sat evening' }] },
+  { match: ['health'], slots: [{ days: [1, 2, 3, 4, 5], start: 6, end: 20, label: 'Health focus' }] },
+  { match: ['learning', 'spiritual'], slots: [{ days: [1, 2, 3, 4, 5], start: 6, end: 20, label: 'Growth/Learning' }] },
+];
+
+const FALLBACK_SLOTS = [
+  { days: [1, 2, 3, 4, 5, 6, 7], start: 8, end: 12, label: 'Fallback AM' },
+  { days: [1, 2, 3, 4, 5, 6, 7], start: 13, end: 17, label: 'Fallback PM' },
+  { days: [1, 2, 3, 4, 5, 6, 7], start: 18, end: 22, label: 'Fallback evening' },
+];
+
+function resolvePlanningMode(profile, requestedMode) {
+  const fromReq = String(requestedMode || '').toLowerCase();
+  const fromProfile = String(profile?.plannerMode || '').toLowerCase();
+  return (fromReq || fromProfile) === 'strict' ? 'strict' : 'smart';
+}
+
+function normalizeBucket(value) {
+  const raw = String(value || '').trim().toLowerCase();
+  return raw === 'morning' || raw === 'afternoon' || raw === 'evening' || raw === 'anytime' ? raw : null;
+}
+
+function toMinutes(hhmm) {
+  const [h = '0', m = '0'] = String(hhmm || '0:0').split(':');
+  return (Number(h) * 60) + Number(m);
+}
+
+function isMainGigLabel(value) {
+  const raw = String(value || '').toLowerCase();
+  if (!raw) return false;
+  if (raw.includes('workout')) return false;
+  if (raw.includes('main gig') || raw.includes('work shift')) return true;
+  return /\bwork\b/.test(raw);
+}
+
+function isMainGigBlock(block) {
+  if (!block) return false;
+  if (block.entityType === 'work_shift' || block.sourceType === 'work_shift_allocation') return true;
+  const label = block.theme || block.category || block.title || '';
+  return isMainGigLabel(label);
+}
+
+function isUserGcalEvent(block) {
+  const source = String(block?.source || block?.sourceType || '').toLowerCase();
+  return source === 'gcal' || source === 'google_calendar' || block?.createdBy === 'google';
+}
+
+function isFitnessBlock(block) {
+  const label = String(block?.theme || block?.category || block?.title || '').toLowerCase();
+  return label.includes('health') || label.includes('fitness') || label.includes('gym')
+    || label.includes('workout') || label.includes('exercise') || label.includes('run')
+    || label.includes('swim') || label.includes('cycle') || label.includes('sport');
+}
+
+function findFreeGapsInSlot(slotStartMs, slotEndMs, busyList, minGapMs = MIN_BLOCK_MS) {
+  const overlaps = busyList
+    .filter((b) => b.end > slotStartMs && b.start < slotEndMs)
+    .sort((a, b) => a.start - b.start);
+  const gaps = [];
+  let cursor = slotStartMs;
+  for (const overlap of overlaps) {
+    if (overlap.start > cursor && overlap.start - cursor >= minGapMs) {
+      gaps.push({ start: cursor, end: Math.min(overlap.start, slotEndMs) });
+    }
+    cursor = Math.max(cursor, overlap.end);
+    if (cursor >= slotEndMs) break;
+  }
+  if (slotEndMs - cursor >= minGapMs) {
+    gaps.push({ start: cursor, end: slotEndMs });
+  }
+  return gaps;
+}
+
+function buildPickSlots(themeAllocationPlan) {
+  const getUserSlots = (themeLabel, day) => {
+    const label = String(themeLabel || '').trim().toLowerCase();
+    if (!label) return [];
+    const dayAllocations = resolveThemeAllocationsForDate(themeAllocationPlan, day, day.zoneName);
+    const matches = dayAllocations.filter((allocation) => {
+      if (allocation.dayOfWeek !== day.weekday % 7) return false;
+      const allocationTheme = String(allocation.theme || '').trim().toLowerCase();
+      return allocationTheme && (allocationTheme === label || label.includes(allocationTheme) || allocationTheme.includes(label));
+    });
+    return matches.map((allocation) => {
+      const startMinutes = toMinutes(allocation.startTime);
+      const endMinutes = toMinutes(allocation.endTime);
+      return {
+        days: [day.weekday],
+        start: startMinutes / 60,
+        end: endMinutes / 60,
+        label: `Theme block: ${allocation.theme}`,
+      };
+    });
+  };
+
+  const pickSlots = (themeLabel, day) => {
+    const userSlots = getUserSlots(themeLabel, day);
+    if (userSlots.length) return userSlots;
+    const key = String(themeLabel || '').trim().toLowerCase();
+    for (const rule of THEME_RULES) {
+      if (rule.match.some((match) => key.includes(match))) return rule.slots;
+    }
+    return FALLBACK_SLOTS;
+  };
+
+  return { pickSlots };
+}
+
+function filterSlotsByTimeOfDay(slots, timeOfDay) {
+  const normalized = normalizeBucket(timeOfDay);
+  if (!normalized || normalized === 'anytime') return slots;
+  const filtered = slots.filter((slot) => {
+    const hour = Number(slot.start);
+    if (normalized === 'morning') return hour >= 5 && hour < 13;
+    if (normalized === 'afternoon') return hour >= 13 && hour < 19;
+    if (normalized === 'evening') return hour >= 19 || hour < 5;
+    return true;
+  });
+  return filtered.length ? filtered : slots;
+}
+
+function inferDurationMinutes(itemType, entity, existingBlock, requestedMinutes) {
+  const requested = Number(requestedMinutes || 0);
+  if (Number.isFinite(requested) && requested >= 15) return Math.round(requested);
+  const blockDuration = Number(existingBlock?.end || 0) - Number(existingBlock?.start || 0);
+  if (Number.isFinite(blockDuration) && blockDuration >= MIN_BLOCK_MS) {
+    return Math.max(15, Math.round(blockDuration / 60000));
+  }
+  const estimateMin = Number(entity?.estimateMin || 0);
+  if (Number.isFinite(estimateMin) && estimateMin > 0) return Math.max(15, Math.round(estimateMin));
+  return Math.max(15, Math.round(inferItemPoints(itemType, entity) * 60));
+}
+
+function buildBusyIntervals(blocks, { planningMode, persona, excludedBlockIds }) {
+  const busy = [];
+  blocks.forEach((block) => {
+    const blockId = String(block?.id || '').trim();
+    if (blockId && excludedBlockIds.has(blockId)) return;
+    const start = Number(block?.start || 0);
+    const end = Number(block?.end || 0);
+    if (!(start > 0) || !(end > start)) return;
+    if (planningMode === 'strict') {
+      busy.push({ start, end });
+      return;
+    }
+    if (persona === 'work' && isMainGigBlock(block)) return;
+    busy.push({ start, end });
+  });
+  return busy;
+}
+
+function formatTimeString(ms, zone) {
+  return DateTime.fromMillis(ms, { zone }).toFormat('HH:mm');
+}
+
+function plannerWeekStartMs(ms, zone) {
+  return DateTime.fromMillis(ms, { zone }).startOf('week').startOf('day').toMillis();
+}
+
+function plannerWeekKey(ms, zone) {
+  return DateTime.fromMillis(ms, { zone }).startOf('week').toISODate();
+}
+
+async function loadCalendarBlocksForWindow(db, userId, startMs, endMs) {
+  try {
+    const snap = await db.collection('calendar_blocks')
+      .where('ownerUid', '==', userId)
+      .where('start', '<=', endMs)
+      .get();
+    return snap.docs
+      .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }))
+      .filter((row) => {
+        const start = Number(row.start || 0);
+        const end = Number(row.end || 0);
+        return Number.isFinite(start) && Number.isFinite(end) && end >= startMs && start <= endMs;
+      });
+  } catch (_) {
+    const fallback = await db.collection('calendar_blocks')
+      .where('ownerUid', '==', userId)
+      .get()
+      .catch(() => ({ docs: [] }));
+    return fallback.docs
+      .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }))
+      .filter((row) => {
+        const start = Number(row.start || 0);
+        return Number.isFinite(start) && start >= startMs && start <= endMs;
+      });
+  }
+}
+
+async function loadRelatedBlocks(db, userId, itemType, itemId) {
+  const field = itemType === 'task' ? 'taskId' : 'storyId';
+  try {
+    const snap = await db.collection('calendar_blocks')
+      .where('ownerUid', '==', userId)
+      .where(field, '==', itemId)
+      .get();
+    return snap.docs.map((docSnap) => ({ id: docSnap.id, ref: docSnap.ref, ...(docSnap.data() || {}) }));
+  } catch (_) {
+    const fallback = await db.collection('calendar_blocks')
+      .where('ownerUid', '==', userId)
+      .get()
+      .catch(() => ({ docs: [] }));
+    return fallback.docs
+      .map((docSnap) => ({ id: docSnap.id, ref: docSnap.ref, ...(docSnap.data() || {}) }))
+      .filter((row) => String(row[field] || '').trim() === itemId);
+  }
+}
+
+async function resolveSprintIdForDate(db, userId, dateMs) {
+  const snap = await db.collection('sprints').where('ownerUid', '==', userId).get().catch(() => ({ docs: [] }));
+  const exact = snap.docs.find((docSnap) => {
+    const data = docSnap.data() || {};
+    const start = toMillis(data.startDate || data.start);
+    const end = toMillis(data.endDate || data.end);
+    return Number.isFinite(start) && Number.isFinite(end) && start <= dateMs && end >= dateMs;
+  });
+  return exact?.id || null;
+}
+
+function choosePlacement({
+  targetDateMs,
+  targetBucket,
+  durationMinutes,
+  busyIntervals,
+  pickSlots,
+  themeLabel,
+  zone,
+  searchDays,
+  maxTargetDateMs = null,
+}) {
+  const baseDay = DateTime.fromMillis(targetDateMs, { zone }).startOf('day');
+  const durationMs = Math.max(MIN_BLOCK_MS, Math.round(durationMinutes) * 60 * 1000);
+  const requestedBucket = normalizeBucket(targetBucket);
+
+  for (let offset = 0; offset < searchDays; offset += 1) {
+    const day = baseDay.plus({ days: offset });
+    if (Number.isFinite(maxTargetDateMs) && day.toMillis() > Number(maxTargetDateMs)) break;
+    const slots = filterSlotsByTimeOfDay(pickSlots(themeLabel, day), targetBucket);
+    for (const slot of slots) {
+      const slotDays = Array.isArray(slot.days) && slot.days.length ? slot.days : [1, 2, 3, 4, 5, 6, 7];
+      if (!slotDays.includes(day.weekday)) continue;
+      const slotStart = day.set({
+        hour: Math.floor(Number(slot.start || 0)),
+        minute: Math.round((Number(slot.start || 0) % 1) * 60),
+        second: 0,
+        millisecond: 0,
+      }).toMillis();
+      const slotEnd = day.set({
+        hour: Math.floor(Number(slot.end || 0)),
+        minute: Math.round((Number(slot.end || 0) % 1) * 60),
+        second: 0,
+        millisecond: 0,
+      }).toMillis();
+      const gaps = findFreeGapsInSlot(slotStart, slotEnd, busyIntervals, durationMs);
+      const chosenGap = gaps.find((gap) => gap.end - gap.start >= durationMs);
+      if (!chosenGap) continue;
+      let appliedBucket = requestedBucket;
+      if (!appliedBucket) {
+        const lowerLabel = String(slot.label || '').toLowerCase();
+        if (lowerLabel.includes('evening')) appliedBucket = 'evening';
+        else if (lowerLabel.includes('afternoon') || lowerLabel.includes('pm')) appliedBucket = 'afternoon';
+        else if (lowerLabel.includes('morning') || lowerLabel.includes('am')) appliedBucket = 'morning';
+        else appliedBucket = 'anytime';
+      }
+      return {
+        appliedStartMs: chosenGap.start,
+        appliedEndMs: chosenGap.start + durationMs,
+        appliedBucket,
+      };
+    }
+  }
+
+  return null;
+}
+
+function chooseSplitPlacements({
+  targetDateMs,
+  targetBucket,
+  durationMinutes,
+  busyIntervals,
+  pickSlots,
+  themeLabel,
+  zone,
+  searchDays,
+  maxTargetDateMs = null,
+}) {
+  const baseDay = DateTime.fromMillis(targetDateMs, { zone }).startOf('day');
+  let remainingMs = Math.max(MIN_BLOCK_MS, Math.round(durationMinutes) * 60 * 1000);
+  const placements = [];
+  const mutableBusy = Array.isArray(busyIntervals) ? [...busyIntervals] : [];
+  const requestedBucket = normalizeBucket(targetBucket);
+
+  for (let offset = 0; offset < searchDays && remainingMs > 0; offset += 1) {
+    const day = baseDay.plus({ days: offset });
+    if (Number.isFinite(maxTargetDateMs) && day.toMillis() > Number(maxTargetDateMs)) break;
+    const slots = filterSlotsByTimeOfDay(pickSlots(themeLabel, day), targetBucket);
+    for (const slot of slots) {
+      if (remainingMs <= 0) break;
+      const slotDays = Array.isArray(slot.days) && slot.days.length ? slot.days : [1, 2, 3, 4, 5, 6, 7];
+      if (!slotDays.includes(day.weekday)) continue;
+      const slotStart = day.set({
+        hour: Math.floor(Number(slot.start || 0)),
+        minute: Math.round((Number(slot.start || 0) % 1) * 60),
+        second: 0,
+        millisecond: 0,
+      }).toMillis();
+      const slotEnd = day.set({
+        hour: Math.floor(Number(slot.end || 0)),
+        minute: Math.round((Number(slot.end || 0) % 1) * 60),
+        second: 0,
+        millisecond: 0,
+      }).toMillis();
+      const gaps = findFreeGapsInSlot(slotStart, slotEnd, mutableBusy, MIN_BLOCK_MS);
+      for (const gap of gaps) {
+        if (remainingMs <= 0) break;
+        const gapMs = gap.end - gap.start;
+        if (gapMs < MIN_BLOCK_MS) continue;
+        const blockMs = Math.min(gapMs, remainingMs);
+        let appliedBucket = requestedBucket;
+        if (!appliedBucket) {
+          const lowerLabel = String(slot.label || '').toLowerCase();
+          if (lowerLabel.includes('evening')) appliedBucket = 'evening';
+          else if (lowerLabel.includes('afternoon') || lowerLabel.includes('pm')) appliedBucket = 'afternoon';
+          else if (lowerLabel.includes('morning') || lowerLabel.includes('am')) appliedBucket = 'morning';
+          else appliedBucket = 'anytime';
+        }
+        placements.push({
+          appliedStartMs: gap.start,
+          appliedEndMs: gap.start + blockMs,
+          appliedBucket,
+        });
+        mutableBusy.push({ start: gap.start, end: gap.start + blockMs });
+        remainingMs -= blockMs;
+      }
+    }
+  }
+
+  return placements;
+}
+
+async function logSchedulingActivity({
+  db,
+  ownerUid,
+  entityId,
+  entityType,
+  referenceNumber,
+  persona,
+  description,
+  metadata,
+  oldSprintId,
+  newSprintId,
+}) {
+  await db.collection('activity_stream').add({
+    entityId,
+    entityType,
+    activityType: oldSprintId !== newSprintId ? 'sprint_changed' : 'updated',
+    ownerUid,
+    userId: ownerUid,
+    actor: 'planner_schedule_service',
+    description,
+    persona: persona || null,
+    referenceNumber: referenceNumber || null,
+    source: 'function',
+    sourceDetails: 'schedulePlannerItem',
+    metadata,
+    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+}
+
+async function schedulePlannerItemMutation({
+  db,
+  userId,
+  itemType,
+  itemId,
+  targetDateMs,
+  targetBucket,
+  intent = 'move',
+  source = 'planner',
+  rationale = null,
+  linkedBlockId = null,
+  targetSprintId = null,
+  durationMinutes = null,
+  planningMode = null,
+  searchDays = null,
+  maxTargetDateMs = null,
+  allowSplit = false,
+  debugRequestId = null,
+}) {
+  const logContext = {
+    debugRequestId: debugRequestId || null,
+    userId,
+    itemType,
+    itemId,
+    intent,
+    source,
+    targetDateMs,
+    targetBucket: normalizeBucket(targetBucket),
+    linkedBlockId: linkedBlockId || null,
+    targetSprintId: targetSprintId || null,
+    planningMode: planningMode || null,
+    searchDays: searchDays || null,
+    maxTargetDateMs: maxTargetDateMs || null,
+    allowSplit: allowSplit === true,
+  };
+  const normalizedType = String(itemType || '').trim().toLowerCase();
+  if (normalizedType !== 'task' && normalizedType !== 'story') {
+    throw new Error('schedulePlannerItem only supports tasks and stories in this slice.');
+  }
+  const targetMs = Number(targetDateMs || 0);
+  if (!Number.isFinite(targetMs) || targetMs <= 0) {
+    throw new Error('A valid targetDateMs is required.');
+  }
+
+  const profileSnap = await db.collection('profiles').doc(userId).get().catch(() => null);
+  const profile = profileSnap && profileSnap.exists ? (profileSnap.data() || {}) : {};
+  const zone = String(profile?.timezone || profile?.timeZone || DEFAULT_ZONE);
+  const effectivePlanningMode = resolvePlanningMode(profile, planningMode);
+
+  const entityRef = db.collection(normalizedType === 'task' ? 'tasks' : 'stories').doc(itemId);
+  const entitySnap = await entityRef.get();
+  if (!entitySnap.exists) throw new Error(`${normalizedType} not found.`);
+  const entity = entitySnap.data() || {};
+  if (String(entity.ownerUid || '') !== userId) throw new Error('Permission denied for this item.');
+  console.info('[schedulePlannerItemMutation] start', {
+    ...logContext,
+    entityPersona: entity.persona || null,
+    entityTheme: entity.theme || entity.category || null,
+    entityGoalId: entity.goalId || null,
+    entitySprintId: entity.sprintId || null,
+  });
+
+  const relatedBlocks = await loadRelatedBlocks(db, userId, normalizedType, itemId);
+  const explicitBlock = linkedBlockId ? relatedBlocks.find((block) => block.id === linkedBlockId) || null : null;
+  const primaryBlock = explicitBlock || relatedBlocks
+    .slice()
+    .sort((a, b) => Math.abs(Number(a.start || 0) - targetMs) - Math.abs(Number(b.start || 0) - targetMs))[0] || null;
+
+  const effectiveDurationMinutes = inferDurationMinutes(normalizedType, entity, primaryBlock, durationMinutes);
+  const windowStartMs = startOfDayMs(targetMs);
+  const windowEndMs = windowStartMs + (DEFAULT_SEARCH_DAYS * 24 * 60 * 60 * 1000) - 1;
+  const allBlocks = await loadCalendarBlocksForWindow(db, userId, windowStartMs, windowEndMs);
+  const excludedBlockIds = new Set(relatedBlocks.map((block) => block.id).filter(Boolean));
+  const persona = String(entity.persona || 'personal').toLowerCase() === 'work' ? 'work' : 'personal';
+  const themeLabel = entity.theme || entity.category || null;
+  const themePlanSnap = await db.collection('theme_allocations').doc(userId).get().catch(() => null);
+  const themePlan = normalizeThemeAllocationPlan(themePlanSnap && themePlanSnap.exists ? (themePlanSnap.data() || {}) : {});
+  const { pickSlots } = buildPickSlots(themePlan);
+  const normalizedSearchDays = Math.max(1, Math.min(Number(searchDays || DEFAULT_SEARCH_DAYS), 84));
+  const busyIntervals = buildBusyIntervals(allBlocks, { planningMode: effectivePlanningMode, persona, excludedBlockIds });
+  const placements = allowSplit
+    ? chooseSplitPlacements({
+        targetDateMs: targetMs,
+        targetBucket,
+        durationMinutes: effectiveDurationMinutes,
+        busyIntervals,
+        pickSlots,
+        themeLabel,
+        zone,
+        searchDays: normalizedSearchDays,
+        maxTargetDateMs: Number.isFinite(Number(maxTargetDateMs)) ? Number(maxTargetDateMs) : null,
+      })
+    : (() => {
+        const single = choosePlacement({
+          targetDateMs: targetMs,
+          targetBucket,
+          durationMinutes: effectiveDurationMinutes,
+          busyIntervals,
+          pickSlots,
+          themeLabel,
+          zone,
+          searchDays: normalizedSearchDays,
+          maxTargetDateMs: Number.isFinite(Number(maxTargetDateMs)) ? Number(maxTargetDateMs) : null,
+        });
+        return single ? [single] : [];
+      })();
+
+  if (!placements.length) {
+    console.warn('[schedulePlannerItemMutation] no-placement', {
+      ...logContext,
+      effectivePlanningMode,
+      busyIntervals: busyIntervals.length,
+      relatedBlocks: relatedBlocks.length,
+      durationMinutes: effectiveDurationMinutes,
+      persona,
+      themeLabel,
+    });
+    throw new Error('No feasible slot was available without conflicting with current calendar constraints.');
+  }
+
+  const firstPlacement = placements[0];
+  const lastPlacement = placements[placements.length - 1];
+  const totalScheduledMinutes = placements.reduce((sum, placement) => (
+    sum + Math.max(0, Math.round((placement.appliedEndMs - placement.appliedStartMs) / 60000))
+  ), 0);
+  const appliedDayMs = startOfDayMs(firstPlacement.appliedStartMs);
+  const appliedWeekStartMs = plannerWeekStartMs(appliedDayMs, zone);
+  const appliedWeekKey = plannerWeekKey(appliedDayMs, zone);
+  const resolvedSprintId = targetSprintId || await resolveSprintIdForDate(db, userId, appliedDayMs);
+  const timeString = formatTimeString(firstPlacement.appliedStartMs, zone);
+  const oldSprintId = String(entity.sprintId || '');
+  const splitGroupId = db.collection('_').doc().id;
+  const reusableBlocks = [primaryBlock, ...relatedBlocks.filter((block) => !primaryBlock || block.id !== primaryBlock.id)].filter(Boolean);
+
+  const entityPatch = normalizedType === 'task'
+    ? {
+        dueDate: lastPlacement.appliedEndMs,
+        dueDateMs: lastPlacement.appliedEndMs,
+        scheduledTime: timeString,
+        actualScheduledStart: firstPlacement.appliedStartMs,
+        timeOfDay: firstPlacement.appliedBucket,
+        plannedWeekKey: appliedWeekKey,
+        plannedWeekStart: appliedWeekStartMs,
+        sprintId: resolvedSprintId || null,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }
+    : {
+        targetDate: lastPlacement.appliedEndMs,
+        dueDate: lastPlacement.appliedEndMs,
+        plannedStartDate: firstPlacement.appliedStartMs,
+        plannedTime: timeString,
+        actualScheduledStart: firstPlacement.appliedStartMs,
+        timeOfDay: firstPlacement.appliedBucket,
+        plannedWeekKey: appliedWeekKey,
+        plannedWeekStart: appliedWeekStartMs,
+        sprintId: resolvedSprintId || null,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      };
+
+  if (intent === 'defer') {
+    entityPatch.deferredUntil = appliedDayMs;
+    entityPatch.deferredReason = rationale || null;
+    entityPatch.deferredBy = source || 'planner';
+    entityPatch.deferredAt = admin.firestore.FieldValue.serverTimestamp();
+  } else {
+    entityPatch.deferredUntil = null;
+    entityPatch.deferredReason = null;
+    entityPatch.deferredBy = null;
+  }
+
+  const batch = db.batch();
+  const usedBlockIds = new Set();
+  placements.forEach((placement, index) => {
+    const reusable = reusableBlocks[index] || null;
+    const blockRef = reusable?.ref || db.collection('calendar_blocks').doc();
+    const blockPayload = {
+      ownerUid: userId,
+      title: String(entity.title || reusable?.title || normalizedType).trim(),
+      start: placement.appliedStartMs,
+      end: placement.appliedEndMs,
+      entityType: normalizedType,
+      sourceType: normalizedType,
+      source: reusable?.source || 'planner_schedule_service',
+      status: 'planned',
+      aiGenerated: reusable?.aiGenerated !== false,
+      taskId: normalizedType === 'task' ? itemId : null,
+      storyId: normalizedType === 'story' ? itemId : null,
+      goalId: entity.goalId || reusable?.goalId || null,
+      theme: entity.theme || reusable?.theme || null,
+      persona,
+      rationale: rationale || null,
+      syncToGoogle: true,
+      splitGroupId,
+      splitIndex: index,
+      splitCount: placements.length,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdAt: reusable?.createdAt || admin.firestore.FieldValue.serverTimestamp(),
+    };
+    batch.set(blockRef, blockPayload, { merge: true });
+    usedBlockIds.add(blockRef.id);
+  });
+  batch.set(entityRef, entityPatch, { merge: true });
+
+  relatedBlocks
+    .filter((block) => !usedBlockIds.has(block.id))
+    .filter((block) => block.aiGenerated === true || String(block.source || '').includes('planner') || String(block.source || '').includes('scheduler'))
+    .forEach((block) => {
+      batch.delete(db.collection('calendar_blocks').doc(block.id));
+    });
+
+  await batch.commit();
+  console.info('[schedulePlannerItemMutation] committed', {
+    ...logContext,
+    effectivePlanningMode,
+    durationMinutes: effectiveDurationMinutes,
+    persona,
+    themeLabel,
+    placementCount: placements.length,
+    placements: placements.map((placement) => ({
+      appliedStartMs: placement.appliedStartMs,
+      appliedEndMs: placement.appliedEndMs,
+      appliedBucket: placement.appliedBucket,
+    })),
+    usedBlockIds: Array.from(usedBlockIds),
+    splitGroupId,
+    resolvedSprintId: resolvedSprintId || null,
+  });
+
+  const activityPlacement = firstPlacement;
+  const description = intent === 'defer'
+    ? `Deferred to ${DateTime.fromMillis(activityPlacement.appliedStartMs, { zone }).toFormat('dd LLL yyyy HH:mm')} (${activityPlacement.appliedBucket}) via ${source}.`
+    : `Moved to ${DateTime.fromMillis(activityPlacement.appliedStartMs, { zone }).toFormat('dd LLL yyyy HH:mm')} (${activityPlacement.appliedBucket}) via ${source}.`;
+  await logSchedulingActivity({
+    db,
+    ownerUid: userId,
+    entityId: itemId,
+    entityType: normalizedType,
+    referenceNumber: entity.ref || entity.referenceNumber || null,
+    persona,
+    description,
+    metadata: {
+      source,
+      rationale: rationale || null,
+      planningMode: effectivePlanningMode,
+      requestedTargetDateMs: targetMs,
+      requestedBucket: normalizeBucket(targetBucket),
+      appliedStartMs: firstPlacement.appliedStartMs,
+      appliedEndMs: lastPlacement.appliedEndMs,
+      appliedBucket: firstPlacement.appliedBucket,
+      appliedWeekKey,
+      appliedWeekStartMs,
+      blockCount: placements.length,
+      scheduledMinutes: totalScheduledMinutes,
+      splitGroupId,
+      sprintId: resolvedSprintId || null,
+    },
+    oldSprintId,
+    newSprintId: resolvedSprintId || '',
+  });
+
+  return {
+    ok: true,
+    debugRequestId: debugRequestId || null,
+    planningMode: effectivePlanningMode,
+    appliedStartMs: firstPlacement.appliedStartMs,
+    appliedEndMs: lastPlacement.appliedEndMs,
+    appliedDayMs,
+    appliedBucket: firstPlacement.appliedBucket,
+    appliedWeekKey,
+    appliedWeekStartMs,
+    scheduledMinutes: totalScheduledMinutes,
+    blockCount: placements.length,
+    sprintId: resolvedSprintId || null,
+    blockId: Array.from(usedBlockIds)[0] || null,
+  };
+}
+
+module.exports = {
+  schedulePlannerItemMutation,
+};

--- a/react-app/src/components/DailyPlanPage.tsx
+++ b/react-app/src/components/DailyPlanPage.tsx
@@ -1,174 +1,169 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Alert, Badge, Button, Card, Container, ListGroup } from 'react-bootstrap';
-import { collection, doc, getDoc, onSnapshot, query, serverTimestamp, updateDoc, where } from 'firebase/firestore';
-import { CalendarPlus, Check, Clock3, Target } from 'lucide-react';
-import { db } from '../firebase';
+import { Alert, Badge, Button, Card, Container, Form, Modal } from 'react-bootstrap';
+import { collection, doc, getDoc, limit, onSnapshot, orderBy, query, serverTimestamp, setDoc, updateDoc, where } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
+import { format } from 'date-fns';
+import { bucketLabel, bucketOrder, type TimelineBucket } from '../utils/timelineBuckets';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { db, functions } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
 import { usePersona } from '../contexts/PersonaContext';
 import { useSprint } from '../contexts/SprintContext';
-import { Goal, Story, Task } from '../types';
-import { isRecurringDueOnDate, resolveTaskDueMs } from '../utils/recurringTaskDue';
+import { useSidebar } from '../contexts/SidebarContext';
+import type { Goal, Sprint, Story, Task } from '../types';
+import { ChoiceHelper } from '../config/choices';
 import DeferItemModal from './DeferItemModal';
-import EditTaskModal from './EditTaskModal';
 import EditStoryModal from './EditStoryModal';
-import NewCalendarEventModal, { BlockFormState, toInputValue } from './planner/NewCalendarEventModal';
+import EditTaskModal from './EditTaskModal';
+import NewCalendarEventModal, { type BlockFormState, toInputValue } from './planner/NewCalendarEventModal';
+import PlannerWorkCard from './planner/PlannerWorkCard';
 import { useFocusGoals } from '../hooks/useFocusGoals';
-import { getActiveFocusLeafGoalIds, getGoalAncestors, getGoalDisplayPath } from '../utils/goalHierarchy';
+import {
+  buildPlannerItems,
+  normalizeStoryStatus,
+  toDayKey,
+  toMs,
+  type PlannerCalendarBlockRow,
+  type PlannerItem,
+  type PlannerScheduledInstanceRow,
+  type PlannerSummaryEvent,
+} from '../utils/plannerItems';
+import { getActiveFocusLeafGoalIds } from '../utils/goalHierarchy';
 import { isFreshTimestamp } from '../utils/kpiFreshness';
+import { buildPlannerRecommendation, type PlannerRecommendation } from '../utils/plannerRecommendations';
+import CheckInDaily from './checkins/CheckInDaily';
+import { buildDayCapacityMap, plannerItemPoints } from '../utils/plannerCapacity';
+import { schedulePlannerItem as schedulePlannerItemMutation } from '../utils/plannerScheduling';
 
-type TimelineBucket = 'morning' | 'afternoon' | 'evening';
-type TimelineFilter = 'task' | 'story' | 'chore' | 'event' | 'top3' | 'review' | null;
+type TimelineFilter = 'task' | 'story' | 'chore' | 'focus' | 'review' | 'top3' | null;
+type DailyPlanMode = 'list' | 'plan' | 'review' | 'checkin';
 
-type TimelineItem = {
+type DeferTarget = {
+  type: 'task' | 'story';
   id: string;
-  kind: 'task' | 'story' | 'chore' | 'event';
   title: string;
-  ref: string | null;
-  timeLabel: string;
-  sortMs: number | null;
-  bucket: TimelineBucket;
-  sourceId?: string;
-  isTop3?: boolean;
-  deferredUntilMs?: number | null;
-  goalTitle: string | null;
-  goalTheme: string | null;
   isFocusAligned: boolean;
-  rawTask: Task | null;
-  rawStory: Story | null;
-  scheduledBlockStart: number | null;
-  scheduledBlockEnd: number | null;
 };
 
-type CalendarBlockRow = {
-  id: string;
-  title?: string;
-  start?: number;
-  end?: number;
-  taskId?: string | null;
-  storyId?: string | null;
-  linkedStoryId?: string | null;
+const dayStartMs = (date: Date | number) => {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+  return next.getTime();
 };
 
-type ScheduledInstanceRow = {
-  id: string;
-  ownerUid: string;
-  sourceType?: string | null;
-  sourceId?: string | null;
-  occurrenceDate?: string | null;
-  status?: string | null;
-  updatedAt?: number | null;
-};
-
-const bucketOrder: TimelineBucket[] = ['morning', 'afternoon', 'evening'];
-
-const bucketLabel = (bucket: TimelineBucket) => (
-  bucket === 'morning' ? 'Morning' : bucket === 'afternoon' ? 'Afternoon' : 'Evening'
+const createPlannerActionId = (prefix: 'move' | 'defer') => (
+  `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 );
 
-const toMs = (value: any): number | null => {
-  if (value == null) return null;
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (value instanceof Date) return value.getTime();
-  if (typeof value?.toDate === 'function') {
-    try {
-      return value.toDate().getTime();
-    } catch {
-      return null;
-    }
+const nextSprintForDate = (sprints: Sprint[], afterMs: number) =>
+  [...sprints]
+    .filter((sprint) => Number(sprint.startDate || 0) > afterMs)
+    .sort((a, b) => Number(a.startDate || 0) - Number(b.startDate || 0))[0] || null;
+
+const extractSummaryEvents = (summary: any): PlannerSummaryEvent[] => {
+  const candidates = [summary?.calendar?.events, summary?.eventsToday, summary?.upcomingEvents, summary?.calendarEvents, summary?.dailyBrief?.calendar];
+  for (const candidate of candidates) {
+    if (!Array.isArray(candidate) || candidate.length === 0) continue;
+    const mapped = candidate
+      .map((item: any, index: number) => {
+        const title = String(item?.title || item?.summary || item?.name || '').trim();
+        if (!title) return null;
+        return {
+          id: String(item?.id || item?.eventId || `${title}-${index}`),
+          title,
+          startMs: toMs(item?.start ?? item?.startAt ?? item?.startDate ?? item?.when),
+          endMs: toMs(item?.end ?? item?.endAt ?? item?.endDate),
+        };
+      })
+      .filter(Boolean) as PlannerSummaryEvent[];
+    if (mapped.length > 0) return mapped;
   }
-  const parsed = Date.parse(String(value));
-  return Number.isNaN(parsed) ? null : parsed;
+  return [];
 };
 
-const isDoneStatus = (value: any): boolean => {
-  if (typeof value === 'number') return value >= 2;
-  const raw = String(value || '').trim().toLowerCase();
-  return raw === 'done' || raw === 'complete' || raw === 'completed' || raw === 'archived';
+const getAutoMode = ({
+  isMobile,
+  reviewDone,
+  reviewCount,
+  hour,
+}: {
+  isMobile: boolean;
+  reviewDone: boolean;
+  reviewCount: number;
+  hour: number;
+}): DailyPlanMode => {
+  if (hour >= 19) return 'checkin';
+  if (!reviewDone && reviewCount > 0 && hour < 13) return 'review';
+  return isMobile ? 'list' : 'plan';
 };
-
-const normalizeStoryStatus = (value: any): number => {
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  const raw = String(value || '').trim().toLowerCase();
-  if (raw === 'done' || raw === 'complete' || raw === 'completed') return 4;
-  if (raw === 'testing' || raw === 'qa' || raw === 'review') return 3;
-  if (raw === 'in progress' || raw === 'in-progress' || raw === 'active' || raw === 'doing' || raw === 'blocked') return 2;
-  if (raw === 'planned' || raw === 'ready') return 1;
-  return 0;
-};
-
-const getChoreKind = (task: Task): 'chore' | 'routine' | 'habit' | null => {
-  const raw = String((task as any)?.type || (task as any)?.task_type || '').trim().toLowerCase();
-  const normalized = raw === 'habitual' ? 'habit' : raw;
-  if (normalized === 'chore' || normalized === 'routine' || normalized === 'habit') return normalized;
-  return null;
-};
-
-const bucketFromTime = (ms: number | null | undefined, timeOfDay?: string | null): TimelineBucket => {
-  const tod = String(timeOfDay || '').toLowerCase().trim();
-  if (tod === 'morning' || tod === 'afternoon' || tod === 'evening') return tod as TimelineBucket;
-  if (!ms || !Number.isFinite(ms)) return 'morning';
-  const date = new Date(ms);
-  const minute = date.getHours() * 60 + date.getMinutes();
-  if (minute >= 300 && minute <= 779) return 'morning';
-  if (minute >= 780 && minute <= 1139) return 'afternoon';
-  return 'evening';
-};
-
-const bucketPseudoTime = (dayStartMs: number, bucket: TimelineBucket) => {
-  if (bucket === 'morning') return dayStartMs + (9 * 60 * 60 * 1000);
-  if (bucket === 'afternoon') return dayStartMs + (14 * 60 * 60 * 1000);
-  return dayStartMs + (19.5 * 60 * 60 * 1000);
-};
-
-const formatTimeLabel = (startMs: number | null | undefined, endMs?: number | null, timeOfDay?: string | null): string => {
-  if (!startMs || !Number.isFinite(startMs)) {
-    return `Unscheduled (${bucketLabel(bucketFromTime(null, timeOfDay))})`;
-  }
-  const start = new Date(startMs);
-  const startLabel = start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  if (endMs && Number.isFinite(endMs)) {
-    const end = new Date(endMs);
-    const endLabel = end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    return `${startLabel} - ${endLabel}`;
-  }
-  return startLabel;
-};
-
-const resolveTaskRef = (task: Task) => task.ref || `TK-${task.id.slice(-6).toUpperCase()}`;
-const resolveStoryRef = (story: Story) => ((story as any).referenceNumber || story.ref || `ST-${story.id.slice(-6).toUpperCase()}`);
 
 const DailyPlanPage: React.FC = () => {
   const { currentUser } = useAuth();
   const { currentPersona } = usePersona();
-  const { selectedSprintId } = useSprint();
+  const { selectedSprintId, sprints } = useSprint();
   const { activeFocusGoals } = useFocusGoals(currentUser?.uid);
+  const { showSidebar } = useSidebar();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const [tasks, setTasks] = useState<Task[]>([]);
   const [stories, setStories] = useState<Story[]>([]);
   const [goals, setGoals] = useState<Goal[]>([]);
-  const [calendarBlocks, setCalendarBlocks] = useState<CalendarBlockRow[]>([]);
-  const [scheduledInstances, setScheduledInstances] = useState<ScheduledInstanceRow[]>([]);
+  const [calendarBlocks, setCalendarBlocks] = useState<PlannerCalendarBlockRow[]>([]);
+  const [scheduledInstances, setScheduledInstances] = useState<PlannerScheduledInstanceRow[]>([]);
   const [summary, setSummary] = useState<any | null>(null);
-  const [deferTarget, setDeferTarget] = useState<{ type: 'task' | 'story'; id: string; title: string } | null>(null);
-  const [morningReviewDone, setMorningReviewDone] = useState(false);
-  const [activeKindFilter, setActiveKindFilter] = useState<TimelineFilter>(null);
+  const [deferTarget, setDeferTarget] = useState<DeferTarget | null>(null);
   const [pageMessage, setPageMessage] = useState<{ variant: 'warning' | 'danger' | 'success'; text: string } | null>(null);
   const [editTask, setEditTask] = useState<Task | null>(null);
   const [editStory, setEditStory] = useState<Story | null>(null);
-  const [scheduleTarget, setScheduleTarget] = useState<TimelineItem | null>(null);
+  const [scheduleTarget, setScheduleTarget] = useState<PlannerItem | null>(null);
+  const [activeKindFilter, setActiveKindFilter] = useState<TimelineFilter>(null);
+  const [morningReviewDone, setMorningReviewDone] = useState(false);
+  const [applyingKey, setApplyingKey] = useState<string | null>(null);
+  const [isMobileLayout, setIsMobileLayout] = useState<boolean>(typeof window !== 'undefined' ? window.innerWidth < 768 : false);
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+  const [userSelectedMode, setUserSelectedMode] = useState(false);
+  const [mode, setMode] = useState<DailyPlanMode>(() => {
+    if (typeof window === 'undefined') return 'plan';
+    const params = new URLSearchParams(window.location.search);
+    const forcedTab = params.get('tab');
+    if (forcedTab === 'checkin') return 'checkin';
+    return getAutoMode({
+      isMobile: window.innerWidth < 768,
+      reviewDone: false,
+      reviewCount: 0,
+      hour: new Date().getHours(),
+    });
+  });
+  const [moveModal, setMoveModal] = useState<{ item: PlannerItem; recommendation: PlannerRecommendation | null } | null>(null);
 
-  const today = useMemo(() => new Date(), []);
-  const todayStartMs = useMemo(() => {
-    const d = new Date();
-    d.setHours(0, 0, 0, 0);
-    return d.getTime();
+  const todayStartMs = useMemo(() => dayStartMs(new Date()), []);
+  const todayEndMs = useMemo(() => todayStartMs + (24 * 60 * 60 * 1000) - 1, [todayStartMs]);
+  const todayIso = useMemo(() => new Date(todayStartMs).toISOString().slice(0, 10), [todayStartMs]);
+  const activeFocusGoalIds = useMemo(() => getActiveFocusLeafGoalIds(activeFocusGoals), [activeFocusGoals]);
+  const nextSprint = useMemo(() => nextSprintForDate(sprints as Sprint[], todayEndMs), [sprints, todayEndMs]);
+  const reviewStateId = useMemo(
+    () => (currentUser?.uid ? `${currentUser.uid}_${currentPersona || 'personal'}_${todayIso}` : null),
+    [currentUser?.uid, currentPersona, todayIso],
+  );
+
+  useEffect(() => {
+    const update = () => {
+      const mobile = window.innerWidth < 768;
+      setIsMobileLayout(mobile);
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
   }, []);
-  const todayEndMs = useMemo(() => {
-    const d = new Date();
-    d.setHours(23, 59, 59, 999);
-    return d.getTime();
-  }, []);
-  const todayIso = useMemo(() => new Date().toISOString().slice(0, 10), []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.get('tab') === 'checkin' && mode !== 'checkin') {
+      setMode('checkin');
+      setUserSelectedMode(false);
+    }
+  }, [location.search, mode]);
 
   useEffect(() => {
     if (!currentUser?.uid) return;
@@ -189,19 +184,33 @@ const DailyPlanPage: React.FC = () => {
   }, [currentUser?.uid]);
 
   useEffect(() => {
+    if (!reviewStateId) {
+      setMorningReviewDone(false);
+      return;
+    }
+    const unsub = onSnapshot(doc(db, 'daily_plan_state', reviewStateId), (snap) => {
+      const data = snap.data() as any;
+      setMorningReviewDone(!!(data?.reviewCompletedAt || data?.reviewCompletedAtMs));
+    }, (error) => {
+      console.warn('DailyPlanPage: daily_plan_state listener denied/failed', error?.message || error);
+      setMorningReviewDone(false);
+    });
+    return () => unsub();
+  }, [reviewStateId]);
+
+  useEffect(() => {
     if (!currentUser?.uid) {
       setTasks([]);
       return;
     }
-    const q = query(collection(db, 'tasks'), where('ownerUid', '==', currentUser.uid));
+    const q = query(collection(db, 'tasks'), where('ownerUid', '==', currentUser.uid), orderBy('updatedAt', 'desc'), limit(300));
     const unsub = onSnapshot(q, (snap) => {
       let rows = snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Task[];
-      const persona = currentPersona || 'personal';
-      rows = rows.filter((task: any) => {
-        if (persona === 'work') return task.persona === 'work';
-        return task.persona == null || task.persona === 'personal';
-      });
+      rows = rows.filter((task: any) => currentPersona === 'work' ? task.persona === 'work' : task.persona == null || task.persona === 'personal');
       setTasks(rows);
+    }, (error) => {
+      console.warn('DailyPlanPage: tasks listener denied/failed', error?.message || error);
+      setTasks([]);
     });
     return () => unsub();
   }, [currentUser?.uid, currentPersona]);
@@ -211,15 +220,14 @@ const DailyPlanPage: React.FC = () => {
       setStories([]);
       return;
     }
-    const q = query(collection(db, 'stories'), where('ownerUid', '==', currentUser.uid));
+    const q = query(collection(db, 'stories'), where('ownerUid', '==', currentUser.uid), orderBy('updatedAt', 'desc'), limit(300));
     const unsub = onSnapshot(q, (snap) => {
       let rows = snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Story[];
-      const persona = currentPersona || 'personal';
-      rows = rows.filter((story: any) => {
-        if (persona === 'work') return story.persona === 'work';
-        return story.persona == null || story.persona === 'personal';
-      });
+      rows = rows.filter((story: any) => currentPersona === 'work' ? story.persona === 'work' : story.persona == null || story.persona === 'personal');
       setStories(rows);
+    }, (error) => {
+      console.warn('DailyPlanPage: stories listener denied/failed', error?.message || error);
+      setStories([]);
     });
     return () => unsub();
   }, [currentUser?.uid, currentPersona]);
@@ -232,6 +240,9 @@ const DailyPlanPage: React.FC = () => {
     const q = query(collection(db, 'goals'), where('ownerUid', '==', currentUser.uid));
     const unsub = onSnapshot(q, (snap) => {
       setGoals(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Goal[]);
+    }, (error) => {
+      console.warn('DailyPlanPage: goals listener denied/failed', error?.message || error);
+      setGoals([]);
     });
     return () => unsub();
   }, [currentUser?.uid]);
@@ -241,15 +252,17 @@ const DailyPlanPage: React.FC = () => {
       setCalendarBlocks([]);
       return;
     }
-    const q = query(collection(db, 'calendar_blocks'), where('ownerUid', '==', currentUser.uid));
+    const q = query(
+      collection(db, 'calendar_blocks'),
+      where('ownerUid', '==', currentUser.uid),
+      where('start', '>=', todayStartMs),
+      where('start', '<=', todayEndMs),
+    );
     const unsub = onSnapshot(q, (snap) => {
-      const rows = snap.docs
-        .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) }))
-        .filter((row: any) => {
-          const startMs = toMs(row.start);
-          return startMs != null && startMs >= todayStartMs && startMs <= todayEndMs;
-        }) as CalendarBlockRow[];
-      setCalendarBlocks(rows);
+      setCalendarBlocks(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as PlannerCalendarBlockRow[]);
+    }, (error) => {
+      console.warn('DailyPlanPage: calendar_blocks listener denied/failed', error?.message || error);
+      setCalendarBlocks([]);
     });
     return () => unsub();
   }, [currentUser?.uid, todayStartMs, todayEndMs]);
@@ -265,7 +278,10 @@ const DailyPlanPage: React.FC = () => {
       where('occurrenceDate', '==', todayIso),
     );
     const unsub = onSnapshot(q, (snap) => {
-      setScheduledInstances(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as ScheduledInstanceRow[]);
+      setScheduledInstances(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as PlannerScheduledInstanceRow[]);
+    }, (error) => {
+      console.warn('DailyPlanPage: scheduled_instances listener denied/failed', error?.message || error);
+      setScheduledInstances([]);
     });
     return () => unsub();
   }, [currentUser?.uid, todayIso]);
@@ -280,271 +296,120 @@ const DailyPlanPage: React.FC = () => {
       const sorted = [...snap.docs].sort((a, b) => (toMs(b.data()?.generatedAt) || 0) - (toMs(a.data()?.generatedAt) || 0));
       const row = sorted[0]?.data() as any;
       setSummary(row?.summary || null);
+    }, (error) => {
+      console.warn('DailyPlanPage: daily_summaries listener denied/failed', error?.message || error);
+      setSummary(null);
     });
     return () => unsub();
   }, [currentUser?.uid]);
 
-  useEffect(() => {
-    if (!currentUser?.uid) {
-      setMorningReviewDone(false);
-      return;
-    }
-    const key = `dailyPlanMorningReview:${currentUser.uid}:${todayIso}`;
-    setMorningReviewDone(window.localStorage.getItem(key) === '1');
-  }, [currentUser?.uid, todayIso]);
+  const timelineItems = useMemo(
+    () =>
+      buildPlannerItems({
+        tasks,
+        stories,
+        goals,
+        calendarBlocks,
+        scheduledInstances,
+        activeFocusGoalIds,
+        rangeStartMs: todayStartMs,
+        rangeEndMs: todayEndMs,
+        selectedSprintId,
+        includeUnscheduledTasks: true,
+        summaryEvents: extractSummaryEvents(summary),
+      }),
+    [tasks, stories, goals, calendarBlocks, scheduledInstances, activeFocusGoalIds, todayStartMs, todayEndMs, selectedSprintId, summary],
+  );
 
-  const storyMap = useMemo(() => new Map(stories.map((story) => [story.id, story])), [stories]);
-  const goalMap = useMemo(() => new Map(goals.map((goal) => [goal.id, goal])), [goals]);
-  const activeFocusGoalIds = useMemo(() => getActiveFocusLeafGoalIds(activeFocusGoals), [activeFocusGoals]);
+  const timelineWorkItems = useMemo(() => timelineItems.filter((item) => item.kind !== 'event'), [timelineItems]);
 
-  const isGoalAlignedToFocus = useMemo(() => (
-    (goalId: string | null | undefined) => {
-      const normalized = String(goalId || '').trim();
-      if (!normalized) return false;
-      if (activeFocusGoalIds.has(normalized)) return true;
-      return getGoalAncestors(normalized, goals).some((goal) => activeFocusGoalIds.has(goal.id));
-    }
-  ), [activeFocusGoalIds, goals]);
-
-  const overviewCalendarEvents = useMemo(() => {
-    const candidates = [summary?.calendar?.events, summary?.eventsToday, summary?.upcomingEvents, summary?.calendarEvents, summary?.dailyBrief?.calendar];
-    for (const candidate of candidates) {
-      if (!Array.isArray(candidate) || candidate.length === 0) continue;
-      const mapped = candidate
-        .map((item: any, index: number) => {
-          const title = String(item?.title || item?.summary || item?.name || '').trim();
-          if (!title) return null;
-          const startMs = toMs(item?.start ?? item?.startAt ?? item?.startDate ?? item?.when);
-          const endMs = toMs(item?.end ?? item?.endAt ?? item?.endDate);
-          return { id: String(item?.id || item?.eventId || `${title}-${index}`), title, startMs, endMs };
-        })
-        .filter(Boolean) as Array<{ id: string; title: string; startMs: number | null; endMs: number | null }>;
-      if (mapped.length > 0) return mapped;
-    }
-    return [] as Array<{ id: string; title: string; startMs: number | null; endMs: number | null }>;
-  }, [summary]);
-
-  const scheduledInstanceBySourceKey = useMemo(() => {
-    const map = new Map<string, ScheduledInstanceRow>();
-    scheduledInstances.forEach((instance) => {
-      const sourceType = String(instance.sourceType || '').trim().toLowerCase();
-      const sourceId = String(instance.sourceId || '').trim();
-      if (!sourceType || !sourceId) return;
-      map.set(`${sourceType}:${sourceId}`, instance);
+  const dailyLoadHours = useMemo(() => {
+    const map = new Map<string, number>();
+    timelineWorkItems.forEach((item) => {
+      map.set(item.dayKey, (map.get(item.dayKey) || 0) + plannerItemPoints(item));
     });
     return map;
-  }, [scheduledInstances]);
+  }, [timelineWorkItems]);
 
-  const timelineItems = useMemo(() => {
-    const rows: TimelineItem[] = [];
-    const seen = new Set<string>();
-    const blockByTaskId = new Map<string, CalendarBlockRow>();
-    const blockByStoryId = new Map<string, CalendarBlockRow>();
+  const dayCapacity = useMemo(() => buildDayCapacityMap([todayIso], timelineWorkItems, 8).get(todayIso) || null, [timelineWorkItems, todayIso]);
 
-    calendarBlocks.forEach((block) => {
-      const taskId = String(block.taskId || '').trim();
-      const storyId = String(block.storyId || block.linkedStoryId || '').trim();
-      if (taskId) blockByTaskId.set(taskId, block);
-      if (storyId) blockByStoryId.set(storyId, block);
+  const reviewItems = useMemo(
+    () =>
+      timelineWorkItems.filter(
+        (item) =>
+          (item.kind === 'task' || item.kind === 'story')
+          && !item.isTop3
+          && !item.isFocusAligned
+          && !(item.deferredUntilMs && item.deferredUntilMs > Date.now()),
+      ),
+    [timelineWorkItems],
+  );
+
+  const recommendationByItemId = useMemo(() => {
+    const next = new Map<string, PlannerRecommendation>();
+    reviewItems.forEach((item) => {
+      next.set(item.id, buildPlannerRecommendation({
+        item,
+        weekStartMs: todayStartMs,
+        weekEndMs: todayEndMs,
+        dailyLoadHours,
+        nextSprint,
+      }));
     });
+    return next;
+  }, [reviewItems, todayStartMs, todayEndMs, dailyLoadHours, nextSprint]);
 
-    const push = (row: TimelineItem, dedupeKey = row.id) => {
-      if (seen.has(dedupeKey)) return;
-      seen.add(dedupeKey);
-      rows.push(row);
-    };
+  const reviewItemIds = useMemo(() => new Set(reviewItems.map((item) => item.id)), [reviewItems]);
 
-    const buildTaskRow = (task: Task, kind: 'task' | 'chore') => {
-      const choreKind = getChoreKind(task);
-      const instanceSourceTypes = choreKind === 'habit'
-        ? ['habit', 'routine', 'chore']
-        : choreKind
-          ? [choreKind]
-          : ['task'];
-      const matchingInstance = instanceSourceTypes
-        .map((sourceType) => scheduledInstanceBySourceKey.get(`${sourceType}:${task.id}`) || null)
-        .find(Boolean) || null;
-      const instanceStatus = String(matchingInstance?.status || '').trim().toLowerCase();
-      if (matchingInstance && ['completed', 'missed', 'skipped', 'cancelled'].includes(instanceStatus)) {
-        return;
-      }
-      const linkedBlock = blockByTaskId.get(task.id) || null;
-      const parentStory = (task as any).storyId ? storyMap.get((task as any).storyId) || null : null;
-      const goalId = String((task as any).goalId || (parentStory as any)?.goalId || '').trim() || null;
-      const goal = goalId ? goalMap.get(goalId) || null : null;
-      const dueMs = linkedBlock ? toMs(linkedBlock.start) : resolveTaskDueMs(task);
-      const endMs = linkedBlock ? toMs(linkedBlock.end) : null;
-      const bucket = bucketFromTime(dueMs, (task as any).timeOfDay);
-      const include = !!linkedBlock || !dueMs || dueMs <= todayEndMs;
-      if (!include) return;
-      push({
-        id: `${kind}-${task.id}`,
-        kind,
-        title: task.title || (kind === 'chore' ? 'Chore' : 'Task'),
-        ref: resolveTaskRef(task),
-        timeLabel: formatTimeLabel(dueMs, endMs, (task as any).timeOfDay),
-        sortMs: dueMs ?? bucketPseudoTime(todayStartMs, bucket),
-        bucket,
-        sourceId: task.id,
-        isTop3: !!((task as any).aiTop3ForDay && String((task as any).aiTop3Date || '').slice(0, 10) === todayIso),
-        deferredUntilMs: toMs((task as any).deferredUntil),
-        goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
-        goalTheme: goal ? String((goal as any).theme || '') || null : null,
-        isFocusAligned: isGoalAlignedToFocus(goalId),
-        rawTask: task,
-        rawStory: null,
-        scheduledBlockStart: linkedBlock ? toMs(linkedBlock.start) : null,
-        scheduledBlockEnd: linkedBlock ? toMs(linkedBlock.end) : null,
-      });
-    };
+  useEffect(() => {
+    if (new URLSearchParams(location.search).get('tab') === 'checkin') return;
+    if (userSelectedMode) return;
+    setMode(getAutoMode({
+      isMobile: isMobileLayout,
+      reviewDone: morningReviewDone,
+      reviewCount: reviewItems.length,
+      hour: new Date().getHours(),
+    }));
+  }, [isMobileLayout, location.search, morningReviewDone, reviewItems.length, userSelectedMode]);
 
-    tasks.filter((task) => !isDoneStatus((task as any).status)).filter((task) => !getChoreKind(task)).forEach((task) => buildTaskRow(task, 'task'));
-    tasks
-      .filter((task) => !isDoneStatus((task as any).status))
-      .filter((task) => !!getChoreKind(task))
-      .filter((task) => !!blockByTaskId.get(task.id) || isRecurringDueOnDate(task, today, todayStartMs) || !!resolveTaskDueMs(task))
-      .forEach((task) => buildTaskRow(task, 'chore'));
-
-    stories
-      .filter((story) => !isDoneStatus((story as any).status))
-      .filter((story) => (selectedSprintId ? String((story as any).sprintId || '') === String(selectedSprintId) : true))
-      .forEach((story) => {
-        const linkedBlock = blockByStoryId.get(story.id) || null;
-        const dueMs = linkedBlock ? toMs(linkedBlock.start) : toMs((story as any).targetDate || (story as any).dueDate || (story as any).plannedStartDate);
-        const endMs = linkedBlock ? toMs(linkedBlock.end) : null;
-        const bucket = bucketFromTime(dueMs, (story as any).timeOfDay);
-        const include = !!linkedBlock || !dueMs || dueMs <= todayEndMs;
-        if (!include) return;
-        const goalId = String((story as any).goalId || '').trim() || null;
-        const goal = goalId ? goalMap.get(goalId) || null : null;
-        push({
-          id: `story-${story.id}`,
-          kind: 'story',
-          title: story.title || 'Story',
-          ref: resolveStoryRef(story),
-          timeLabel: formatTimeLabel(dueMs, endMs, (story as any).timeOfDay),
-          sortMs: dueMs ?? bucketPseudoTime(todayStartMs, bucket),
-          bucket,
-          sourceId: story.id,
-          isTop3: !!((story as any).aiTop3ForDay && String((story as any).aiTop3Date || '').slice(0, 10) === todayIso),
-          deferredUntilMs: toMs((story as any).deferredUntil),
-          goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
-          goalTheme: goal ? String((goal as any).theme || '') || null : null,
-          isFocusAligned: isGoalAlignedToFocus(goalId),
-          rawTask: null,
-          rawStory: story,
-          scheduledBlockStart: linkedBlock ? toMs(linkedBlock.start) : null,
-          scheduledBlockEnd: linkedBlock ? toMs(linkedBlock.end) : null,
-        });
-      });
-
-    calendarBlocks.filter((block) => !String(block.taskId || '').trim() && !String(block.storyId || block.linkedStoryId || '').trim()).forEach((block) => {
-      const startMs = toMs(block.start);
-      const endMs = toMs(block.end);
-      const bucket = bucketFromTime(startMs);
-      const timeLabel = formatTimeLabel(startMs, endMs);
-      const dedupeKey = `event:${String(block.title || '').toLowerCase()}:${timeLabel}`;
-      push({
-        id: `event-block-${block.id}`,
-        kind: 'event',
-        title: String(block.title || 'Calendar event').trim() || 'Calendar event',
-        ref: null,
-        timeLabel,
-        sortMs: startMs ?? bucketPseudoTime(todayStartMs, bucket),
-        bucket,
-        goalTitle: null,
-        goalTheme: null,
-        isFocusAligned: false,
-        rawTask: null,
-        rawStory: null,
-        scheduledBlockStart: startMs,
-        scheduledBlockEnd: endMs,
-      }, dedupeKey);
-    });
-
-    overviewCalendarEvents.forEach((event) => {
-      if (event.startMs && (event.startMs < todayStartMs || event.startMs > todayEndMs)) return;
-      const bucket = bucketFromTime(event.startMs);
-      const timeLabel = formatTimeLabel(event.startMs, event.endMs);
-      const dedupeKey = `event:${event.title.toLowerCase()}:${timeLabel}`;
-      push({
-        id: `event-summary-${event.id}`,
-        kind: 'event',
-        title: event.title,
-        ref: null,
-        timeLabel,
-        sortMs: event.startMs ?? bucketPseudoTime(todayStartMs, bucket),
-        bucket,
-        goalTitle: null,
-        goalTheme: null,
-        isFocusAligned: false,
-        rawTask: null,
-        rawStory: null,
-        scheduledBlockStart: event.startMs,
-        scheduledBlockEnd: event.endMs,
-      }, dedupeKey);
-    });
-
-    return rows.sort((a, b) => {
-      const aMs = a.sortMs ?? Number.MAX_SAFE_INTEGER;
-      const bMs = b.sortMs ?? Number.MAX_SAFE_INTEGER;
-      if (aMs !== bMs) return aMs - bMs;
-      return a.title.localeCompare(b.title);
-    });
-  }, [tasks, stories, selectedSprintId, overviewCalendarEvents, today, todayStartMs, todayEndMs, todayIso, goalMap, storyMap, activeFocusGoalIds, calendarBlocks, scheduledInstanceBySourceKey, goals, isGoalAlignedToFocus]);
-
-  const todoSummary = useMemo(() => {
-    const tasksCount = timelineItems.filter((item) => item.kind === 'task').length;
-    const storiesCount = timelineItems.filter((item) => item.kind === 'story').length;
-    const choresCount = timelineItems.filter((item) => item.kind === 'chore').length;
-    const eventsCount = timelineItems.filter((item) => item.kind === 'event').length;
-    const top3Count = timelineItems.filter((item) => (item.kind === 'task' || item.kind === 'story') && item.isTop3).length;
-    const deferCandidates = timelineItems.filter((item) =>
-      (item.kind === 'task' || item.kind === 'story')
-      && !item.isTop3
-      && !item.isFocusAligned
-      && !(item.deferredUntilMs && item.deferredUntilMs > Date.now())
-    );
-    return { tasksCount, storiesCount, choresCount, eventsCount, top3Count, deferCandidates };
-  }, [timelineItems]);
+  const todoSummary = useMemo(() => ({
+    tasksCount: timelineWorkItems.filter((item) => item.kind === 'task').length,
+    storiesCount: timelineWorkItems.filter((item) => item.kind === 'story').length,
+    choresCount: timelineWorkItems.filter((item) => item.kind === 'chore').length,
+    eventsCount: timelineItems.filter((item) => item.kind === 'event').length,
+    top3Count: timelineWorkItems.filter((item) => (item.kind === 'task' || item.kind === 'story') && item.isTop3).length,
+    focusCount: timelineWorkItems.filter((item) => item.isFocusAligned).length,
+    reviewCount: reviewItems.length,
+    overdueCount: timelineWorkItems.filter((item) => item.dueAt != null && item.dueAt < Date.now()).length,
+  }), [timelineItems, timelineWorkItems, reviewItems]);
 
   const filteredTimelineItems = useMemo(() => {
-    if (!activeKindFilter) return timelineItems;
-    if (activeKindFilter === 'top3') {
-      return timelineItems.filter((item) => (item.kind === 'task' || item.kind === 'story') && item.isTop3);
-    }
-    if (activeKindFilter === 'review') {
-      return timelineItems.filter((item) =>
-        (item.kind === 'task' || item.kind === 'story')
-        && !item.isTop3
-        && !item.isFocusAligned
-        && !(item.deferredUntilMs && item.deferredUntilMs > Date.now())
-      );
-    }
-    return timelineItems.filter((item) => item.kind === activeKindFilter);
-  }, [timelineItems, activeKindFilter]);
-
-  const empty = filteredTimelineItems.length === 0;
+    const source = mode === 'review' ? reviewItems : mode === 'plan' ? timelineItems : timelineWorkItems;
+    if (!activeKindFilter) return source;
+    if (activeKindFilter === 'focus') return source.filter((item) => item.isFocusAligned);
+    if (activeKindFilter === 'review') return reviewItems;
+    if (activeKindFilter === 'top3') return source.filter((item) => item.isTop3);
+    return source.filter((item) => item.kind === activeKindFilter);
+  }, [timelineItems, timelineWorkItems, reviewItems, activeKindFilter, mode]);
 
   const scheduleStories = useMemo(() => {
     if (!scheduleTarget) return [] as Story[];
     if (scheduleTarget.rawStory) return [scheduleTarget.rawStory];
     if (scheduleTarget.rawTask && (scheduleTarget.rawTask as any).storyId) {
-      const parent = storyMap.get((scheduleTarget.rawTask as any).storyId);
+      const parent = stories.find((story) => story.id === (scheduleTarget.rawTask as any).storyId);
       return parent ? [parent] : [];
     }
     return [] as Story[];
-  }, [scheduleTarget, storyMap]);
+  }, [scheduleTarget, stories]);
 
   const scheduleInitialValues = useMemo(() => {
     if (!scheduleTarget) return undefined;
     const rawTask = scheduleTarget.rawTask;
     const rawStory = scheduleTarget.rawStory;
-    const parentStory = rawTask && (rawTask as any).storyId ? storyMap.get((rawTask as any).storyId) || null : null;
     const base = new Date();
     base.setMinutes(0, 0, 0);
     base.setHours(base.getHours() + 1);
-    const startMs = scheduleTarget.scheduledBlockStart || (scheduleTarget.sortMs && !scheduleTarget.timeLabel.startsWith('Unscheduled') ? scheduleTarget.sortMs : null);
+    const startMs = scheduleTarget.scheduledBlockStart || scheduleTarget.sortMs || null;
     const start = startMs ? new Date(startMs) : base;
     const durationMin = Math.max(15, Math.min(240, Math.round(Number((rawTask as any)?.estimateMin || 0) || (Number((rawTask as any)?.points || (rawStory as any)?.points || 0) * 60) || 60)));
     const end = scheduleTarget.scheduledBlockEnd ? new Date(scheduleTarget.scheduledBlockEnd) : new Date(start.getTime() + durationMin * 60 * 1000);
@@ -554,70 +419,276 @@ const DailyPlanPage: React.FC = () => {
       end: toInputValue(end),
       syncToGoogle: true,
       rationale: 'Scheduled from Daily Plan',
-      persona: ((rawTask as any)?.persona || (rawStory as any)?.persona || (parentStory as any)?.persona || currentPersona || 'personal') as 'personal' | 'work',
-      theme: String((rawStory as any)?.theme || (parentStory as any)?.theme || (rawTask as any)?.theme || 'General'),
+      persona: ((rawTask as any)?.persona || (rawStory as any)?.persona || currentPersona || 'personal') as 'personal' | 'work',
+      theme: String((rawStory as any)?.theme || (rawTask as any)?.theme || 'General'),
       category: ((rawTask as any)?.category || 'Wellbeing') as any,
-      storyId: rawStory?.id || parentStory?.id,
+      storyId: rawStory?.id || (rawTask as any)?.storyId || undefined,
       taskId: rawTask?.id,
       aiScore: Number.isFinite(Number((rawTask as any)?.aiCriticalityScore || (rawStory as any)?.aiCriticalityScore)) ? Number((rawTask as any)?.aiCriticalityScore || (rawStory as any)?.aiCriticalityScore) : null,
       aiReason: String((rawTask as any)?.aiReason || (rawTask as any)?.aiPriorityReason || (rawStory as any)?.aiReason || (rawStory as any)?.aiPriorityReason || '').trim() || null,
     } as Partial<BlockFormState>;
-  }, [scheduleTarget, storyMap, currentPersona]);
+  }, [scheduleTarget, currentPersona]);
 
   const markMorningReviewDone = () => {
-    if (!currentUser?.uid) return;
-    const key = `dailyPlanMorningReview:${currentUser.uid}:${todayIso}`;
-    window.localStorage.setItem(key, '1');
+    if (!currentUser?.uid || !reviewStateId) return;
+    void setDoc(doc(db, 'daily_plan_state', reviewStateId), {
+      ownerUid: currentUser.uid,
+      persona: currentPersona || 'personal',
+      dayKey: todayIso,
+      reviewCompletedAt: serverTimestamp(),
+      reviewCompletedAtMs: Date.now(),
+      updatedAt: serverTimestamp(),
+    }, { merge: true });
     setMorningReviewDone(true);
+    setActiveKindFilter(null);
+    setMode(isMobileLayout ? 'list' : 'plan');
   };
 
-  const applyDefer = async (payload: { dateMs: number; rationale: string; source: string }) => {
-    if (!deferTarget) return;
-    const collectionName = deferTarget.type === 'story' ? 'stories' : 'tasks';
-    await updateDoc(doc(db, collectionName, deferTarget.id), {
-      deferredUntil: payload.dateMs,
-      deferredReason: payload.rationale,
-      deferredBy: payload.source,
-      deferredAt: serverTimestamp(),
-      updatedAt: serverTimestamp(),
+  const selectMode = (nextMode: DailyPlanMode) => {
+    setUserSelectedMode(true);
+    setMode(nextMode);
+    if (nextMode === 'checkin') {
+      if (location.search !== '?tab=checkin') {
+        navigate('/daily-plan?tab=checkin', { replace: true });
+      }
+      return;
+    }
+    if (location.search) {
+      navigate('/daily-plan', { replace: true });
+    }
+  };
+
+  const updateTaskQuick = async (task: Task, patch: Record<string, any>) => {
+    try {
+      await updateDoc(doc(db, 'tasks', task.id), {
+        ...patch,
+        updatedAt: serverTimestamp(),
+      });
+    } catch (error: any) {
+      console.error('Failed to update task from daily plan', error);
+      setPageMessage({ variant: 'danger', text: error?.message || 'Failed to update this task.' });
+    }
+  };
+
+  const updateStoryQuick = async (story: Story, patch: Record<string, any>) => {
+    try {
+      await updateDoc(doc(db, 'stories', story.id), {
+        ...patch,
+        updatedAt: serverTimestamp(),
+      });
+    } catch (error: any) {
+      console.error('Failed to update story from daily plan', error);
+      setPageMessage({ variant: 'danger', text: error?.message || 'Failed to update this story.' });
+    }
+  };
+
+  const cycleTaskStatus = (task: Task) => {
+    const options = ChoiceHelper.getOptions('task', 'status').map((opt) => opt.value);
+    const current = Number((task as any)?.status ?? 0);
+    const currentIndex = Math.max(0, options.indexOf(current));
+    const next = options[(currentIndex + 1) % options.length] ?? 0;
+    void updateTaskQuick(task, { status: next });
+  };
+
+  const cycleStoryStatus = (story: Story) => {
+    const options = ChoiceHelper.getOptions('story', 'status').map((opt) => opt.value);
+    const current = normalizeStoryStatus((story as any)?.status);
+    const currentIndex = Math.max(0, options.indexOf(current));
+    const next = options[(currentIndex + 1) % options.length] ?? 0;
+    void updateStoryQuick(story, { status: next });
+  };
+
+  const cycleTaskPriority = (task: Task) => {
+    const options = [0, ...ChoiceHelper.getOptions('task', 'priority').map((opt) => opt.value)];
+    const current = Number((task as any)?.priority ?? 0);
+    const currentIndex = Math.max(0, options.indexOf(current));
+    const next = options[(currentIndex + 1) % options.length] ?? 0;
+    void updateTaskQuick(task, { priority: next });
+  };
+
+  const cycleStoryPriority = (story: Story) => {
+    const options = [0, ...ChoiceHelper.getOptions('story', 'priority').map((opt) => opt.value)];
+    const current = Number((story as any)?.priority ?? 0);
+    const currentIndex = Math.max(0, options.indexOf(current));
+    const next = options[(currentIndex + 1) % options.length] ?? 0;
+    void updateStoryQuick(story, { priority: next });
+  };
+
+  const buildTargetTiming = (targetDateMs: number, targetBucket: TimelineBucket, durationMinutes: number) => {
+    const startHour = targetBucket === 'morning' ? 9 : targetBucket === 'afternoon' ? 14 : targetBucket === 'evening' ? 19 : 12;
+    const startMs = dayStartMs(targetDateMs) + startHour * 60 * 60 * 1000;
+    const safeDurationMinutes = Math.max(15, durationMinutes || 30);
+    return {
+      startMs,
+      endMs: startMs + safeDurationMinutes * 60 * 1000,
+    };
+  };
+
+  const updateScheduledInstanceTiming = async (item: PlannerItem, targetDateMs: number, targetBucket: TimelineBucket) => {
+    if (!item.scheduledInstanceId) return;
+    const durationMinutes = Math.max(
+      15,
+      Math.round((((item.scheduledBlockEnd || 0) - (item.scheduledBlockStart || 0)) / 60000) || Number((item.rawTask as any)?.estimateMin || 0) || 30),
+    );
+    const { startMs, endMs } = buildTargetTiming(targetDateMs, targetBucket, durationMinutes);
+    await updateDoc(doc(db, 'scheduled_instances', item.scheduledInstanceId), {
+      occurrenceDate: toDayKey(targetDateMs),
+      dayKey: toDayKey(targetDateMs),
+      timeOfDay: targetBucket,
+      plannedStart: new Date(startMs).toISOString(),
+      plannedEnd: new Date(endMs).toISOString(),
+      updatedAt: Date.now(),
     });
   };
 
-  const handleItemDone = async (item: TimelineItem, event: React.MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    if (item.rawTask) {
-      const choreKind = getChoreKind(item.rawTask);
-      if (choreKind) {
-        const candidateSourceTypes = choreKind === 'habit'
-          ? ['habit', 'routine', 'chore']
-          : [choreKind];
-        const matchingInstance = candidateSourceTypes
-          .map((sourceType) => scheduledInstanceBySourceKey.get(`${sourceType}:${item.rawTask!.id}`) || null)
-          .find(Boolean) || null;
-        if (matchingInstance) {
-          await updateDoc(doc(db, 'scheduled_instances', matchingInstance.id), {
-            status: 'completed',
-            statusUpdatedAt: Date.now(),
-            updatedAt: Date.now(),
-          });
-          return;
-        }
-        setPageMessage({
-          variant: 'warning',
-          text: 'Could not find today\'s scheduled instance for this recurring item, so the parent reminder was left unchanged.',
+  const updateGroupTiming = async (item: PlannerItem, targetDateMs: number, targetBucket: TimelineBucket) => {
+    const children = Array.isArray(item.childItems) ? item.childItems : [];
+    await Promise.all(children.map((child) => updateScheduledInstanceTiming(child, targetDateMs, targetBucket)));
+  };
+
+  const handleItemDone = async (item: PlannerItem) => {
+    setApplyingKey(item.id);
+    try {
+      if (item.scheduledInstanceId) {
+        await updateDoc(doc(db, 'scheduled_instances', item.scheduledInstanceId), {
+          status: 'completed',
+          statusUpdatedAt: Date.now(),
+          updatedAt: Date.now(),
         });
-        return;
+        const taskType = String((item.rawTask as any)?.type || '').toLowerCase();
+        if (['chore', 'routine', 'habit', 'habitual'].includes(taskType) && item.rawTask?.id) {
+          const callable = httpsCallable(functions, 'completeChoreTask');
+          await callable({ taskId: item.rawTask.id });
+        }
+        setPageMessage({ variant: 'success', text: `${item.title} marked complete for today.` });
+      } else if (item.rawTask) {
+        await updateDoc(doc(db, 'tasks', item.rawTask.id), { status: 2, updatedAt: serverTimestamp() });
+        setPageMessage({ variant: 'success', text: `${item.title} marked done.` });
+      } else if (item.rawStory) {
+        const nextStatus = Math.min(4, normalizeStoryStatus((item.rawStory as any).status) + 1);
+        await updateDoc(doc(db, 'stories', item.rawStory.id), { status: nextStatus, updatedAt: serverTimestamp() });
+        setPageMessage({ variant: 'success', text: `${item.title} advanced to the next story stage.` });
       }
-      await updateDoc(doc(db, 'tasks', item.rawTask.id), { status: 2, updatedAt: serverTimestamp() });
-      return;
-    }
-    if (item.rawStory) {
-      const nextStatus = Math.min(4, normalizeStoryStatus((item.rawStory as any).status) + 1);
-      await updateDoc(doc(db, 'stories', item.rawStory.id), { status: nextStatus, updatedAt: serverTimestamp() });
+    } catch (error: any) {
+      console.error('Failed to mark planner item done', error);
+      setPageMessage({ variant: 'danger', text: error?.message || 'Failed to update this item.' });
+    } finally {
+      setApplyingKey(null);
     }
   };
 
-  const openItemEditor = (item: TimelineItem) => {
+  const applyMove = async (item: PlannerItem, targetDateMs: number, targetBucket: TimelineBucket, recommendation?: PlannerRecommendation | null) => {
+    setApplyingKey(item.id);
+    const debugRequestId = createPlannerActionId('move');
+    console.info('[DailyPlanPage] move_confirmed', {
+      debugRequestId,
+      itemId: item.id,
+      itemKind: item.kind,
+      sourceId: item.sourceId || null,
+      targetDateMs,
+      targetBucket,
+      recommendation: recommendation || null,
+    });
+    try {
+      if (item.childItems?.length) {
+        await updateGroupTiming(item, targetDateMs, targetBucket);
+      } else if (item.scheduledInstanceId) {
+        await updateScheduledInstanceTiming(item, targetDateMs, targetBucket);
+      } else if (item.rawTask) {
+        const result = await schedulePlannerItemMutation({
+          itemType: 'task',
+          itemId: item.rawTask.id,
+          targetDateMs,
+          targetBucket,
+          intent: recommendation?.action === 'next_sprint' ? 'defer' : 'move',
+          source: 'daily_plan',
+          rationale: recommendation?.rationale || null,
+          linkedBlockId: item.scheduledBlockId || null,
+          targetSprintId: recommendation?.action === 'next_sprint' ? (nextSprint?.id || null) : null,
+          durationMinutes: Math.max(
+            15,
+            Math.round((((item.scheduledBlockEnd || 0) - (item.scheduledBlockStart || 0)) / 60000) || Number((item.rawTask as any)?.estimateMin || 0) || 30),
+          ),
+          debugRequestId,
+        });
+        setPageMessage({
+          variant: 'success',
+          text: `${item.title} moved to ${new Date(result.appliedStartMs).toLocaleDateString()} ${bucketLabel((result.appliedBucket || targetBucket) as TimelineBucket).toLowerCase()}.`,
+        });
+      } else if (item.rawStory) {
+        const result = await schedulePlannerItemMutation({
+          itemType: 'story',
+          itemId: item.rawStory.id,
+          targetDateMs,
+          targetBucket,
+          intent: recommendation?.action === 'next_sprint' ? 'defer' : 'move',
+          source: 'daily_plan',
+          rationale: recommendation?.rationale || null,
+          linkedBlockId: item.scheduledBlockId || null,
+          targetSprintId: recommendation?.action === 'next_sprint' ? (nextSprint?.id || null) : null,
+          durationMinutes: Math.max(
+            15,
+            Math.round((((item.scheduledBlockEnd || 0) - (item.scheduledBlockStart || 0)) / 60000) || Number((item.rawStory as any)?.estimateMin || 0) || 60),
+          ),
+          debugRequestId,
+        });
+        setPageMessage({
+          variant: 'success',
+          text: `${item.title} moved to ${new Date(result.appliedStartMs).toLocaleDateString()} ${bucketLabel((result.appliedBucket || targetBucket) as TimelineBucket).toLowerCase()}.`,
+        });
+      } else {
+        setPageMessage({
+          variant: 'success',
+          text: `${item.title} moved to ${new Date(targetDateMs).toLocaleDateString()} ${bucketLabel(targetBucket).toLowerCase()}.`,
+        });
+      }
+      setMoveModal(null);
+    } catch (error: any) {
+      console.error('[DailyPlanPage] move_failed', { debugRequestId, error });
+      setPageMessage({ variant: 'danger', text: error?.message || 'Failed to move this item.' });
+    } finally {
+      setApplyingKey(null);
+    }
+  };
+
+  const applyRecommendation = async (item: PlannerItem, recommendation: PlannerRecommendation) => {
+    if (recommendation.action === 'keep_week') {
+      setPageMessage({ variant: 'success', text: `${item.title} kept in today’s plan.` });
+      return;
+    }
+    if (recommendation.targetDateMs == null || recommendation.targetBucket == null) {
+      setPageMessage({ variant: 'warning', text: 'No actionable recommendation was available.' });
+      return;
+    }
+    if (recommendation.action === 'next_recurrence') {
+      setApplyingKey(item.id);
+      try {
+        if (item.childItems?.length) {
+          await updateGroupTiming(item, recommendation.targetDateMs, recommendation.targetBucket || item.timeOfDay);
+        } else if (item.scheduledInstanceId) {
+          await updateScheduledInstanceTiming(item, recommendation.targetDateMs, recommendation.targetBucket || item.timeOfDay);
+        } else if (item.rawTask) {
+          await updateDoc(doc(db, 'tasks', item.rawTask.id), {
+            deferredUntil: recommendation.targetDateMs,
+            deferredReason: recommendation.rationale,
+            deferredBy: 'daily_plan',
+            deferredAt: serverTimestamp(),
+            updatedAt: serverTimestamp(),
+          });
+        }
+        setPageMessage({ variant: 'success', text: `${item.title} deferred to its next sensible recurrence.` });
+      } catch (error: any) {
+        console.error('Failed to defer recurring item', error);
+        setPageMessage({ variant: 'danger', text: error?.message || 'Failed to defer this recurring item.' });
+      } finally {
+        setApplyingKey(null);
+      }
+      return;
+    }
+    await applyMove(item, recommendation.targetDateMs, recommendation.targetBucket, recommendation);
+  };
+
+  const openItemEditor = (item: PlannerItem) => {
     if (item.rawTask) {
       setEditTask(item.rawTask);
       return;
@@ -625,160 +696,231 @@ const DailyPlanPage: React.FC = () => {
     if (item.rawStory) setEditStory(item.rawStory);
   };
 
-  const filterButtons: Array<{ key: TimelineFilter; label: string; count: number; variant: string; }> = [
+  const renderPlannerCard = (item: PlannerItem) => {
+    const recommendation = recommendationByItemId.get(item.id) || null;
+    return (
+      <PlannerWorkCard
+        item={item}
+        context="daily"
+        isMobileLayout={isMobileLayout}
+        applyingKey={applyingKey}
+        showDoneControl={mode !== 'review'}
+        doneAsCheckbox={mode === 'list'}
+        showInlineRecommendation={!!recommendation && (mode === 'review' || reviewItemIds.has(item.id))}
+        recommendation={recommendation}
+        expanded={!!expandedGroups[item.id]}
+        onToggleExpanded={(nextItem) => setExpandedGroups((prev) => ({ ...prev, [nextItem.id]: !prev[nextItem.id] }))}
+        onToggleDone={(nextItem) => { void handleItemDone(nextItem); }}
+        onOpenActivity={(nextItem) => showSidebar(nextItem.rawTask ? nextItem.rawTask as any : nextItem.rawStory as any, nextItem.rawTask ? 'task' : 'story')}
+        onOpenEditor={openItemEditor}
+        onSchedule={setScheduleTarget}
+        onMove={(nextItem) => {
+          console.info('[DailyPlanPage] move_clicked', {
+            itemId: nextItem.id,
+            itemKind: nextItem.kind,
+            sourceId: nextItem.sourceId || null,
+          });
+          const fallbackRecommendation = nextItem.kind === 'chore'
+            ? buildPlannerRecommendation({
+              item: nextItem,
+              weekStartMs: todayStartMs,
+              weekEndMs: todayEndMs,
+              dailyLoadHours,
+              nextSprint,
+            })
+            : null;
+          const nextRecommendation = recommendationByItemId.get(nextItem.id) || fallbackRecommendation || null;
+          console.info('[DailyPlanPage] move_modal_opened', {
+            itemId: nextItem.id,
+            itemKind: nextItem.kind,
+            recommendation: nextRecommendation || null,
+          });
+          setMoveModal({ item: nextItem, recommendation: nextRecommendation });
+          if (nextItem.kind === 'chore' && nextRecommendation?.targetDateMs != null) {
+            setPageMessage({
+              variant: 'success',
+              text: `${nextItem.title} move defaults were prefilled using its recurrence and current load.`,
+            });
+          }
+        }}
+        onDefer={(nextItem) => {
+          console.info('[DailyPlanPage] defer_clicked', {
+            itemId: nextItem.id,
+            itemKind: nextItem.kind,
+            sourceId: nextItem.sourceId || null,
+          });
+          if (nextItem.kind === 'event' || nextItem.childItems?.length) return;
+          const recurringRecommendation = nextItem.kind === 'chore'
+            ? buildPlannerRecommendation({
+              item: nextItem,
+              weekStartMs: todayStartMs,
+              weekEndMs: todayEndMs,
+              dailyLoadHours,
+              nextSprint,
+            })
+            : null;
+          if (recurringRecommendation?.action === 'next_recurrence') {
+            void applyRecommendation(nextItem, recurringRecommendation);
+            return;
+          }
+          setDeferTarget({ type: nextItem.kind === 'story' ? 'story' : 'task', id: nextItem.sourceId || '', title: nextItem.title, isFocusAligned: nextItem.isFocusAligned });
+        }}
+        onAcceptRecommendation={(nextItem) => {
+          const nextRecommendation = recommendationByItemId.get(nextItem.id);
+          if (nextRecommendation) void applyRecommendation(nextItem, nextRecommendation);
+        }}
+        onCycleStatus={(nextItem) => {
+          if (nextItem.rawTask) cycleTaskStatus(nextItem.rawTask);
+          else if (nextItem.rawStory) cycleStoryStatus(nextItem.rawStory);
+        }}
+        onCyclePriority={(nextItem) => {
+          if (nextItem.rawTask) cycleTaskPriority(nextItem.rawTask);
+          else if (nextItem.rawStory) cycleStoryPriority(nextItem.rawStory);
+        }}
+        onStatusChange={(nextItem, nextStatus) => {
+          if (nextItem.rawTask) updateTaskQuick(nextItem.rawTask, { status: nextStatus as any });
+          else if (nextItem.rawStory) updateStoryQuick(nextItem.rawStory, { status: nextStatus as any });
+        }}
+        onPriorityChange={(nextItem, nextPriority) => {
+          if (nextItem.rawTask) updateTaskQuick(nextItem.rawTask, { priority: nextPriority as any });
+          else if (nextItem.rawStory) updateStoryQuick(nextItem.rawStory, { priority: nextPriority as any });
+        }}
+      />
+    );
+  };
+
+  const filterButtons: Array<{ key: TimelineFilter; label: string; count: number; variant: string }> = [
     { key: 'task', label: 'Tasks', count: todoSummary.tasksCount, variant: 'primary' },
     { key: 'story', label: 'Stories', count: todoSummary.storiesCount, variant: 'info' },
     { key: 'chore', label: 'Chores', count: todoSummary.choresCount, variant: 'success' },
-    { key: 'event', label: 'Events', count: todoSummary.eventsCount, variant: 'secondary' },
     { key: 'top3', label: 'Top 3', count: todoSummary.top3Count, variant: 'danger' },
-    { key: 'review', label: 'Review', count: todoSummary.deferCandidates.length, variant: 'warning' },
+    { key: 'focus', label: 'Focus', count: todoSummary.focusCount, variant: 'success' },
+    { key: 'review', label: 'Review', count: todoSummary.reviewCount, variant: 'warning' },
   ];
 
   return (
-    <Container fluid="sm" className="py-3">
+    <Container fluid="sm" className={isMobileLayout ? 'py-2 px-2' : 'py-3'}>
       <Card className="border-0 shadow-sm">
-        <Card.Header className="d-flex align-items-center justify-content-between">
-          <div className="fw-semibold">Daily Plan</div>
-          <Badge bg={empty ? 'secondary' : 'info'} pill>{filteredTimelineItems.length}</Badge>
+        <Card.Header className="d-flex align-items-center justify-content-between flex-wrap gap-2">
+          <div>
+            <div className="fw-semibold">Daily Plan</div>
+            <div className="text-muted small">Overview stays the home page; this is the daily operating surface.</div>
+          </div>
+          <div className="d-flex align-items-center gap-2 flex-wrap">
+            <Badge bg="secondary">Open {timelineWorkItems.length}</Badge>
+            <Badge bg="warning" text="dark">Review {todoSummary.reviewCount}</Badge>
+            <Badge bg="danger">Overdue {todoSummary.overdueCount}</Badge>
+          </div>
         </Card.Header>
         <Card.Body>
           {pageMessage && (
-            <Alert variant={pageMessage.variant} className="py-2 px-3" dismissible onClose={() => setPageMessage(null)}>
+            <Alert variant={pageMessage.variant} dismissible className="py-2" onClose={() => setPageMessage(null)}>
               {pageMessage.text}
             </Alert>
           )}
-          <div className="text-muted small mb-3">
-            Review today in one place: open items inline, finish them quickly, and schedule or defer without leaving the page.
+
+          <div className="d-flex gap-2 flex-wrap mb-3">
+            <Button size="sm" variant={mode === 'list' ? 'primary' : 'outline-primary'} onClick={() => selectMode('list')}>
+              Today
+            </Button>
+            <Button size="sm" variant={mode === 'plan' ? 'primary' : 'outline-primary'} onClick={() => selectMode('plan')}>
+              Schedule
+            </Button>
+            <Button size="sm" variant={mode === 'review' ? 'primary' : 'outline-primary'} onClick={() => selectMode('review')}>
+              Triage
+            </Button>
+            <Button size="sm" variant={mode === 'checkin' ? 'primary' : 'outline-primary'} onClick={() => selectMode('checkin')}>
+              Check-in
+            </Button>
           </div>
 
-          <div className="d-flex flex-wrap gap-2 mb-3">
-            {filterButtons.map((filter) => {
-              const active = activeKindFilter === filter.key;
-              return (
+          <div className="text-muted small mb-3">
+            {mode === 'list' && 'Today: actionable work only, best for checking things off.'}
+            {mode === 'plan' && 'Schedule: your day laid out by morning, afternoon, evening, and standalone events.'}
+            {mode === 'review' && 'Triage: items outside today’s focus or capacity, with defer recommendations.'}
+            {mode === 'checkin' && 'Check-in: update progress, comments, and completion so nightly planning uses the latest state.'}
+          </div>
+
+          {mode !== 'checkin' && (
+            <div className="d-flex flex-wrap gap-2 mb-3">
+              {filterButtons.map((filter) => (
                 <Button
                   key={filter.key || 'all'}
                   size="sm"
-                  variant={active ? filter.variant : `outline-${filter.variant}`}
+                  variant={activeKindFilter === filter.key ? filter.variant : `outline-${filter.variant}`}
                   className="rounded-pill"
                   onClick={() => setActiveKindFilter((prev) => (prev === filter.key ? null : filter.key))}
                 >
                   {filter.label} {filter.count}
                 </Button>
-              );
-            })}
-          </div>
+              ))}
+            </div>
+          )}
 
-          {!morningReviewDone && timelineItems.length > 0 && (
-            <Alert variant="warning" className="d-flex align-items-center justify-content-between gap-2 flex-wrap py-2 px-3">
-              <div>
-                <div className="fw-semibold">Morning check-in</div>
-                <div className="small">
-                  Today: {todoSummary.tasksCount} tasks, {todoSummary.storiesCount} stories, {todoSummary.choresCount} chores, {todoSummary.eventsCount} events. Top 3 protected: {todoSummary.top3Count}. Review non-focus, non-Top 3 work first.
-                </div>
+          {mode === 'plan' && dayCapacity && (
+            <Alert variant={dayCapacity.overCapacity ? 'danger' : dayCapacity.remainingPoints <= 2 ? 'warning' : 'light'} className="py-2 px-3">
+              <div className="fw-semibold">Today capacity</div>
+              <div className="small text-muted">
+                {dayCapacity.plannedPoints.toFixed(1)}/{dayCapacity.capacityPoints.toFixed(1)} pts planned · {dayCapacity.remainingPoints.toFixed(1)} pts free · {dayCapacity.utilizationPct}% used
               </div>
-              <Button size="sm" variant="primary" onClick={markMorningReviewDone}>
-                Mark reviewed
-              </Button>
             </Alert>
           )}
 
-          {empty ? (
-            <Alert variant="light" className="mb-0">
-              {activeKindFilter ? 'No items match the current filter.' : 'No items scheduled for today.'}
+          {mode !== 'checkin' && !morningReviewDone && reviewItems.length > 0 && (
+            <Alert variant="warning" className="d-flex align-items-center justify-content-between gap-2 flex-wrap py-2 px-3">
+              <div>
+                <div className="fw-semibold">Morning review</div>
+                <div className="small">
+                  {todoSummary.reviewCount} items are outside your Top 3 and active focus goals. Triage them before the day fills up.
+                </div>
+              </div>
+              <div className={`d-flex gap-2 ${isMobileLayout ? 'w-100 flex-column' : ''}`}>
+                <Button size="sm" variant="outline-dark" className={isMobileLayout ? 'w-100' : undefined} onClick={() => selectMode('review')}>
+                  Open review
+                </Button>
+                <Button size="sm" variant="primary" className={isMobileLayout ? 'w-100' : undefined} onClick={markMorningReviewDone}>
+                  Mark reviewed
+                </Button>
+              </div>
             </Alert>
+          )}
+
+          {mode === 'checkin' ? (
+            <CheckInDaily embedded fixedDate={new Date(todayStartMs)} />
+          ) : mode === 'review' ? (
+            filteredTimelineItems.length === 0 ? (
+              <Alert variant="light" className="mb-0">No review items waiting.</Alert>
+            ) : (
+              <div className="d-flex flex-column gap-2">
+                {filteredTimelineItems.map((item) => renderPlannerCard(item))}
+              </div>
+            )
+          ) : mode === 'list' ? (
+            filteredTimelineItems.length === 0 ? (
+              <Alert variant="light" className="mb-0">No items in the current list view.</Alert>
+            ) : (
+              <div className="d-flex flex-column gap-2">
+                {filteredTimelineItems.map((item) => renderPlannerCard(item))}
+              </div>
+            )
+          ) : filteredTimelineItems.length === 0 ? (
+            <Alert variant="light" className="mb-0">No items in today’s plan.</Alert>
           ) : (
             bucketOrder.map((bucket) => {
               const items = filteredTimelineItems.filter((item) => item.bucket === bucket);
               if (items.length === 0) return null;
+              const bucketPoints = items.reduce((sum, item) => sum + plannerItemPoints(item), 0);
               return (
                 <div key={bucket} className="mb-3">
-                  <div className="text-uppercase text-muted small fw-semibold mb-1">{bucketLabel(bucket)}</div>
-                  <ListGroup variant="flush">
-                    {items.map((item) => {
-                      const editable = item.kind !== 'event';
-                      const variant = item.kind === 'story' ? 'info' : item.kind === 'chore' ? 'success' : item.kind === 'event' ? 'secondary' : 'primary';
-                      const kindLabel = item.kind === 'story' ? 'Story' : item.kind === 'chore' ? 'Chore' : item.kind === 'event' ? 'Event' : 'Task';
-                      return (
-                        <ListGroup.Item
-                          key={item.id}
-                          className="d-flex align-items-start gap-2 py-2 px-0 border-0 border-bottom"
-                          role={editable ? 'button' : undefined}
-                          tabIndex={editable ? 0 : undefined}
-                          onClick={() => editable && openItemEditor(item)}
-                          onKeyDown={(event) => {
-                            if (!editable) return;
-                            if (event.key === 'Enter' || event.key === ' ') {
-                              event.preventDefault();
-                              openItemEditor(item);
-                            }
-                          }}
-                          style={{ cursor: editable ? 'pointer' : 'default' }}
-                        >
-                          {editable && (
-                            <Button
-                              size="sm"
-                              variant="outline-success"
-                              className="rounded-circle d-inline-flex align-items-center justify-content-center p-1 mt-1"
-                              title={item.kind === 'chore' ? 'Mark instance done' : 'Mark done'}
-                              onClick={(event) => void handleItemDone(item, event)}
-                            >
-                              <Check size={14} />
-                            </Button>
-                          )}
-
-                          <div className="flex-grow-1 min-w-0">
-                            <div className="d-flex flex-wrap align-items-center gap-2 mb-1">
-                              <div className="fw-semibold text-truncate small">{item.title}</div>
-                              <Badge bg={variant}>{kindLabel}</Badge>
-                              {item.isTop3 && <Badge bg="danger">Top 3</Badge>}
-                              {item.isFocusAligned && <Badge bg="success">Focus</Badge>}
-                              {item.deferredUntilMs && item.deferredUntilMs > Date.now() && <Badge bg="warning" text="dark">Deferred</Badge>}
-                            </div>
-                            <div className="text-muted" style={{ fontSize: '0.74rem' }}>
-                              {[item.ref, item.timeLabel].filter(Boolean).join(' · ')}
-                            </div>
-                            {item.goalTitle && (
-                              <div className="d-flex align-items-center gap-1 mt-1" style={{ fontSize: '0.72rem', opacity: 0.8 }}>
-                                <Target size={12} />
-                                <span>{item.goalTitle}</span>
-                              </div>
-                            )}
-                          </div>
-
-                          {editable && (
-                            <div className="d-flex align-items-center gap-1 ms-2">
-                              <Button
-                                size="sm"
-                                variant="outline-secondary"
-                                title="Schedule now"
-                                className="d-inline-flex align-items-center justify-content-center p-1"
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  setScheduleTarget(item);
-                                }}
-                              >
-                                <CalendarPlus size={14} />
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="outline-warning"
-                                title="Defer intelligently"
-                                className="d-inline-flex align-items-center justify-content-center p-1"
-                                disabled={!item.sourceId || (!!item.isTop3 && item.kind !== 'chore')}
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  if (!item.sourceId) return;
-                                  setDeferTarget({ type: item.kind === 'story' ? 'story' : 'task', id: item.sourceId, title: item.title });
-                                }}
-                              >
-                                <Clock3 size={14} />
-                              </Button>
-                            </div>
-                          )}
-                        </ListGroup.Item>
-                      );
-                    })}
-                  </ListGroup>
+                  <div className="d-flex align-items-center justify-content-between gap-2 mb-1">
+                    <div className="text-uppercase text-muted small fw-semibold">{bucketLabel(bucket)}</div>
+                    <div className="text-muted" style={{ fontSize: '0.72rem' }}>
+                      {bucketPoints.toFixed(1)} pts in bucket{dayCapacity ? ` · ${dayCapacity.remainingPoints.toFixed(1)} pts free today` : ''}
+                    </div>
+                  </div>
+                  <div className="d-flex flex-column gap-2">
+                    {items.map((item) => renderPlannerCard(item))}
+                  </div>
                 </div>
               );
             })
@@ -793,13 +935,129 @@ const DailyPlanPage: React.FC = () => {
           itemType={deferTarget.type}
           itemId={deferTarget.id}
           itemTitle={deferTarget.title}
-          onApply={applyDefer}
+          focusContext={{
+            isFocusAligned: deferTarget.isFocusAligned,
+            activeFocusGoals: activeFocusGoals.map((focusGoal) => ({
+              id: focusGoal.id,
+              title: focusGoal.title || null,
+              focusRootGoalIds: Array.isArray(focusGoal.focusRootGoalIds) ? focusGoal.focusRootGoalIds : [],
+              focusLeafGoalIds: Array.isArray(focusGoal.focusLeafGoalIds) ? focusGoal.focusLeafGoalIds : [],
+              goalIds: Array.isArray(focusGoal.goalIds) ? focusGoal.goalIds : [],
+            })),
+          }}
+          onApply={async (payload) => {
+            if (!deferTarget) return;
+            const affectedItem = timelineWorkItems.find((item) => item.sourceId === deferTarget.id && item.kind === deferTarget.type) || null;
+            const debugRequestId = createPlannerActionId('defer');
+            console.info('[DailyPlanPage] defer_confirmed', {
+              debugRequestId,
+              itemType: deferTarget.type,
+              itemId: deferTarget.id,
+              title: deferTarget.title,
+              payload,
+              affectedItemId: affectedItem?.id || null,
+              linkedBlockId: affectedItem?.scheduledBlockId || null,
+            });
+            const result = await schedulePlannerItemMutation({
+              itemType: deferTarget.type,
+              itemId: deferTarget.id,
+              targetDateMs: payload.dateMs,
+              targetBucket: affectedItem?.timeOfDay || null,
+              intent: 'defer',
+              source: payload.source || 'daily_plan',
+              rationale: payload.rationale,
+              linkedBlockId: affectedItem?.scheduledBlockId || null,
+              durationMinutes: affectedItem
+                ? Math.max(
+                    15,
+                    Math.round((((affectedItem.scheduledBlockEnd || 0) - (affectedItem.scheduledBlockStart || 0)) / 60000)
+                      || Number((affectedItem.rawTask as any)?.estimateMin || (affectedItem.rawStory as any)?.estimateMin || 0)
+                      || 30),
+                  )
+                : null,
+              debugRequestId,
+            });
+            setPageMessage({ variant: 'success', text: `${deferTarget.title} deferred to ${new Date(result.appliedStartMs).toLocaleDateString()}.` });
+            setDeferTarget(null);
+          }}
         />
+      )}
+
+      {moveModal && (
+        <Modal show={!!moveModal} onHide={() => setMoveModal(null)} centered>
+          <Modal.Header closeButton>
+            <Modal.Title style={{ fontSize: 16 }}>Move item</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <div className="fw-semibold mb-2">{moveModal.item.title}</div>
+            <div className="text-muted small mb-3">{moveModal.recommendation?.rationale || 'Pick a bucket for this item.'}</div>
+            <Form.Group className="mb-3">
+              <Form.Label className="small text-muted">Date</Form.Label>
+              <Form.Control
+                type="date"
+                value={format(new Date(moveModal.recommendation?.targetDateMs || todayStartMs), 'yyyy-MM-dd')}
+                onChange={(e) => {
+                  const parsed = Date.parse(`${e.target.value}T12:00:00`);
+                  setMoveModal({
+                    ...moveModal,
+                    recommendation: {
+                      ...(moveModal.recommendation || { action: 'move_day', label: 'Move day', rationale: '' }),
+                      targetDateMs: parsed,
+                      targetBucket: moveModal.recommendation?.targetBucket || 'morning',
+                    },
+                  });
+                }}
+              />
+            </Form.Group>
+            <Form.Group>
+              <Form.Label className="small text-muted">Time of day</Form.Label>
+              <Form.Select
+                value={moveModal.recommendation?.targetBucket || 'morning'}
+                onChange={(e) => {
+                  setMoveModal({
+                    ...moveModal,
+                    recommendation: {
+                      ...(moveModal.recommendation || { action: 'move_day', label: 'Move day', rationale: '' }),
+                      targetDateMs: moveModal.recommendation?.targetDateMs || todayStartMs,
+                      targetBucket: e.target.value as TimelineBucket,
+                    },
+                  });
+                }}
+              >
+                {bucketOrder.map((bucket) => (
+                  <option key={bucket} value={bucket}>{bucketLabel(bucket)}</option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={() => setMoveModal(null)}>Cancel</Button>
+            <Button
+              variant="primary"
+              disabled={!moveModal.recommendation?.targetDateMs || !moveModal.recommendation?.targetBucket}
+              onClick={() => moveModal.recommendation?.targetDateMs != null && moveModal.recommendation?.targetBucket != null
+                ? void applyMove(moveModal.item, moveModal.recommendation.targetDateMs, moveModal.recommendation.targetBucket, moveModal.recommendation)
+                : undefined}
+            >
+              Save move
+            </Button>
+          </Modal.Footer>
+        </Modal>
       )}
 
       <EditTaskModal show={!!editTask} task={editTask} onHide={() => setEditTask(null)} onUpdated={() => setEditTask(null)} />
       <EditStoryModal show={!!editStory} onHide={() => setEditStory(null)} story={editStory} goals={goals} onStoryUpdated={() => setEditStory(null)} />
-      <NewCalendarEventModal show={!!scheduleTarget} onHide={() => setScheduleTarget(null)} initialValues={scheduleInitialValues} stories={scheduleStories} onSaved={() => setScheduleTarget(null)} />
+      <NewCalendarEventModal
+        show={!!scheduleTarget}
+        onHide={() => setScheduleTarget(null)}
+        initialValues={scheduleInitialValues}
+        stories={scheduleStories}
+        onSaved={() => {
+          const scheduledTitle = scheduleTarget?.title || 'Item';
+          setScheduleTarget(null);
+          setPageMessage({ variant: 'success', text: `${scheduledTitle} added to your calendar.` });
+        }}
+      />
     </Container>
   );
 };

--- a/react-app/src/components/DeferItemModal.tsx
+++ b/react-app/src/components/DeferItemModal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Alert, Button, Form, Modal, Spinner } from 'react-bootstrap';
 import { httpsCallable } from 'firebase/functions';
 import { functions } from '../firebase';
+import { normalizePlannerSchedulingError } from '../utils/plannerScheduling';
 
 type ItemType = 'task' | 'story';
 
@@ -20,6 +21,16 @@ interface DeferItemModalProps {
   itemType: ItemType;
   itemId: string;
   itemTitle: string;
+  focusContext?: {
+    isFocusAligned?: boolean;
+    activeFocusGoals?: Array<{
+      id: string;
+      title?: string | null;
+      focusRootGoalIds?: string[];
+      focusLeafGoalIds?: string[];
+      goalIds?: string[];
+    }>;
+  };
   onApply: (payload: { dateMs: number; rationale: string; source: string }) => Promise<void>;
 }
 
@@ -43,6 +54,7 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
   itemType,
   itemId,
   itemTitle,
+  focusContext,
   onApply,
 }) => {
   const [loading, setLoading] = useState(false);
@@ -54,21 +66,35 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
   const [selectedKey, setSelectedKey] = useState<string>('');
   const [customDate, setCustomDate] = useState<string>('');
   const [showMoreSuggestions, setShowMoreSuggestions] = useState(false);
+  const hasFocusPressure = !focusContext?.isFocusAligned && (focusContext?.activeFocusGoals?.length || 0) > 0;
 
   useEffect(() => {
     if (!show) return;
     let cancelled = false;
+    console.info('[DeferItemModal] opened', { itemType, itemId, itemTitle });
 
     const loadOptions = async () => {
       setLoading(true);
       setError(null);
       try {
         const callable = httpsCallable(functions, 'suggestDeferralOptions');
-        const resp: any = await callable({ itemType, itemId, horizonDays: 21 });
+        const resp: any = await callable({
+          itemType,
+          itemId,
+          horizonDays: 21,
+          focusContext,
+        });
         const next = Array.isArray(resp?.data?.options) ? resp.data.options : [];
         const top = Array.isArray(resp?.data?.topOptions) ? resp.data.topOptions : next.slice(0, 3);
         const more = Array.isArray(resp?.data?.moreOptions) ? resp.data.moreOptions : next.slice(3);
         if (cancelled) return;
+        console.info('[DeferItemModal] suggestions_loaded', {
+          itemType,
+          itemId,
+          options: next.length,
+          topOptions: top.length,
+          moreOptions: more.length,
+        });
         setOptions(next);
         setTopOptions(top);
         setMoreOptions(more);
@@ -76,7 +102,8 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
         setShowMoreSuggestions(false);
       } catch (err: any) {
         if (cancelled) return;
-        setError(err?.message || 'Could not generate defer suggestions.');
+        console.error('[DeferItemModal] suggestions_failed', { itemType, itemId, err });
+        setError(normalizePlannerSchedulingError(err).message || 'Could not generate defer suggestions.');
         setOptions([]);
         setTopOptions([]);
         setMoreOptions([]);
@@ -90,7 +117,7 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [show, itemId, itemType]);
+  }, [show, itemId, itemType, itemTitle, focusContext]);
 
   const selectedOption = useMemo(
     () => options.find((opt) => opt.key === selectedKey) || null,
@@ -127,11 +154,21 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
     }
 
     setApplying(true);
+    console.info('[DeferItemModal] apply_clicked', {
+      itemType,
+      itemId,
+      itemTitle,
+      selectedKey,
+      dateMs,
+      source,
+      rationale,
+    });
     try {
       await onApply({ dateMs, rationale, source });
       onHide();
     } catch (err: any) {
-      setError(err?.message || 'Failed to defer this item.');
+      console.error('[DeferItemModal] apply_failed', { itemType, itemId, err });
+      setError(normalizePlannerSchedulingError(err).message || 'Failed to defer this item.');
     } finally {
       setApplying(false);
     }
@@ -149,6 +186,11 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
         <p className="text-muted small mb-3">
           Suggestions are ranked to reduce near-term overload using sprint windows and calendar utilization.
         </p>
+        {hasFocusPressure && (
+          <Alert variant="info" className="py-2 small">
+            This item is outside your active focus goals. Deferring it can free capacity for focus work.
+          </Alert>
+        )}
 
         {error && <Alert variant="warning" className="py-2">{error}</Alert>}
 

--- a/react-app/src/components/MobileHome.tsx
+++ b/react-app/src/components/MobileHome.tsx
@@ -1,15 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Container, Card, Button, Badge, ListGroup, Form, Modal, Spinner } from 'react-bootstrap';
-import { useNavigate } from 'react-router-dom';
 import { httpsCallable } from 'firebase/functions';
 import { collection, query, where, onSnapshot, orderBy, limit, updateDoc, doc, serverTimestamp } from 'firebase/firestore';
 import { db, functions } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
 import { useSprint } from '../contexts/SprintContext';
 import { usePersona } from '../contexts/PersonaContext';
-import { Goal, Story, Task, Sprint as SprintType } from '../types';
+import { Goal, Story, Task } from '../types';
 import { ActivityStreamService } from '../services/ActivityStreamService';
-import { ChoiceHelper, StoryStatus } from '../config/choices';
+import { ChoiceHelper } from '../config/choices';
 import { getBadgeVariant, getPriorityBadge, getStatusName } from '../utils/statusHelpers';
 import { taskStatusText } from '../utils/storyCardFormatting';
 import { extractWeatherSummary, extractWeatherTemp, formatWeatherLine } from '../utils/weatherFormat';
@@ -25,11 +24,24 @@ import {
   formatFullReplanSummary,
   normalizePlannerCallableError,
 } from '../utils/plannerOrchestration';
-import DailyPlanPage from './DailyPlanPage';
+import {
+  findItemWithManualPriorityRank,
+  getManualPriorityLabel,
+  getManualPriorityRank,
+  getNextManualPriorityRank,
+} from '../utils/manualPriority';
+import { useFocusGoals } from '../hooks/useFocusGoals';
+import { getProtectedFocusGoalIds, isGoalInHierarchySet } from '../utils/goalHierarchy';
+import { schedulePlannerItem as schedulePlannerItemMutation } from '../utils/plannerScheduling';
 
-type TabKey = 'overview' | 'tasks' | 'stories' | 'goals' | 'chores' | 'daily_plan';
+type TabKey = 'overview' | 'tasks' | 'stories' | 'goals' | 'chores';
 type TaskViewFilter = 'top3' | 'due_today' | 'overdue' | 'all';
 type GoalsViewFilter = 'active_sprint' | 'year';
+type MobileSharedFilters = {
+  top3: boolean;
+  chores: boolean;
+  focusAligned: boolean;
+};
 
 const THEME_COLORS: Record<number, string> = {
   1: '#22c55e', // Health
@@ -60,10 +72,10 @@ const formatShortDate = (value?: number) => {
 };
 
 const MobileHome: React.FC = () => {
-  const navigate = useNavigate();
   const { currentUser } = useAuth();
   const { selectedSprintId, setSelectedSprintId, sprints } = useSprint();
   const { currentPersona, setPersona } = usePersona();
+  const { activeFocusGoals } = useFocusGoals(currentUser?.uid);
 
   const [activeTab, setActiveTab] = useState<TabKey>('overview');
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -90,11 +102,11 @@ const MobileHome: React.FC = () => {
   const [choreCompletionBusy, setChoreCompletionBusy] = useState<Record<string, boolean>>({});
   const [convertingTaskId, setConvertingTaskId] = useState<string | null>(null);
   const [flaggingStoryId, setFlaggingStoryId] = useState<string | null>(null);
-  const [priorityFlagConfirm, setPriorityFlagConfirm] = useState<{ story: Story; existing: Story } | null>(null);
   const [priorityReplanPromptStory, setPriorityReplanPromptStory] = useState<Story | null>(null);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [editingStory, setEditingStory] = useState<Story | null>(null);
   const [deferTarget, setDeferTarget] = useState<{ type: 'task' | 'story'; id: string; title: string } | null>(null);
+  const [sharedFilters, setSharedFilters] = useState<MobileSharedFilters>({ top3: false, chores: false, focusAligned: false });
   const todayIso = useMemo(() => new Date().toISOString().split('T')[0], []);
   const activePlanningSprints = useMemo(
     () => sprints.filter((s) => s.status === 0 || s.status === 1),
@@ -353,6 +365,13 @@ const MobileHome: React.FC = () => {
   const storiesByRef = useMemo(() => new Map(stories.map(s => [(s.ref || s.id || '').toUpperCase(), s])), [stories]);
   const tasksByRef = useMemo(() => new Map(tasks.map(t => [(t.ref || t.id || '').toUpperCase(), t])), [tasks]);
   const goalsById = useMemo(() => new Map(goals.map(g => [g.id, g])), [goals]);
+  const protectedFocusGoalIds = useMemo(() => {
+    const ids = new Set<string>();
+    activeFocusGoals.forEach((focusGoal) => {
+      getProtectedFocusGoalIds(focusGoal).forEach((goalId) => ids.add(goalId));
+    });
+    return ids;
+  }, [activeFocusGoals]);
   const currentSprint = useMemo(() => {
     const source = activePlanningSprints.length ? activePlanningSprints : sprints;
     if (!source || !source.length) return undefined;
@@ -381,21 +400,69 @@ const MobileHome: React.FC = () => {
     return normalizeAiScore((story.metadata?.aiScore ?? story.metadata?.aiCriticalityScore ?? (story as any).aiCriticalityScore ?? null));
   }, [normalizeAiScore]);
 
+  const getTaskManualRank = useCallback((task: Task) => {
+    const directRank = getManualPriorityRank(task);
+    if (directRank) return directRank;
+    const parentStoryId = String(task.storyId || (task.parentType === 'story' ? task.parentId || '' : '')).trim();
+    if (!parentStoryId) return null;
+    return getManualPriorityRank(storiesById.get(parentStoryId));
+  }, [storiesById]);
+
+  const isStoryFocusAligned = useCallback((story?: Story | null) => {
+    const goalId = String(story?.goalId || '').trim();
+    if (!goalId || protectedFocusGoalIds.size === 0) return false;
+    return isGoalInHierarchySet(goalId, goals, protectedFocusGoalIds);
+  }, [goals, protectedFocusGoalIds]);
+
+  const isTaskFocusAligned = useCallback((task?: Task | null) => {
+    const directGoalId = String((task as any)?.goalId || '').trim();
+    if (directGoalId && protectedFocusGoalIds.size > 0) {
+      return isGoalInHierarchySet(directGoalId, goals, protectedFocusGoalIds);
+    }
+    const parentStoryId = String(task?.storyId || (task?.parentType === 'story' ? task?.parentId || '' : '')).trim();
+    if (!parentStoryId) return false;
+    return isStoryFocusAligned(storiesById.get(parentStoryId));
+  }, [goals, protectedFocusGoalIds, isStoryFocusAligned, storiesById]);
+
   const isTop3Task = useCallback((task: Task) => {
+    if (getTaskManualRank(task)) return true;
     const flagged = (task as any).aiTop3ForDay === true;
     if (!flagged) return false;
     const aiDate = (task as any).aiTop3Date;
     if (!aiDate) return true;
     return String(aiDate).slice(0, 10) === todayIso;
-  }, [todayIso]);
+  }, [getTaskManualRank, todayIso]);
 
   const isTop3Story = useCallback((story: Story) => {
+    if (getManualPriorityRank(story)) return true;
     const flagged = (story as any).aiTop3ForDay === true;
     if (!flagged) return false;
     const aiDate = (story as any).aiTop3Date;
     if (!aiDate) return true;
     return String(aiDate).slice(0, 10) === todayIso;
   }, [todayIso]);
+
+  const matchesTaskSharedFilters = useCallback((task: Task) => {
+    if (sharedFilters.top3 && !isTop3Task(task)) return false;
+    if (sharedFilters.chores && !getChoreKind(task)) return false;
+    if (sharedFilters.focusAligned && !isTaskFocusAligned(task)) return false;
+    return true;
+  }, [sharedFilters, isTop3Task, getChoreKind, isTaskFocusAligned]);
+
+  const matchesStorySharedFilters = useCallback((story: Story) => {
+    if (sharedFilters.top3 && !isTop3Story(story)) return false;
+    if (sharedFilters.chores) return false;
+    if (sharedFilters.focusAligned && !isStoryFocusAligned(story)) return false;
+    return true;
+  }, [sharedFilters, isTop3Story, isStoryFocusAligned]);
+
+  const matchesTimelineSharedFilters = useCallback((item: MobileTimelineItem) => {
+    if (!sharedFilters.top3 && !sharedFilters.chores && !sharedFilters.focusAligned) return true;
+    if (item.kind === 'event') return false;
+    if (item.story) return matchesStorySharedFilters(item.story);
+    if (item.task) return matchesTaskSharedFilters(item.task);
+    return false;
+  }, [sharedFilters, matchesStorySharedFilters, matchesTaskSharedFilters]);
 
   const sprintDaysLeft = useMemo(() => {
     if (!currentSprint) return null;
@@ -456,11 +523,6 @@ const MobileHome: React.FC = () => {
   const openNoteModal = (type: 'task'|'story'|'goal', id: string) => {
     setNoteText('');
     setNoteModal({ type, id, show: true });
-  };
-
-  const openDeepLink = (task: Task) => {
-    const href = task.ref ? `/tasks/${task.ref}` : `/tasks/${task.id}`;
-    window.open(href, '_blank');
   };
 
   const saveNote = async () => {
@@ -556,13 +618,6 @@ const MobileHome: React.FC = () => {
   };
 
   const handleFlagPriorityStory = async (story: Story) => {
-    const existing = stories.find(
-      (s) => s.id !== story.id && (s as any).userPriorityFlag === true && s.status !== 4
-    );
-    if (existing) {
-      setPriorityFlagConfirm({ story, existing });
-      return;
-    }
     await applyPriorityFlag(story);
   };
 
@@ -573,39 +628,72 @@ const MobileHome: React.FC = () => {
 
   const applyDeferredDate = useCallback(async ({ dateMs, rationale, source }: { dateMs: number; rationale: string; source: string }) => {
     if (!deferTarget) return;
-    const collectionName = deferTarget.type === 'story' ? 'stories' : 'tasks';
-    await updateDoc(doc(db, collectionName, deferTarget.id), {
-      deferredUntil: dateMs,
-      deferredReason: rationale,
-      deferredBy: source,
-      deferredAt: serverTimestamp(),
-      updatedAt: serverTimestamp(),
-    } as any);
+    const debugRequestId = `mobile-defer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const targetEntity = deferTarget.type === 'task'
+      ? tasks.find((task) => task.id === deferTarget.id) || null
+      : stories.find((story) => story.id === deferTarget.id) || null;
+    console.info('[MobileHome] defer_confirmed', {
+      debugRequestId,
+      itemType: deferTarget.type,
+      itemId: deferTarget.id,
+      title: deferTarget.title,
+      dateMs,
+      source,
+      rationale,
+    });
+    const targetBucketRaw = String((targetEntity as any)?.timeOfDay || '').trim().toLowerCase();
+    const targetBucket = targetBucketRaw === 'morning' || targetBucketRaw === 'afternoon' || targetBucketRaw === 'evening' || targetBucketRaw === 'anytime'
+      ? targetBucketRaw
+      : null;
+    await schedulePlannerItemMutation({
+      itemType: deferTarget.type,
+      itemId: deferTarget.id,
+      targetDateMs: dateMs,
+      targetBucket,
+      intent: 'defer',
+      source: source || 'mobile_home',
+      rationale,
+      durationMinutes: deferTarget.type === 'task'
+        ? Math.max(15, Number((targetEntity as any)?.estimateMin || 30))
+        : Math.max(15, Number((targetEntity as any)?.estimateMin || 60)),
+      debugRequestId,
+    });
     setDeferTarget(null);
-  }, [deferTarget]);
+  }, [deferTarget, tasks, stories]);
 
   const applyPriorityFlag = async (story: Story) => {
     setFlaggingStoryId(story.id);
     try {
-      // Clear any existing flag
-      const existingFlagged = stories.filter(
-        (s) => s.id !== story.id && (s as any).userPriorityFlag === true
-      );
-      for (const s of existingFlagged) {
-        await updateDoc(doc(db, 'stories', s.id), {
+      const storyPersona = String((story as any).persona || 'personal');
+      const currentRank = getManualPriorityRank(story);
+      if (currentRank) {
+        await updateDoc(doc(db, 'stories', story.id), {
           userPriorityFlag: false,
+          userPriorityRank: null,
+          userPriorityFlagAt: null,
           updatedAt: serverTimestamp(),
         });
-      }
-      // Set new flag (toggle if already flagged)
-      const isAlreadyFlagged = (story as any).userPriorityFlag === true;
-      await updateDoc(doc(db, 'stories', story.id), {
-        userPriorityFlag: !isAlreadyFlagged,
-        userPriorityFlagAt: isAlreadyFlagged ? null : new Date().toISOString(),
-        updatedAt: serverTimestamp(),
-      });
-      // Trigger rescore + replan
-      if (!isAlreadyFlagged) {
+      } else {
+        const nextRank = getNextManualPriorityRank(
+          stories.filter((entry) => entry.status !== 4),
+          storyPersona,
+          story.id,
+        );
+        const conflictingStory = findItemWithManualPriorityRank(stories, storyPersona, nextRank, story.id);
+        if (conflictingStory?.id) {
+          await updateDoc(doc(db, 'stories', conflictingStory.id), {
+            userPriorityFlag: false,
+            userPriorityRank: null,
+            userPriorityFlagAt: null,
+            updatedAt: serverTimestamp(),
+          });
+        }
+        await updateDoc(doc(db, 'stories', story.id), {
+          userPriorityFlag: true,
+          userPriorityRank: nextRank,
+          userPriorityFlagAt: new Date().toISOString(),
+          updatedAt: serverTimestamp(),
+        });
         const rescore = httpsCallable(functions, 'deltaPriorityRescore');
         await rescore({ entityId: story.id, entityType: 'story' }).catch(() => {});
         setPriorityReplanPromptStory(story);
@@ -614,7 +702,6 @@ const MobileHome: React.FC = () => {
       console.error('Failed to flag priority story', e);
     } finally {
       setFlaggingStoryId(null);
-      setPriorityFlagConfirm(null);
     }
   };
 
@@ -692,23 +779,27 @@ const MobileHome: React.FC = () => {
     return Number.isNaN(parsed) ? null : parsed;
   };
 
-  const getTaskDueValue = (task: Task) => {
+  const getTaskDueValue = useCallback((task: Task) => {
     const candidate = task.dueDate || task.dueDateMs || task.targetDate || null;
     return resolveDateValue(candidate) ?? Infinity;
-  };
+  }, []);
 
   const pendingTasks = useMemo(() => {
     let base = showCompleted ? tasks : tasks.filter(t => t.status !== 2);
     if (aiFocusOnly) {
       base = base.filter((task) => {
+        if (getTaskManualRank(task)) return true;
         const aiScore = getTaskAiScore(task);
         return aiScore != null && aiScore >= aiThreshold;
       });
     }
     return base;
-  }, [tasks, showCompleted, aiFocusOnly, aiThreshold, getTaskAiScore]);
+  }, [tasks, showCompleted, aiFocusOnly, aiThreshold, getTaskAiScore, getTaskManualRank]);
   const sortedPendingTasks = useMemo(() => {
     return [...pendingTasks].sort((a, b) => {
+      const manualA = getTaskManualRank(a) || 99;
+      const manualB = getTaskManualRank(b) || 99;
+      if (manualA !== manualB) return manualA - manualB;
       const aiA = getTaskAiScore(a) ?? 0;
       const aiB = getTaskAiScore(b) ?? 0;
       if (aiA !== aiB) return aiB - aiA;
@@ -717,17 +808,18 @@ const MobileHome: React.FC = () => {
       if (dueA !== dueB) return dueA - dueB;
       return (b.priority || 0) - (a.priority || 0);
     });
-  }, [pendingTasks, getTaskAiScore]);
+  }, [pendingTasks, getTaskAiScore, getTaskManualRank, getTaskDueValue]);
 
-  const getStoryDueValue = (story: Story) => {
+  const getStoryDueValue = useCallback((story: Story) => {
     const candidate = story.dueDate || story.targetDate || story.plannedStartDate || null;
     return resolveDateValue(candidate) ?? Infinity;
-  };
+  }, []);
 
   const filteredStories = useMemo(() => {
     let base = showCompleted ? stories : stories.filter(s => s.status !== 4);
     if (aiFocusOnly) {
       base = base.filter((story) => {
+        if (getManualPriorityRank(story)) return true;
         const aiScore = getStoryAiScore(story);
         return aiScore != null && aiScore >= aiThreshold;
       });
@@ -737,6 +829,9 @@ const MobileHome: React.FC = () => {
 
   const sortedStories = useMemo(() => {
     return [...filteredStories].sort((a, b) => {
+      const manualA = getManualPriorityRank(a) || 99;
+      const manualB = getManualPriorityRank(b) || 99;
+      if (manualA !== manualB) return manualA - manualB;
       const aiA = getStoryAiScore(a) ?? 0;
       const aiB = getStoryAiScore(b) ?? 0;
       if (aiA !== aiB) return aiB - aiA;
@@ -745,7 +840,7 @@ const MobileHome: React.FC = () => {
       if (dueA !== dueB) return dueA - dueB;
       return (b.priority || 0) - (a.priority || 0);
     });
-  }, [filteredStories, getStoryAiScore]);
+  }, [filteredStories, getStoryAiScore, getStoryDueValue]);
 
   const top3Tasks = useMemo(() => {
     return tasks
@@ -753,6 +848,9 @@ const MobileHome: React.FC = () => {
       .filter(t => t.status !== 2)
       .filter(isTop3Task)
       .sort((a, b) => {
+        const manualA = getTaskManualRank(a) || 99;
+        const manualB = getTaskManualRank(b) || 99;
+        if (manualA !== manualB) return manualA - manualB;
         const ar = Number((a as any).aiPriorityRank || 0) || 99;
         const br = Number((b as any).aiPriorityRank || 0) || 99;
         if (ar !== br) return ar - br;
@@ -762,13 +860,16 @@ const MobileHome: React.FC = () => {
         return String(a.title || '').localeCompare(String(b.title || ''));
       })
       .slice(0, 3);
-  }, [tasks, isTop3Task, getTaskAiScore]);
+  }, [tasks, isTop3Task, getTaskAiScore, getTaskManualRank]);
 
   const top3Stories = useMemo(() => {
     return stories
       .filter(s => s.status !== 4)
       .filter(isTop3Story)
       .sort((a, b) => {
+        const manualA = getManualPriorityRank(a) || 99;
+        const manualB = getManualPriorityRank(b) || 99;
+        if (manualA !== manualB) return manualA - manualB;
         const ar = Number((a as any).aiFocusStoryRank || 0) || 99;
         const br = Number((b as any).aiFocusStoryRank || 0) || 99;
         if (ar !== br) return ar - br;
@@ -779,8 +880,6 @@ const MobileHome: React.FC = () => {
       })
       .slice(0, 3);
   }, [stories, isTop3Story, getStoryAiScore]);
-
-  const top3TaskIdSet = useMemo(() => new Set(top3Tasks.map((task) => task.id)), [top3Tasks]);
 
   const tasksDueTodayForMobile = useMemo(() => {
     const today = new Date();
@@ -805,17 +904,28 @@ const MobileHome: React.FC = () => {
   }, [sortedPendingTasks, getTaskDueMs]);
 
   const visibleTaskRows = useMemo(() => {
+    let rows: Task[];
     if (tasksViewFilter === 'top3') {
-      return sortedPendingTasks.filter((task) => top3TaskIdSet.has(task.id));
+      rows = sortedPendingTasks.filter((task) => isTop3Task(task));
+    } else if (tasksViewFilter === 'due_today') {
+      rows = tasksDueTodayForMobile;
+    } else if (tasksViewFilter === 'overdue') {
+      rows = tasksOverdueForMobile;
+    } else {
+      rows = sortedPendingTasks;
     }
-    if (tasksViewFilter === 'due_today') {
-      return tasksDueTodayForMobile;
-    }
-    if (tasksViewFilter === 'overdue') {
-      return tasksOverdueForMobile;
-    }
-    return sortedPendingTasks;
-  }, [tasksViewFilter, sortedPendingTasks, top3TaskIdSet, tasksDueTodayForMobile, tasksOverdueForMobile]);
+    return rows.filter(matchesTaskSharedFilters);
+  }, [tasksViewFilter, sortedPendingTasks, isTop3Task, tasksDueTodayForMobile, tasksOverdueForMobile, matchesTaskSharedFilters]);
+
+  const visibleStoryRows = useMemo(
+    () => sortedStories.filter(matchesStorySharedFilters),
+    [sortedStories, matchesStorySharedFilters],
+  );
+
+  const visibleChoreRows = useMemo(
+    () => choresDueToday.filter(matchesTaskSharedFilters),
+    [choresDueToday, matchesTaskSharedFilters],
+  );
 
   const filteredGoalsForMobile = useMemo(() => {
     const currentYear = new Date().getFullYear();
@@ -842,7 +952,7 @@ const MobileHome: React.FC = () => {
     story?: Story;
   };
 
-  const bucketFromTime = (ms: number | null | undefined, timeOfDay?: string | null): MobileTimelineBucket => {
+  const bucketFromTime = useCallback((ms: number | null | undefined, timeOfDay?: string | null): MobileTimelineBucket => {
     const tod = String(timeOfDay || '').toLowerCase().trim();
     if (tod === 'morning' || tod === 'afternoon' || tod === 'evening') return tod as MobileTimelineBucket;
     if (!ms || !Number.isFinite(ms)) return 'morning';
@@ -851,7 +961,7 @@ const MobileHome: React.FC = () => {
     if (minute >= 300 && minute <= 779) return 'morning';
     if (minute >= 780 && minute <= 1139) return 'afternoon';
     return 'evening';
-  };
+  }, []);
 
   const timelineTimeLabel = (startMs: number | null | undefined, endMs?: number | null): string => {
     if (!startMs || !Number.isFinite(startMs)) return 'Anytime';
@@ -976,13 +1086,15 @@ const MobileHome: React.FC = () => {
       });
     });
 
-    return rows.sort((a, b) => {
+    return rows
+      .filter(matchesTimelineSharedFilters)
+      .sort((a, b) => {
       const aTime = a.sortMs ?? Number.MAX_SAFE_INTEGER;
       const bTime = b.sortMs ?? Number.MAX_SAFE_INTEGER;
       if (aTime !== bTime) return aTime - bTime;
       return a.title.localeCompare(b.title);
     });
-  }, [tasksDueTodayForMobile, choresDueToday, sortedStories, overviewCalendarEvents, getTaskDueMs]);
+  }, [tasksDueTodayForMobile, choresDueToday, sortedStories, overviewCalendarEvents, getTaskDueMs, matchesTimelineSharedFilters, bucketFromTime]);
 
   const renderChoresHabitsWidget = () => {
     // Group by time-of-day bucket, respecting explicit timeOfDay field before falling back to schedule time.
@@ -993,7 +1105,7 @@ const MobileHome: React.FC = () => {
       { key: 'evening' as const, label: 'Evening' },
     ] as const;
     const grouped = { morning: [] as Task[], afternoon: [] as Task[], evening: [] as Task[] };
-    choresDueToday.forEach((task) => {
+    visibleChoreRows.forEach((task) => {
       const bucket = bucketFromTime(toChoreMs(task), (task as any).timeOfDay);
       grouped[bucket].push(task);
     });
@@ -1007,6 +1119,10 @@ const MobileHome: React.FC = () => {
       const dueLabel = formatDueLabel(dueMs);
       const isOverdue = !!dueMs && dueMs < todayStartMs;
       const busy = !!choreCompletionBusy[task.id];
+      const aiScore = getTaskAiScore(task);
+      const manualPriority = getManualPriorityLabel(task) || null;
+      const top3 = isTop3Task(task);
+      const focusAligned = isTaskFocusAligned(task);
       return (
         <ListGroup.Item key={task.id} className="d-flex align-items-center gap-2" style={{ fontSize: 14 }}>
           <Form.Check
@@ -1019,6 +1135,12 @@ const MobileHome: React.FC = () => {
           <div className="flex-grow-1">
             <div className="fw-semibold">{task.title}</div>
             <div className="text-muted small">{isOverdue ? `Overdue · ${dueLabel}` : `Due ${dueLabel}`}</div>
+            <div className="d-flex flex-wrap gap-1 mt-1">
+              {manualPriority && <Badge bg="danger">{manualPriority}</Badge>}
+              {top3 && <Badge bg="warning" text="dark">Top 3</Badge>}
+              {focusAligned && <Badge bg="success">Focus</Badge>}
+              {aiScore != null && <Badge bg="secondary">AI {Math.round(aiScore)}/100</Badge>}
+            </div>
           </div>
           <div className="d-flex flex-column align-items-end gap-1">
             {isOverdue && <Badge bg="danger">Overdue</Badge>}
@@ -1033,13 +1155,13 @@ const MobileHome: React.FC = () => {
         <Card.Header className="py-2 d-flex align-items-center justify-content-between" style={{ background: 'transparent', border: 'none' }}>
           <div>
             <strong>Chores &amp; Habits</strong>
-            <Badge bg="secondary" pill className="ms-2">{choresDueToday.length}</Badge>
+            <Badge bg="secondary" pill className="ms-2">{visibleChoreRows.length}</Badge>
           </div>
         </Card.Header>
         <Card.Body className="pt-0">
           {choresLoading ? (
             <div className="text-muted small">Loading chores…</div>
-          ) : choresDueToday.length === 0 ? (
+          ) : visibleChoreRows.length === 0 ? (
             <div className="text-muted small">No chores, habits, or routines due today.</div>
           ) : hasGroups ? (
             <>
@@ -1060,7 +1182,7 @@ const MobileHome: React.FC = () => {
             </>
           ) : (
             <ListGroup variant="flush">
-              {choresDueToday.map(renderChoreItem)}
+              {visibleChoreRows.map(renderChoreItem)}
             </ListGroup>
           )}
         </Card.Body>
@@ -1232,11 +1354,11 @@ const MobileHome: React.FC = () => {
         </Card>
       </div>
       {/* AI Daily Summary + Focus */}
-      {/* Tabs: Overview | Tasks | Stories | Goals | Chores | Daily Plan */}
+      {/* Tabs: Overview | Tasks | Stories | Goals | Chores */}
       <div className="mobile-filter-tabs mb-3">
         <div className="d-flex align-items-center gap-1 flex-nowrap" style={{ overflowX: 'auto', WebkitOverflowScrolling: 'touch' }}>
           <div className="btn-group flex-nowrap w-100" role="group">
-            {(['overview','tasks','stories','goals','chores','daily_plan'] as TabKey[]).map(key => (
+            {(['overview','tasks','stories','goals','chores'] as TabKey[]).map(key => (
               <Button
                 key={key}
                 variant={activeTab === key ? 'primary' : 'outline-primary'}
@@ -1244,22 +1366,46 @@ const MobileHome: React.FC = () => {
                 onClick={() => setActiveTab(key)}
                 style={{ padding: '3px 6px', fontSize: 11, whiteSpace: 'nowrap' }}
               >
-                {key === 'overview'
-                  ? 'Overview'
-                  : key === 'tasks'
-                    ? 'Tasks'
-                    : key === 'stories'
-                      ? 'Stories'
-                      : key === 'goals'
-                        ? 'Goals'
-                        : key === 'chores'
-                          ? 'Chores'
-                          : 'Daily Plan'}
+                {key === 'overview' ? 'Overview' : key === 'tasks' ? 'Tasks' : key === 'stories' ? 'Stories' : key === 'goals' ? 'Goals' : 'Chores'}
               </Button>
             ))}
           </div>
         </div>
       </div>
+
+      {activeTab !== 'goals' && (
+        <>
+          <div className="d-flex flex-wrap gap-2 mb-2">
+            <Button
+              size="sm"
+              variant={sharedFilters.top3 ? 'danger' : 'outline-danger'}
+              className="rounded-pill"
+              onClick={() => setSharedFilters((prev) => ({ ...prev, top3: !prev.top3 }))}
+            >
+              Top 3
+            </Button>
+            <Button
+              size="sm"
+              variant={sharedFilters.chores ? 'success' : 'outline-success'}
+              className="rounded-pill"
+              onClick={() => setSharedFilters((prev) => ({ ...prev, chores: !prev.chores }))}
+            >
+              Chores
+            </Button>
+            <Button
+              size="sm"
+              variant={sharedFilters.focusAligned ? 'primary' : 'outline-primary'}
+              className="rounded-pill"
+              onClick={() => setSharedFilters((prev) => ({ ...prev, focusAligned: !prev.focusAligned }))}
+            >
+              Focus aligned
+            </Button>
+          </div>
+          <div className="text-muted small mb-3">
+            Top 3 is AI-ranked by default. Manual <strong>#1</strong>, <strong>#2</strong>, and <strong>#3</strong> override AI ranking, and any unassigned Top 3 slots are filled by AI during replanning.
+          </div>
+        </>
+      )}
 
       {(activeTab === 'tasks' || activeTab === 'stories' || activeTab === 'goals') && (
         <div className="d-flex flex-wrap gap-2 mb-3 align-items-center">
@@ -1530,18 +1676,137 @@ const MobileHome: React.FC = () => {
             </Card>
           )}
 
-          <Card className="mb-3" style={{ background: '#eef2ff' }}>
-            <Card.Header className="py-2 d-flex align-items-center justify-content-between" style={{ background: 'transparent', border: 'none' }}>
-              <div>
+              <Card className="mb-3" style={{ background: '#eef2ff' }}>
+              <Card.Header className="py-2 d-flex align-items-center justify-content-between" style={{ background: 'transparent', border: 'none' }}>
+                <div>
                 <strong>Daily Plan</strong>
-                <Badge bg="info" pill className="ms-2">Tab</Badge>
+                <Badge bg="secondary" pill className="ms-2">{unifiedTimelineItems.length}</Badge>
               </div>
             </Card.Header>
             <Card.Body className="pt-0">
-              <div className="text-muted small mb-2">Daily Plan is available as its own tab in the mobile overview menu.</div>
-              <Button size="sm" variant="outline-primary" onClick={() => setActiveTab('daily_plan')}>
-                Open Daily Plan tab
-              </Button>
+              <div className="text-muted small mb-2">Tip: Use the clock icon on task/story cards to defer with smart suggestions.</div>
+              {unifiedTimelineItems.length === 0 ? (
+                <div className="text-muted small">No tasks, stories, chores, or calendar events scheduled today.</div>
+              ) : (
+                (['morning', 'afternoon', 'evening'] as MobileTimelineBucket[]).map((bucket) => {
+                  const items = unifiedTimelineItems.filter((row) => row.bucket === bucket);
+                  if (items.length === 0) return null;
+                  const label = bucket === 'morning' ? 'Morning' : bucket === 'afternoon' ? 'Afternoon' : 'Evening';
+                  return (
+                    <div key={bucket} className="mb-2">
+                      <div className="text-uppercase text-muted small fw-semibold mb-1">{label}</div>
+                      <ListGroup variant="flush">
+                        {items.map((item) => {
+                          const isTask = item.kind === 'task' || item.kind === 'chore';
+                          const isDone = !!item.task && Number(item.task.status ?? 0) === 2;
+                          const aiScore = item.task ? getTaskAiScore(item.task) : item.story ? getStoryAiScore(item.story) : null;
+                          const manualPriority = item.task
+                            ? getManualPriorityLabel(item.task)
+                            : item.story
+                              ? getManualPriorityLabel(item.story)
+                              : null;
+                          const top3 = item.task ? isTop3Task(item.task) : item.story ? isTop3Story(item.story) : false;
+                          const focusAligned = item.task ? isTaskFocusAligned(item.task) : item.story ? isStoryFocusAligned(item.story) : false;
+                          const badgeVariant =
+                            item.kind === 'story' ? 'info' :
+                            item.kind === 'chore' ? 'success' :
+                            item.kind === 'event' ? 'secondary' : 'primary';
+                          const badgeLabel =
+                            item.kind === 'story' ? 'Story' :
+                            item.kind === 'chore' ? 'Chore' :
+                            item.kind === 'event' ? 'Event' : 'Task';
+                          return (
+                            <ListGroup.Item key={item.id} className="d-flex align-items-center gap-2" style={{ fontSize: 14 }}>
+                              {isTask && item.task ? (
+                                <Form.Check
+                                  type="checkbox"
+                                  checked={isDone || !!choreCompletionBusy[item.task.id]}
+                                  disabled={isDone || !!choreCompletionBusy[item.task.id]}
+                                  onChange={() => {
+                                    if (item.kind === 'chore') {
+                                      void handleCompleteChoreTask(item.task!);
+                                    } else {
+                                      void updateTaskField(item.task!, { status: 2 });
+                                    }
+                                  }}
+                                  aria-label={`Complete ${item.title}`}
+                                />
+                              ) : (
+                                <span style={{ width: 14 }} />
+                              )}
+                              <div className="flex-grow-1">
+                                <div className="fw-semibold">
+                                  {item.task ? (
+                                    <button
+                                      type="button"
+                                      className="btn btn-link p-0 text-decoration-none text-start align-baseline"
+                                      onClick={() => setEditingTask(item.task!)}
+                                    >
+                                      {item.title}
+                                    </button>
+                                  ) : item.story ? (
+                                    <button
+                                      type="button"
+                                      className="btn btn-link p-0 text-decoration-none text-start align-baseline"
+                                      onClick={() => setEditingStory(item.story!)}
+                                    >
+                                      {item.title}
+                                    </button>
+                                  ) : (
+                                    item.title
+                                  )}
+                                </div>
+                                <div className="text-muted small">{item.timeLabel}</div>
+                                {(manualPriority || top3 || focusAligned || aiScore != null || item.task || item.story) && (
+                                  <div className="d-flex flex-wrap gap-1 mt-1">
+                                    {manualPriority && <Badge bg="danger">{manualPriority}</Badge>}
+                                    {top3 && <Badge bg="warning" text="dark">Top 3</Badge>}
+                                    {focusAligned && <Badge bg="success">Focus</Badge>}
+                                    {aiScore != null && <Badge bg="secondary">AI {Math.round(aiScore)}/100</Badge>}
+                                  </div>
+                                )}
+                                {(item.task || item.story) && (
+                                  <div className="d-flex flex-wrap gap-2 mt-2">
+                                    <Button
+                                      variant="outline-secondary"
+                                      size="sm"
+                                      onClick={() => openNoteModal(item.task ? 'task' : 'story', item.task ? item.task.id : item.story!.id)}
+                                    >
+                                      Note
+                                    </Button>
+                                    <Button
+                                      variant="outline-warning"
+                                      size="sm"
+                                      onClick={() => setDeferTarget({
+                                        type: item.story ? 'story' : 'task',
+                                        id: item.story ? item.story.id : item.task!.id,
+                                        title: item.title,
+                                      })}
+                                    >
+                                      Defer
+                                    </Button>
+                                    <Button
+                                      variant="outline-primary"
+                                      size="sm"
+                                      onClick={() => {
+                                        if (item.task) setEditingTask(item.task);
+                                        if (item.story) setEditingStory(item.story);
+                                      }}
+                                    >
+                                      Edit
+                                    </Button>
+                                  </div>
+                                )}
+                              </div>
+                              <Badge bg={badgeVariant}>{badgeLabel}</Badge>
+                            </ListGroup.Item>
+                          );
+                        })}
+                      </ListGroup>
+                    </div>
+                  );
+                })
+              )}
             </Card.Body>
           </Card>
 
@@ -1657,7 +1922,9 @@ const MobileHome: React.FC = () => {
                 const storyLabel = story ? `${story.ref} · ${story.title}` : task.ref;
                 const goalLabel = goal ? `Goal: ${goal.title}` : 'Unlinked goal';
                 const aiScore = getTaskAiScore(task);
-                const isCriticalTask = (task.priority || 0) >= 4;
+                const manualPriorityLabel = getManualPriorityLabel(task);
+                const isTaskTop3 = isTop3Task(task);
+                const focusAligned = isTaskFocusAligned(task);
                 return (
                   <ListGroup.Item
                     key={task.id}
@@ -1691,14 +1958,12 @@ const MobileHome: React.FC = () => {
                             <option value={3}>High</option>
                             <option value={4}>Critical</option>
                           </select>
-                          {aiScore != null && (
-                            <Badge pill bg="secondary">AI {Math.round(aiScore)}/100</Badge>
-                          )}
                         </div>
                       </div>
                       <div className="d-flex align-items-center gap-2 mt-2 flex-nowrap" style={{ minWidth: 0 }}>
                         <Form.Select
                           size="sm"
+                          className="dashboard-chip-select"
                           value={Number(task.status)}
                           onChange={(e) => updateTaskField(task, { status: Number(e.target.value) as any })}
                           style={{ flex: 1, minWidth: 0 }}
@@ -1721,6 +1986,14 @@ const MobileHome: React.FC = () => {
                       <div className="d-flex flex-wrap gap-2 mt-1 align-items-center small text-muted">
                         <span>Status: {taskStatusText(task.status)}</span>
                         <span>Due: {formatShortDate(task.dueDate)}</span>
+                      </div>
+                      <div className="d-flex flex-wrap gap-1 mt-2">
+                        {manualPriorityLabel && <Badge pill bg="danger">{manualPriorityLabel}</Badge>}
+                        {isTaskTop3 && <Badge pill bg="warning" text="dark">Top 3</Badge>}
+                        {focusAligned && <Badge pill bg="success">Focus</Badge>}
+                        {aiScore != null && (
+                          <Badge pill bg="secondary">AI {Math.round(aiScore)}/100</Badge>
+                        )}
                       </div>
                       <div className="d-flex flex-wrap gap-2 mt-2 align-items-center">
                         <Button variant="outline-secondary" size="sm" onClick={() => openNoteModal('task', task.id)}>Note</Button>
@@ -1754,20 +2027,28 @@ const MobileHome: React.FC = () => {
         </div>
       )}
 
-      {activeTab === 'daily_plan' && (
-        <div>
-          <DailyPlanPage />
-        </div>
-      )}
-
       {activeTab === 'stories' && (
+        visibleStoryRows.length === 0 ? (
+          <Card className="text-center p-4">
+            <Card.Body>
+              <div className="text-muted">No stories match the current mobile filters.</div>
+            </Card.Body>
+          </Card>
+        ) : (
         <ListGroup>
-          {sortedStories.map(story => {
+          {visibleStoryRows.map(story => {
             const goal = goalsById.get(story.goalId);
             const themeColor = resolveThemeColor(goal?.theme ?? story.theme);
             const acceptance = story.acceptanceCriteria?.slice(0, 2).join(' · ');
-            const isCriticalStory = (story.priority || 0) >= 4;
             const aiScore = getStoryAiScore(story);
+            const manualPriorityRank = getManualPriorityRank(story);
+            const focusAligned = isStoryFocusAligned(story);
+            const isStoryTop3 = isTop3Story(story);
+            const suggestedManualRank = manualPriorityRank || getNextManualPriorityRank(
+              stories.filter((entry) => entry.status !== 4),
+              String((story as any).persona || 'personal'),
+              story.id,
+            );
             return (
               <ListGroup.Item
                 key={story.id}
@@ -1803,17 +2084,12 @@ const MobileHome: React.FC = () => {
                           </select>
                         );
                       })()}
-                      {(story as any).userPriorityFlag && (
-                        <Badge pill bg="danger">#1 Priority</Badge>
-                      )}
-                      {aiScore != null && (
-                        <Badge pill bg="secondary">AI {Math.round(aiScore)}/100</Badge>
-                      )}
                     </div>
                   </div>
                   <div className="d-flex flex-wrap gap-2 align-items-center mt-2">
                     <Form.Select
                       size="sm"
+                      className="dashboard-chip-select"
                       value={Number(story.status)}
                       onChange={(e) => updateStoryField(story, { status: Number(e.target.value) as any })}
                       style={{ minWidth: 160 }}
@@ -1824,13 +2100,13 @@ const MobileHome: React.FC = () => {
                     </Form.Select>
                     <Button variant="outline-secondary" size="sm" onClick={() => openNoteModal('story', story.id)}>Add Note</Button>
                     <Button
-                      variant={(story as any).userPriorityFlag ? 'danger' : 'outline-warning'}
+                      variant={manualPriorityRank ? 'danger' : 'outline-warning'}
                       size="sm"
                       disabled={flaggingStoryId === story.id}
                       onClick={() => handleFlagPriorityStory(story)}
-                      title={(story as any).userPriorityFlag ? 'Remove #1 priority flag' : 'Flag as #1 priority for calendar'}
+                      title={manualPriorityRank ? `Remove manual ${getManualPriorityLabel(story)}` : `Set manual #${suggestedManualRank} priority`}
                     >
-                      <AlertCircle size={14} /> {(story as any).userPriorityFlag ? '#1' : 'Priority'}
+                      <AlertCircle size={14} /> #{manualPriorityRank || suggestedManualRank}
                     </Button>
                     <Button
                       variant="outline-secondary"
@@ -1843,6 +2119,10 @@ const MobileHome: React.FC = () => {
                   </div>
                   <div className="d-flex flex-wrap gap-2 mt-2">
                     <Badge pill bg="dark">Pts {story.points || 0}</Badge>
+                    {manualPriorityRank && <Badge pill bg="danger">{getManualPriorityLabel(story)}</Badge>}
+                    {isStoryTop3 && <Badge pill bg="warning" text="dark">Top 3</Badge>}
+                    {focusAligned && <Badge pill bg="success">Focus</Badge>}
+                    {aiScore != null && <Badge pill bg="secondary">AI {Math.round(aiScore)}/100</Badge>}
                     {sprintDaysLeft != null && (
                       <Badge
                         pill
@@ -1861,6 +2141,7 @@ const MobileHome: React.FC = () => {
             );
           })}
         </ListGroup>
+        )
       )}
 
       {activeTab === 'goals' && (
@@ -1980,37 +2261,13 @@ const MobileHome: React.FC = () => {
         </Modal.Footer>
       </Modal>
 
-      {/* Priority flag confirmation modal */}
-      <Modal show={!!priorityFlagConfirm} onHide={() => setPriorityFlagConfirm(null)} centered>
-        <Modal.Header closeButton>
-          <Modal.Title style={{ fontSize: 16 }}>#1 Priority Already Set</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <p>
-            <strong>{priorityFlagConfirm?.existing?.title}</strong> is already flagged as the #1 priority story.
-          </p>
-          <p>Replace it with <strong>{priorityFlagConfirm?.story?.title}</strong>?</p>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button variant="secondary" size="sm" onClick={() => setPriorityFlagConfirm(null)}>Cancel</Button>
-          <Button
-            variant="danger"
-            size="sm"
-            disabled={!!flaggingStoryId}
-            onClick={() => priorityFlagConfirm && applyPriorityFlag(priorityFlagConfirm.story)}
-          >
-            {flaggingStoryId ? <Spinner animation="border" size="sm" /> : 'Replace'}
-          </Button>
-        </Modal.Footer>
-      </Modal>
-
       <Modal show={!!priorityReplanPromptStory} onHide={() => setPriorityReplanPromptStory(null)} centered>
         <Modal.Header closeButton>
           <Modal.Title style={{ fontSize: 16 }}>Run Delta Replan?</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <p className="mb-2">
-            <strong>{priorityReplanPromptStory?.title || 'This story'}</strong> is now flagged as your #1 priority.
+            <strong>{priorityReplanPromptStory?.title || 'This story'}</strong> is now flagged as {getManualPriorityLabel(priorityReplanPromptStory) || 'a manual priority'}.
           </p>
           <p className="mb-0 text-muted small">
             Run delta replan now to create or rebalance calendar blocks around the new priority.

--- a/react-app/src/components/planner/PlannerWorkCard.tsx
+++ b/react-app/src/components/planner/PlannerWorkCard.tsx
@@ -1,0 +1,460 @@
+import React from 'react';
+import { Button, Card, Form } from 'react-bootstrap';
+import { Activity, CalendarClock, CalendarPlus, Check, ChevronDown, ChevronUp, Clock3, Edit3, MoveRight, Sparkles, Target } from 'lucide-react';
+import type { PlannerItem } from '../../utils/plannerItems';
+import { priorityLabel as formatPriorityLabel, priorityPillClass, storyStatusText, taskStatusText } from '../../utils/storyCardFormatting';
+import { getManualPriorityLabel } from '../../utils/manualPriority';
+import '../../styles/KanbanCards.css';
+
+type PlannerCardContext = 'daily' | 'weekly';
+
+interface PlannerCardRecommendation {
+  label: string;
+  rationale: string;
+}
+
+interface PlannerWorkCardProps {
+  item: PlannerItem;
+  context: PlannerCardContext;
+  isMobileLayout: boolean;
+  applyingKey?: string | null;
+  showDoneControl?: boolean;
+  doneAsCheckbox?: boolean;
+  showInlineRecommendation?: boolean;
+  recommendation?: PlannerCardRecommendation | null;
+  canEditState?: boolean;
+  canShowActions?: boolean;
+  expanded?: boolean;
+  onToggleExpanded?: (item: PlannerItem) => void;
+  onToggleDone?: (item: PlannerItem) => void;
+  onOpenActivity?: (item: PlannerItem) => void;
+  onOpenEditor?: (item: PlannerItem) => void;
+  onSchedule?: (item: PlannerItem) => void;
+  onMove?: (item: PlannerItem) => void;
+  onDefer?: (item: PlannerItem) => void;
+  onAcceptRecommendation?: (item: PlannerItem) => void;
+  onCycleStatus?: (item: PlannerItem) => void;
+  onCyclePriority?: (item: PlannerItem) => void;
+  onStatusChange?: (item: PlannerItem, nextStatus: number) => void;
+  onPriorityChange?: (item: PlannerItem, nextPriority: number) => void;
+}
+
+const normalizeAiScore = (value: any): number | null => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  if (numeric <= 1) return Math.round(numeric * 100);
+  return Math.round(numeric);
+};
+
+const formatDateChip = (value?: number | null) => {
+  if (!value) return null;
+  return new Date(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+};
+
+const buildChildMeta = (child: PlannerItem) => {
+  const parts = [child.ref, child.timeLabel].filter(Boolean);
+  return parts.join(' · ');
+};
+
+const PlannerWorkCard: React.FC<PlannerWorkCardProps> = ({
+  item,
+  context,
+  isMobileLayout,
+  applyingKey = null,
+  showDoneControl = true,
+  doneAsCheckbox = false,
+  showInlineRecommendation = false,
+  recommendation = null,
+  canEditState = true,
+  canShowActions = true,
+  expanded = false,
+  onToggleExpanded,
+  onToggleDone,
+  onOpenActivity,
+  onOpenEditor,
+  onSchedule,
+  onMove,
+  onDefer,
+  onAcceptRecommendation,
+  onCycleStatus,
+  onCyclePriority,
+  onStatusChange,
+  onPriorityChange,
+}) => {
+  const isEvent = item.kind === 'event';
+  const isGroup = Array.isArray(item.childItems) && item.childItems.length > 0;
+  const itemKindLabel = item.kind === 'story' ? 'Story' : item.kind === 'chore' ? (isGroup ? 'Chore block' : 'Chore') : item.kind === 'event' ? 'Event' : 'Task';
+  const choiceTable = item.rawStory ? 'story' : 'task';
+  const statusValue = item.rawStory ? Number((item.rawStory as any)?.status ?? 0) : Number((item.rawTask as any)?.status ?? 0);
+  const priorityValue = Number((item.rawTask as any)?.priority ?? (item.rawStory as any)?.priority ?? 0);
+  const statusLabel = item.kind === 'event'
+    ? 'Event'
+    : choiceTable === 'story'
+      ? storyStatusText(statusValue)
+      : taskStatusText(statusValue);
+  const priorityLabel = formatPriorityLabel(priorityValue, 'No priority');
+  const manualPriorityLabel = getManualPriorityLabel(item.rawStory || item.rawTask);
+  const aiScore = normalizeAiScore(
+    (item.rawTask as any)?.aiCriticalityScore
+    ?? (item.rawTask as any)?.metadata?.aiScore
+    ?? (item.rawTask as any)?.metadata?.aiCriticalityScore
+    ?? (item.rawStory as any)?.metadata?.aiScore
+    ?? (item.rawStory as any)?.metadata?.aiCriticalityScore
+    ?? (item.rawStory as any)?.aiCriticalityScore
+    ?? null,
+  );
+  const dueValue = formatDateChip(item.dueAt);
+  const deferredLabel = item.deferredUntilMs
+    ? `Deferred to ${new Date(item.deferredUntilMs).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`
+    : null;
+  const scheduledBlockLabel = (() => {
+    if (!item.timeLabel) return null;
+    if (item.scheduledBlockStart && item.scheduledBlockEnd) {
+      const start = new Date(item.scheduledBlockStart);
+      const end = new Date(item.scheduledBlockEnd);
+      const dayLabel = start.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
+      const timeLabel = `${start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}-${end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+      return `Planned ${dayLabel} ${timeLabel}`;
+    }
+    if (item.scheduledBlockStart) {
+      const start = new Date(item.scheduledBlockStart);
+      const dayLabel = start.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
+      const timeLabel = start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      return `Planned ${dayLabel} ${timeLabel}`;
+    }
+    return item.timeLabel;
+  })();
+  const scheduledSourceClassName = String(item.scheduledSourceLabel || '').toLowerCase().includes('gcal')
+    ? 'kanban-card__source-note kanban-card__source-note--quiet'
+    : 'kanban-card__source-note';
+  const pointsValue = Number((item.rawTask as any)?.points ?? (item.rawStory as any)?.points ?? 0);
+  const actionButtons = canShowActions && !isEvent;
+  const color = item.kind === 'story' ? '#0dcaf0' : item.kind === 'chore' ? '#198754' : item.kind === 'event' ? '#6c757d' : '#0d6efd';
+
+  return (
+    <Card
+      key={item.id}
+      className="border shadow-sm"
+      style={{ borderLeft: `4px solid ${color}` }}
+    >
+      <Card.Body className={isMobileLayout ? 'p-2' : context === 'weekly' ? 'p-2' : 'p-3'}>
+        <div className="d-flex align-items-start gap-2">
+          {showDoneControl && !isEvent && !isGroup && onToggleDone && (
+            doneAsCheckbox ? (
+              <Form.Check
+                type="checkbox"
+                checked={false}
+                disabled={applyingKey === item.id}
+                onChange={() => onToggleDone(item)}
+                className="mt-1"
+              />
+            ) : (
+              <Button
+                size="sm"
+                variant="outline-success"
+                className="rounded-circle d-inline-flex align-items-center justify-content-center p-1 mt-1 flex-shrink-0"
+                onClick={() => onToggleDone(item)}
+                disabled={applyingKey === item.id}
+              >
+                <Check size={14} />
+              </Button>
+            )
+          )}
+
+          <div className="flex-grow-1 min-w-0">
+            <div className={`d-flex ${isMobileLayout ? 'flex-column' : 'align-items-start justify-content-between'} gap-2`}>
+              <div className="min-w-0">
+                <div className="fw-semibold small kanban-card__title mb-1" style={{ lineHeight: 1.25 }}>
+                    {item.title}
+                </div>
+                <div className="kanban-card__meta">
+                  {!isEvent && !isGroup && canEditState && (
+                    onPriorityChange ? (
+                      <Form.Select
+                        size="sm"
+                        aria-label="Priority"
+                        value={priorityValue}
+                        onChange={(event) => onPriorityChange(item, Number(event.target.value))}
+                        className={priorityPillClass(priorityValue > 0 ? priorityValue : null)}
+                        style={{ minWidth: isMobileLayout ? 110 : 120, backgroundClip: 'padding-box' }}
+                      >
+                        <option value={0}>No priority</option>
+                        <option value={1}>Low</option>
+                        <option value={2}>Medium</option>
+                        <option value={3}>High</option>
+                        <option value={4}>Critical</option>
+                      </Form.Select>
+                    ) : onCyclePriority ? (
+                      <button
+                        type="button"
+                        className={priorityPillClass(priorityValue > 0 ? priorityValue : null)}
+                        style={{ appearance: 'none', backgroundClip: 'padding-box', cursor: 'pointer' }}
+                        onClick={() => onCyclePriority(item)}
+                        title="Tap to cycle priority"
+                      >
+                        {priorityLabel}
+                      </button>
+                    ) : null
+                  )}
+                  {manualPriorityLabel && (
+                    <span
+                      className="kanban-card__meta-badge"
+                      style={{
+                        borderColor: 'rgba(220, 53, 69, 0.45)',
+                        backgroundColor: 'rgba(220, 53, 69, 0.12)',
+                        color: 'var(--bs-danger)',
+                      }}
+                      title="Manual priority"
+                    >
+                      {manualPriorityLabel}
+                    </span>
+                  )}
+                  {item.isTop3 && (
+                    <span className="kanban-card__meta-badge kanban-card__meta-badge--top3" title="Top 3 priority">
+                      Top 3
+                    </span>
+                  )}
+                  {isGroup && (
+                    <span className="kanban-card__meta-badge" title="Grouped recurring items">
+                      {item.childItems!.length} items
+                    </span>
+                  )}
+                  {pointsValue > 0 && (
+                    <span className="kanban-card__meta-badge" title="Estimated points">
+                      {pointsValue} pts
+                    </span>
+                  )}
+                  {item.progressPct != null && (item.kind === 'task' || item.kind === 'story') && (
+                    <span className="kanban-card__meta-badge" title="Progress">
+                      Progress {Math.round(item.progressPct)}%
+                    </span>
+                  )}
+                  {scheduledBlockLabel && (
+                    <span className="d-inline-flex flex-column" style={{ lineHeight: 1.2 }}>
+                      <span
+                        className="kanban-card__meta-badge"
+                        style={{
+                          borderColor: 'rgba(37, 99, 235, 0.45)',
+                          backgroundColor: 'rgba(37, 99, 235, 0.12)',
+                          color: '#2563eb',
+                        }}
+                        title={scheduledBlockLabel}
+                      >
+                        <CalendarClock size={11} style={{ marginRight: 4, marginTop: -1 }} />
+                        {scheduledBlockLabel}
+                      </span>
+                      {item.scheduledSourceLabel && (
+                        <span className={scheduledSourceClassName} style={{ marginTop: 2 }}>
+                          {item.scheduledSourceLabel}
+                        </span>
+                      )}
+                    </span>
+                  )}
+                  {deferredLabel && (
+                    <span
+                      className="kanban-card__meta-badge"
+                      style={{
+                        borderColor: 'rgba(245, 158, 11, 0.45)',
+                        backgroundColor: 'rgba(245, 158, 11, 0.12)',
+                        color: '#b45309',
+                      }}
+                      title={deferredLabel}
+                    >
+                      <Clock3 size={11} style={{ marginRight: 4, marginTop: -1 }} />
+                      Deferred
+                    </span>
+                  )}
+                  {dueValue && (
+                    <span className="kanban-card__meta-badge" title={`Due ${dueValue}`}>
+                      Due {dueValue}
+                    </span>
+                  )}
+                  {item.isFocusAligned && (
+                    <span className="kanban-card__meta-badge" style={{ borderColor: 'rgba(22, 163, 74, 0.35)', color: '#15803d', backgroundColor: 'rgba(34, 197, 94, 0.1)' }}>
+                      Focus
+                    </span>
+                  )}
+                  {itemKindLabel && (
+                    <span className="kanban-card__meta-badge" title="Item type">
+                      {itemKindLabel}
+                    </span>
+                  )}
+                  {aiScore != null && (
+                    <span className="kanban-card__meta-badge" title="AI score">
+                      AI {aiScore}/100
+                    </span>
+                  )}
+                  {!isEvent && !isGroup && canEditState && onStatusChange ? (
+                    <Form.Select
+                      size="sm"
+                      aria-label="Status"
+                      value={statusValue}
+                      onChange={(event) => onStatusChange(item, Number(event.target.value))}
+                      className="dashboard-chip-select"
+                      style={{ minWidth: isMobileLayout ? 118 : 132 }}
+                    >
+                      {choiceTable === 'story' ? (
+                        <>
+                          <option value={0}>Backlog</option>
+                          <option value={1}>Ready</option>
+                          <option value={2}>In Progress</option>
+                          <option value={3}>Review</option>
+                          <option value={4}>Done</option>
+                        </>
+                      ) : (
+                        <>
+                          <option value={0}>To do</option>
+                          <option value={1}>Doing</option>
+                          <option value={2}>Done</option>
+                        </>
+                      )}
+                    </Form.Select>
+                  ) : (
+                    <span className="kanban-card__meta-text" title="Status">
+                      {statusLabel}
+                    </span>
+                  )}
+                </div>
+                <div className="text-muted kanban-card__description" style={{ fontSize: '0.74rem' }}>
+                  {[item.ref, !scheduledBlockLabel ? item.timeLabel : null].filter(Boolean).join(' · ')}
+                </div>
+                {item.goalTitle && (
+                  <div className="kanban-card__goal mt-1">
+                    <Target size={12} />
+                    <span style={{ overflowWrap: 'anywhere' }}>{item.goalTitle}</span>
+                  </div>
+                )}
+                {showInlineRecommendation && recommendation && (
+                  <div className="mt-2 small">
+                    <div className="fw-semibold d-inline-flex align-items-center gap-1"><Sparkles size={13} /> {recommendation.label}</div>
+                    <div className="text-muted">{recommendation.rationale}</div>
+                  </div>
+                )}
+                {isGroup && item.childItems && item.childItems.length > 0 && (
+                  <div className="mt-2">
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      className="rounded-pill py-0 px-2"
+                      onClick={() => onToggleExpanded?.(item)}
+                    >
+                      {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />} {expanded ? 'Hide items' : 'Show items'}
+                    </Button>
+                    {expanded && (
+                      <div className="mt-2 d-flex flex-column gap-2">
+                        {item.childItems.map((child) => (
+                          <div key={child.id} className="border rounded px-2 py-1">
+                            <div className="d-flex align-items-start gap-2">
+                              {onToggleDone && (
+                                <Form.Check
+                                  type="checkbox"
+                                  checked={false}
+                                  disabled={applyingKey === child.id}
+                                  onChange={() => onToggleDone(child)}
+                                  className="mt-1"
+                                />
+                              )}
+                              <div className="min-w-0 flex-grow-1">
+                                <div className="fw-semibold small" style={{ overflowWrap: 'anywhere' }}>{child.title}</div>
+                                <div className="text-muted" style={{ fontSize: '0.72rem' }}>{buildChildMeta(child)}</div>
+                              </div>
+                              {onDefer && (
+                                <Button
+                                  size="sm"
+                                  variant="outline-warning"
+                                  className="p-1 d-inline-flex align-items-center justify-content-center"
+                                  onClick={() => onDefer(child)}
+                                >
+                                  <Clock3 size={14} />
+                                </Button>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {actionButtons && (
+                <div className="d-flex align-items-center gap-1 flex-wrap">
+                  {onOpenActivity && (item.rawTask || item.rawStory) && (
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      className={isMobileLayout ? 'px-2 py-1 d-inline-flex align-items-center justify-content-center' : 'p-1 d-inline-flex align-items-center justify-content-center'}
+                      onClick={() => onOpenActivity(item)}
+                    >
+                      <Activity size={14} className={isMobileLayout ? 'me-1' : undefined} />
+                      {isMobileLayout ? 'Note' : null}
+                    </Button>
+                  )}
+                  {onOpenEditor && (item.rawTask || item.rawStory) && (
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      className={isMobileLayout ? 'px-2 py-1 d-inline-flex align-items-center justify-content-center' : 'p-1 d-inline-flex align-items-center justify-content-center'}
+                      onClick={() => onOpenEditor(item)}
+                    >
+                      <Edit3 size={14} className={isMobileLayout ? 'me-1' : undefined} />
+                      {isMobileLayout ? 'Edit' : null}
+                    </Button>
+                  )}
+                  {onSchedule && !isGroup && (
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      className={isMobileLayout ? 'px-2 py-1 d-inline-flex align-items-center justify-content-center' : 'p-1 d-inline-flex align-items-center justify-content-center'}
+                      onClick={() => onSchedule(item)}
+                    >
+                      <CalendarPlus size={14} className={isMobileLayout ? 'me-1' : undefined} />
+                      {isMobileLayout ? 'Schedule' : null}
+                    </Button>
+                  )}
+                  {onMove && (
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      className={isMobileLayout ? 'px-2 py-1 d-inline-flex align-items-center justify-content-center' : 'p-1 d-inline-flex align-items-center justify-content-center'}
+                      onClick={() => onMove(item)}
+                    >
+                      <MoveRight size={14} className={isMobileLayout ? 'me-1' : undefined} />
+                      {isMobileLayout ? 'Move' : null}
+                    </Button>
+                  )}
+                  {showInlineRecommendation && recommendation && onAcceptRecommendation ? (
+                    <>
+                      <Button size="sm" variant="primary" disabled={applyingKey === item.id} onClick={() => onAcceptRecommendation(item)}>
+                        {applyingKey === item.id ? 'Applying…' : 'Accept'}
+                      </Button>
+                      {onDefer && !isGroup && (
+                        <Button size="sm" variant="outline-warning" onClick={() => onDefer(item)}>
+                          More
+                        </Button>
+                      )}
+                    </>
+                  ) : (
+                    onDefer && !isGroup && (
+                      <Button
+                        size="sm"
+                        variant="outline-warning"
+                        className={isMobileLayout ? 'px-2 py-1 d-inline-flex align-items-center justify-content-center' : 'p-1 d-inline-flex align-items-center justify-content-center'}
+                        onClick={() => onDefer(item)}
+                      >
+                        <Clock3 size={14} className={isMobileLayout ? 'me-1' : undefined} />
+                        {isMobileLayout ? 'Defer' : null}
+                      </Button>
+                    )
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default PlannerWorkCard;

--- a/react-app/src/utils/manualPriority.ts
+++ b/react-app/src/utils/manualPriority.ts
@@ -1,0 +1,40 @@
+export type ManualPriorityRank = 1 | 2 | 3 | null;
+
+export function getManualPriorityRank(entity: any): ManualPriorityRank {
+  const explicit = Number(entity?.userPriorityRank);
+  if (explicit === 1 || explicit === 2 || explicit === 3) return explicit;
+  return entity?.userPriorityFlag === true ? 1 : null;
+}
+
+export function getManualPriorityLabel(entity: any): string | null {
+  const rank = getManualPriorityRank(entity);
+  return rank ? `#${rank} Priority` : null;
+}
+
+export function getNextManualPriorityRank(items: any[], persona: string, excludeId?: string): 1 | 2 | 3 {
+  const normalizedPersona = String(persona || 'personal');
+  const used = new Set<number>();
+  (items || []).forEach((item) => {
+    if (!item || item.id === excludeId) return;
+    if (String(item.persona || 'personal') !== normalizedPersona) return;
+    const rank = getManualPriorityRank(item);
+    if (rank) used.add(rank);
+  });
+  if (!used.has(1)) return 1;
+  if (!used.has(2)) return 2;
+  return 3;
+}
+
+export function findItemWithManualPriorityRank<T extends { id?: string; persona?: string }>(
+  items: T[],
+  persona: string,
+  rank: 1 | 2 | 3,
+  excludeId?: string,
+): T | null {
+  const normalizedPersona = String(persona || 'personal');
+  return (items || []).find((item) => {
+    if (!item || item.id === excludeId) return false;
+    if (String(item.persona || 'personal') !== normalizedPersona) return false;
+    return getManualPriorityRank(item) === rank;
+  }) || null;
+}

--- a/react-app/src/utils/plannerCapacity.ts
+++ b/react-app/src/utils/plannerCapacity.ts
@@ -1,0 +1,147 @@
+import type { Goal, Sprint, Story, Task } from '../types';
+import type { PlannerItem } from './plannerItems';
+import { isGoalInHierarchySet } from './goalHierarchy';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface CapacitySummary {
+  capacityPoints: number;
+  plannedPoints: number;
+  remainingPoints: number;
+  utilizationPct: number;
+  overCapacity: boolean;
+  focusAlignedPoints: number;
+  nonFocusPoints: number;
+}
+
+const clampCapacity = (value: number, fallback: number) => {
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  return Math.max(1, Number(value));
+};
+
+export const taskPoints = (task: Task | any): number => {
+  const direct = Number(task?.points || 0);
+  if (Number.isFinite(direct) && direct > 0) return direct;
+  const mins = Number(task?.estimateMin || 0);
+  if (Number.isFinite(mins) && mins > 0) return Math.max(0.25, mins / 60);
+  return 1;
+};
+
+export const storyPoints = (story: Story | any): number => {
+  const direct = Number(story?.points || 0);
+  if (Number.isFinite(direct) && direct > 0) return direct;
+  return 1;
+};
+
+export const plannerItemPoints = (item: PlannerItem): number => {
+  if (Array.isArray(item.childItems) && item.childItems.length > 0) {
+    return item.childItems.reduce((sum, child) => sum + plannerItemPoints(child), 0);
+  }
+  if (item.scheduledBlockStart && item.scheduledBlockEnd && item.scheduledBlockEnd > item.scheduledBlockStart) {
+    return Math.max(0.25, (item.scheduledBlockEnd - item.scheduledBlockStart) / (60 * 60 * 1000));
+  }
+  if (item.rawTask) return taskPoints(item.rawTask);
+  if (item.rawStory) return storyPoints(item.rawStory);
+  return item.kind === 'story' ? 2 : 1;
+};
+
+export const summarizeCapacity = (
+  points: number[],
+  capacityPoints: number,
+  focusPoints: number[] = [],
+): CapacitySummary => {
+  const plannedPoints = points.reduce((sum, value) => sum + value, 0);
+  const focusAlignedPoints = focusPoints.reduce((sum, value) => sum + value, 0);
+  const safeCapacity = clampCapacity(capacityPoints, 1);
+  const remainingPoints = safeCapacity - plannedPoints;
+  const utilizationPct = Math.round((plannedPoints / safeCapacity) * 100);
+  return {
+    capacityPoints: safeCapacity,
+    plannedPoints,
+    remainingPoints,
+    utilizationPct,
+    overCapacity: remainingPoints < 0,
+    focusAlignedPoints,
+    nonFocusPoints: Math.max(0, plannedPoints - focusAlignedPoints),
+  };
+};
+
+export const buildDayCapacityMap = (
+  dayKeys: string[],
+  items: PlannerItem[],
+  capacityPointsPerDay = 8,
+) => {
+  const grouped = new Map<string, PlannerItem[]>();
+  dayKeys.forEach((dayKey) => grouped.set(dayKey, []));
+  items.forEach((item) => {
+    const existing = grouped.get(item.dayKey) || [];
+    existing.push(item);
+    grouped.set(item.dayKey, existing);
+  });
+  const summary = new Map<string, CapacitySummary>();
+  dayKeys.forEach((dayKey) => {
+    const dayItems = grouped.get(dayKey) || [];
+    summary.set(
+      dayKey,
+      summarizeCapacity(
+        dayItems.map((item) => plannerItemPoints(item)),
+        capacityPointsPerDay,
+        dayItems.filter((item) => item.isFocusAligned).map((item) => plannerItemPoints(item)),
+      ),
+    );
+  });
+  return summary;
+};
+
+export const deriveSprintCapacityPoints = (
+  sprint: Sprint | null | undefined,
+  weeklyCapacityPoints = 20,
+) => {
+  const explicit = Number((sprint as any)?.capacityPoints || 0);
+  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+  const startMs = Number((sprint as any)?.startDate || 0);
+  const endMs = Number((sprint as any)?.endDate || 0);
+  if (Number.isFinite(startMs) && Number.isFinite(endMs) && endMs >= startMs) {
+    const sprintWeeks = Math.max(1, Math.ceil((endMs - startMs + DAY_MS) / (7 * DAY_MS)));
+    return sprintWeeks * weeklyCapacityPoints;
+  }
+  return weeklyCapacityPoints;
+};
+
+export const buildSprintCapacitySummary = ({
+  sprint,
+  stories,
+  goals,
+  activeFocusGoalIds,
+  weeklyCapacityPoints = 20,
+}: {
+  sprint: Sprint | null | undefined;
+  stories: Story[];
+  goals: Goal[];
+  activeFocusGoalIds: Set<string>;
+  weeklyCapacityPoints?: number;
+}) => {
+  const focusPoints = stories
+    .filter((story) => {
+      const goalId = String(story.goalId || '').trim();
+      return !!goalId && isGoalInHierarchySet(goalId, goals, activeFocusGoalIds);
+    })
+    .map((story) => storyPoints(story));
+  return summarizeCapacity(
+    stories.map((story) => storyPoints(story)),
+    deriveSprintCapacityPoints(sprint, weeklyCapacityPoints),
+    focusPoints,
+  );
+};
+
+export const findSprintForDate = (sprints: Sprint[], dateMs: number): Sprint | null => {
+  const exact = sprints.find((sprint) => {
+    const startMs = Number((sprint as any)?.startDate || 0);
+    const endMs = Number((sprint as any)?.endDate || 0);
+    return Number.isFinite(startMs) && Number.isFinite(endMs) && dateMs >= startMs && dateMs <= endMs;
+  });
+  if (exact) return exact;
+  return [...sprints]
+    .filter((sprint) => Number((sprint as any)?.startDate || 0) >= dateMs)
+    .sort((a, b) => Number((a as any)?.startDate || 0) - Number((b as any)?.startDate || 0))[0] || null;
+};

--- a/react-app/src/utils/plannerItems.ts
+++ b/react-app/src/utils/plannerItems.ts
@@ -1,0 +1,616 @@
+import type { Goal, Story, Task } from '../types';
+import { getGoalAncestors, getGoalDisplayPath } from './goalHierarchy';
+import { isRecurringDueOnDate, resolveTaskDueMs } from './recurringTaskDue';
+import { storyStatusText, taskStatusText } from './storyCardFormatting';
+import {
+  bucketFromTime,
+  bucketPseudoTime,
+  formatBucketBackfillLabel,
+  type TimelineBucket,
+} from './timelineBuckets';
+
+export type PlannerItemKind = 'task' | 'story' | 'chore' | 'event';
+
+export interface PlannerCalendarBlockRow {
+  id: string;
+  title?: string;
+  start?: number;
+  end?: number;
+  taskId?: string | null;
+  storyId?: string | null;
+  linkedStoryId?: string | null;
+  source?: string | null;
+  entry_method?: string | null;
+  entityType?: string | null;
+  category?: string | null;
+  sourceInstanceId?: string | null;
+  sourceInstanceIds?: string[] | null;
+  choreId?: string | null;
+  routineId?: string | null;
+  habitId?: string | null;
+  items?: Array<Record<string, any>> | null;
+  itemCount?: number | null;
+}
+
+export interface PlannerScheduledInstanceRow {
+  id: string;
+  ownerUid: string;
+  sourceType?: string | null;
+  sourceId?: string | null;
+  occurrenceDate?: string | null;
+  status?: string | null;
+  updatedAt?: number | null;
+  dayKey?: string | null;
+  blockId?: string | null;
+  plannedStart?: string | null;
+  plannedEnd?: string | null;
+  timeOfDay?: string | null;
+  durationMinutes?: number | null;
+  title?: string | null;
+  goalId?: string | null;
+  storyId?: string | null;
+}
+
+export interface PlannerSummaryEvent {
+  id: string;
+  title: string;
+  startMs: number | null;
+  endMs: number | null;
+}
+
+export interface PlannerItem {
+  id: string;
+  kind: PlannerItemKind;
+  title: string;
+  ref: string | null;
+  dayKey: string;
+  timeOfDay: TimelineBucket;
+  timeLabel: string;
+  sortMs: number | null;
+  bucket: TimelineBucket;
+  sourceId?: string;
+  isTop3?: boolean;
+  deferredUntilMs?: number | null;
+  dueAt?: number | null;
+  statusLabel?: string | null;
+  progressPct?: number | null;
+  scheduledSourceLabel?: string | null;
+  goalId?: string | null;
+  goalTitle: string | null;
+  goalTheme: string | null;
+  isFocusAligned: boolean;
+  rawTask: Task | null;
+  rawStory: Story | null;
+  scheduledBlockStart: number | null;
+  scheduledBlockEnd: number | null;
+  scheduledBlockId?: string | null;
+  scheduledInstanceId?: string | null;
+  childItems?: PlannerItem[];
+}
+
+interface PlannerBuildParams {
+  tasks: Task[];
+  stories: Story[];
+  goals: Goal[];
+  calendarBlocks: PlannerCalendarBlockRow[];
+  scheduledInstances: PlannerScheduledInstanceRow[];
+  activeFocusGoalIds: Set<string>;
+  rangeStartMs: number;
+  rangeEndMs: number;
+  selectedSprintId?: string | null;
+  summaryEvents?: PlannerSummaryEvent[];
+  includeUnscheduledTasks?: boolean;
+}
+
+export const toMs = (value: any): number | null => {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value?.toDate === 'function') {
+    try {
+      return value.toDate().getTime();
+    } catch {
+      return null;
+    }
+  }
+  const parsed = Date.parse(String(value));
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+const startOfDayMs = (value: number) => {
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+};
+
+export const toDayKey = (value: number | Date) => {
+  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+  date.setHours(0, 0, 0, 0);
+  return date.toISOString().slice(0, 10);
+};
+
+export const isDoneStatus = (value: any): boolean => {
+  if (typeof value === 'number') return value >= 2;
+  const raw = String(value || '').trim().toLowerCase();
+  return raw === 'done' || raw === 'complete' || raw === 'completed' || raw === 'archived';
+};
+
+export const normalizeStoryStatus = (value: any): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  const raw = String(value || '').trim().toLowerCase();
+  if (raw === 'done' || raw === 'complete' || raw === 'completed') return 4;
+  if (raw === 'testing' || raw === 'qa' || raw === 'review') return 3;
+  if (raw === 'in progress' || raw === 'in-progress' || raw === 'active' || raw === 'doing' || raw === 'blocked') return 2;
+  if (raw === 'planned' || raw === 'ready') return 1;
+  return 0;
+};
+
+const isTop3ForToday = (value: any): boolean => {
+  if (value?.aiTop3ForDay !== true) return false;
+  const top3Date = String(value?.aiTop3Date || '').trim();
+  if (!top3Date) return true;
+  return top3Date.slice(0, 10) === new Date().toISOString().slice(0, 10);
+};
+
+export const getChoreKind = (task: Task): 'chore' | 'routine' | 'habit' | null => {
+  const raw = String((task as any)?.type || (task as any)?.task_type || '').trim().toLowerCase();
+  const normalized = raw === 'habitual' ? 'habit' : raw;
+  if (normalized === 'chore' || normalized === 'routine' || normalized === 'habit') return normalized;
+  return null;
+};
+
+export const resolveTaskRef = (task: Task) => task.ref || `TK-${task.id.slice(-6).toUpperCase()}`;
+export const resolveStoryRef = (story: Story) => ((story as any).referenceNumber || story.ref || `ST-${story.id.slice(-6).toUpperCase()}`);
+
+const scheduledSourceLabelForBlock = (block: PlannerCalendarBlockRow | null): string | null => {
+  const source = String(block?.source || '').toLowerCase();
+  const entryMethod = String(block?.entry_method || '').toLowerCase();
+  const fromGcal = source === 'gcal' || entryMethod === 'google_calendar';
+  if (fromGcal) return 'linked from gcal';
+  if (source === 'bob' || source === 'manual' || entryMethod.includes('manual')) return 'manual';
+  if (source.includes('ai') || entryMethod.includes('auto')) return 'auto-planned';
+  return null;
+};
+
+const isGoalAlignedToFocus = (goalId: string | null | undefined, goals: Goal[], activeFocusGoalIds: Set<string>) => {
+  const normalized = String(goalId || '').trim();
+  if (!normalized) return false;
+  if (activeFocusGoalIds.has(normalized)) return true;
+  return getGoalAncestors(normalized, goals).some((goal) => activeFocusGoalIds.has(goal.id));
+};
+
+const instanceDayKey = (value: string | null | undefined) => {
+  const raw = String(value || '').trim();
+  if (!raw) return null;
+  if (/^\d{8}$/.test(raw)) {
+    return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`;
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+  return null;
+};
+
+const dayKeyToMs = (dayKey: string) => {
+  const parsed = Date.parse(`${dayKey}T12:00:00`);
+  return Number.isNaN(parsed) ? null : startOfDayMs(parsed);
+};
+
+export const buildPlannerItems = ({
+  tasks,
+  stories,
+  goals,
+  calendarBlocks,
+  scheduledInstances,
+  activeFocusGoalIds,
+  rangeStartMs,
+  rangeEndMs,
+  selectedSprintId,
+  summaryEvents = [],
+  includeUnscheduledTasks = false,
+}: PlannerBuildParams): PlannerItem[] => {
+  const rows: PlannerItem[] = [];
+  const seen = new Set<string>();
+  const storyMap = new Map(stories.map((story) => [story.id, story]));
+  const goalMap = new Map(goals.map((goal) => [goal.id, goal]));
+  const taskMap = new Map(tasks.map((task) => [task.id, task]));
+  const blockByTaskId = new Map<string, PlannerCalendarBlockRow>();
+  const blockByStoryId = new Map<string, PlannerCalendarBlockRow>();
+  const calendarBlockById = new Map<string, PlannerCalendarBlockRow>();
+  const blockByInstanceId = new Map<string, PlannerCalendarBlockRow>();
+  const instanceMap = new Map<string, PlannerScheduledInstanceRow[]>();
+  const instanceById = new Map<string, PlannerScheduledInstanceRow>();
+  const groupedRecurringBlockIds = new Set<string>();
+  const groupedRecurringInstanceIds = new Set<string>();
+  const rangeEndDayMs = startOfDayMs(rangeEndMs);
+  const isSingleDayRange = startOfDayMs(rangeStartMs) === startOfDayMs(rangeEndMs);
+
+  calendarBlocks.forEach((block) => {
+    const blockStart = toMs(block.start);
+    calendarBlockById.set(block.id, block);
+    if (blockStart == null || blockStart < rangeStartMs || blockStart > rangeEndMs) return;
+    const taskId = String(block.taskId || '').trim();
+    const storyId = String(block.storyId || block.linkedStoryId || '').trim();
+    if (taskId) blockByTaskId.set(taskId, block);
+    if (storyId) blockByStoryId.set(storyId, block);
+    const sourceInstanceId = String(block.sourceInstanceId || '').trim();
+    if (sourceInstanceId) blockByInstanceId.set(sourceInstanceId, block);
+    const sourceInstanceIds = Array.isArray(block.sourceInstanceIds) ? block.sourceInstanceIds : [];
+    sourceInstanceIds.forEach((instanceId) => {
+      const normalized = String(instanceId || '').trim();
+      if (normalized) blockByInstanceId.set(normalized, block);
+    });
+    const blockEntity = String(block.entityType || block.category || '').toLowerCase();
+    const hasRecurringItems = !!(block.choreId || block.routineId || block.habitId)
+      || blockEntity.includes('chore')
+      || blockEntity.includes('routine')
+      || blockEntity.includes('habit')
+      || ((Array.isArray(block.items) ? block.items : []).some((item) => {
+        const sourceType = String(item?.sourceType || item?.entityType || '').toLowerCase();
+        return ['chore', 'routine', 'habit'].includes(sourceType);
+      }));
+    if (hasRecurringItems && sourceInstanceIds.length > 1) {
+      groupedRecurringBlockIds.add(block.id);
+      sourceInstanceIds.forEach((instanceId) => {
+        const normalized = String(instanceId || '').trim();
+        if (normalized) groupedRecurringInstanceIds.add(normalized);
+      });
+    }
+  });
+
+  scheduledInstances.forEach((instance) => {
+    const sourceType = String(instance.sourceType || '').trim().toLowerCase();
+    const sourceId = String(instance.sourceId || '').trim();
+    const dayKey = instanceDayKey(instance.occurrenceDate);
+    if (!sourceType || !sourceId || !dayKey) return;
+    instanceById.set(instance.id, instance);
+    const ms = dayKeyToMs(dayKey);
+    if (ms == null || ms < startOfDayMs(rangeStartMs) || ms > startOfDayMs(rangeEndMs)) return;
+    const key = `${sourceType}:${sourceId}`;
+    const existing = instanceMap.get(key) || [];
+    existing.push(instance);
+    instanceMap.set(key, existing);
+  });
+
+  const push = (row: PlannerItem, dedupeKey = row.id) => {
+    if (seen.has(dedupeKey)) return;
+    seen.add(dedupeKey);
+    rows.push(row);
+  };
+
+  const addRecurringRows = (task: Task) => {
+    const choreKind = getChoreKind(task);
+    if (!choreKind) return false;
+      const candidateSourceTypes = choreKind === 'habit' ? ['habit', 'routine', 'chore'] : [choreKind];
+      const matchingInstances = candidateSourceTypes.flatMap((sourceType) => instanceMap.get(`${sourceType}:${task.id}`) || []);
+    if (matchingInstances.length === 0) return false;
+
+    matchingInstances.forEach((instance) => {
+      if (groupedRecurringInstanceIds.has(instance.id)) return;
+      const status = String(instance.status || '').trim().toLowerCase();
+      if (['completed', 'missed', 'skipped', 'cancelled'].includes(status)) return;
+      const dayKey = instanceDayKey(instance.occurrenceDate);
+      if (!dayKey) return;
+      const dayMs = dayKeyToMs(dayKey);
+      if (dayMs == null) return;
+      const linkedBlock = blockByInstanceId.get(instance.id) || (instance.blockId ? calendarBlockById.get(String(instance.blockId)) || null : null);
+      const startMs = linkedBlock ? toMs(linkedBlock.start) : toMs(instance.plannedStart);
+      const endMs = linkedBlock ? toMs(linkedBlock.end) : toMs(instance.plannedEnd);
+      const goalId = String((task as any).goalId || '').trim() || null;
+      const goal = goalId ? goalMap.get(goalId) || null : null;
+      const bucket = bucketFromTime(startMs ?? dayMs, instance.timeOfDay || (task as any).timeOfDay, 'morning');
+      const sortMs = startMs ?? bucketPseudoTime(dayMs, bucket);
+      push({
+        id: `instance-${instance.id}`,
+        kind: 'chore',
+        title: task.title || 'Recurring item',
+        ref: resolveTaskRef(task),
+        dayKey,
+        timeOfDay: bucket,
+        timeLabel: formatBucketBackfillLabel(startMs, endMs, instance.timeOfDay || (task as any).timeOfDay),
+        sortMs,
+        bucket,
+        sourceId: task.id,
+        isTop3: false,
+        deferredUntilMs: toMs((task as any).deferredUntil),
+        dueAt: startMs ?? sortMs,
+        statusLabel: taskStatusText((task as any).status),
+        progressPct: Number.isFinite(Number((task as any).progressPct)) ? Number((task as any).progressPct) : null,
+        scheduledSourceLabel: linkedBlock ? scheduledSourceLabelForBlock(linkedBlock) : 'recurring schedule',
+        goalId,
+        goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
+        goalTheme: goal ? String((goal as any).theme || '') || null : null,
+        isFocusAligned: isGoalAlignedToFocus(goalId, goals, activeFocusGoalIds),
+        rawTask: task,
+        rawStory: null,
+        scheduledBlockStart: startMs,
+        scheduledBlockEnd: endMs,
+        scheduledBlockId: linkedBlock?.id || String(instance.blockId || '') || null,
+        scheduledInstanceId: instance.id,
+      });
+    });
+
+    return matchingInstances.length > 0;
+  };
+
+  groupedRecurringBlockIds.forEach((blockId) => {
+    const block = calendarBlockById.get(blockId);
+    if (!block) return;
+    const instanceIds = Array.isArray(block.sourceInstanceIds)
+      ? block.sourceInstanceIds.map((value) => String(value || '').trim()).filter(Boolean)
+      : [];
+    const childItems = instanceIds
+      .map((instanceId) => {
+        const instance = instanceById.get(instanceId);
+        if (!instance) return null;
+        const status = String(instance.status || '').trim().toLowerCase();
+        if (['completed', 'missed', 'skipped', 'cancelled'].includes(status)) return null;
+        const task = taskMap.get(String(instance.sourceId || '').trim());
+        if (!task) return null;
+        const dayKey = instanceDayKey(instance.occurrenceDate) || toDayKey(toMs(block.start) || rangeStartMs);
+        const startMs = toMs(block.start) || toMs(instance.plannedStart);
+        const endMs = toMs(block.end) || toMs(instance.plannedEnd);
+        const goalId = String((task as any).goalId || '').trim() || null;
+        const goal = goalId ? goalMap.get(goalId) || null : null;
+        const bucket = bucketFromTime(startMs, instance.timeOfDay || (task as any).timeOfDay, 'morning');
+        return {
+          id: `instance-${instance.id}`,
+          kind: 'chore' as const,
+          title: task.title || instance.title || 'Recurring item',
+          ref: resolveTaskRef(task),
+          dayKey,
+          timeOfDay: bucket,
+          timeLabel: formatBucketBackfillLabel(startMs, endMs, instance.timeOfDay || (task as any).timeOfDay),
+          sortMs: startMs ?? bucketPseudoTime(dayKeyToMs(dayKey) || rangeStartMs, bucket),
+          bucket,
+          sourceId: task.id,
+          isTop3: false,
+          deferredUntilMs: toMs((task as any).deferredUntil),
+          dueAt: startMs,
+          statusLabel: taskStatusText((task as any).status),
+          progressPct: Number.isFinite(Number((task as any).progressPct)) ? Number((task as any).progressPct) : null,
+          scheduledSourceLabel: scheduledSourceLabelForBlock(block),
+          goalId,
+          goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
+          goalTheme: goal ? String((goal as any).theme || '') || null : null,
+          isFocusAligned: isGoalAlignedToFocus(goalId, goals, activeFocusGoalIds),
+          rawTask: task,
+          rawStory: null,
+          scheduledBlockStart: startMs,
+          scheduledBlockEnd: endMs,
+          scheduledBlockId: block.id,
+          scheduledInstanceId: instance.id,
+        } satisfies PlannerItem;
+      })
+      .filter(Boolean) as PlannerItem[];
+
+    if (childItems.length === 0) return;
+    const earliestStart = childItems.reduce((min, child) => {
+      const value = child.scheduledBlockStart ?? child.sortMs ?? rangeStartMs;
+      return Math.min(min, value);
+    }, Number.MAX_SAFE_INTEGER);
+    const latestEnd = childItems.reduce((max, child) => {
+      const value = child.scheduledBlockEnd ?? child.scheduledBlockStart ?? child.sortMs ?? rangeStartMs;
+      return Math.max(max, value);
+    }, 0);
+    const bucket = bucketFromTime(earliestStart, childItems[0]?.timeOfDay, 'morning');
+    push({
+      id: `chore-group-${block.id}`,
+      kind: 'chore',
+      title: String(block.title || 'Chore block').trim() || 'Chore block',
+      ref: null,
+      dayKey: toDayKey(earliestStart),
+      timeOfDay: bucket,
+      timeLabel: formatBucketBackfillLabel(earliestStart, latestEnd),
+      sortMs: earliestStart,
+      bucket,
+      sourceId: block.id,
+      isTop3: false,
+      deferredUntilMs: null,
+      dueAt: earliestStart,
+      statusLabel: null,
+      progressPct: null,
+      scheduledSourceLabel: scheduledSourceLabelForBlock(block),
+      goalId: null,
+      goalTitle: null,
+      goalTheme: null,
+      isFocusAligned: childItems.some((child) => child.isFocusAligned),
+      rawTask: null,
+      rawStory: null,
+      scheduledBlockStart: earliestStart,
+      scheduledBlockEnd: latestEnd || null,
+      scheduledBlockId: block.id,
+      childItems,
+    });
+  });
+
+  tasks
+    .filter((task) => !isDoneStatus((task as any).status))
+    .forEach((task) => {
+      const choreKind = getChoreKind(task);
+      if (choreKind && addRecurringRows(task)) return;
+
+      if (choreKind) {
+        const fallbackDate = new Date(rangeStartMs);
+        fallbackDate.setHours(0, 0, 0, 0);
+        const dueOnFallback = isRecurringDueOnDate(task, fallbackDate, fallbackDate.getTime());
+        if (!dueOnFallback && !blockByTaskId.get(task.id)) return;
+      }
+
+      const linkedBlock = blockByTaskId.get(task.id) || null;
+      const parentStory = (task as any).storyId ? storyMap.get((task as any).storyId) || null : null;
+      const goalId = String((task as any).goalId || (parentStory as any)?.goalId || '').trim() || null;
+      const goal = goalId ? goalMap.get(goalId) || null : null;
+      const deferredUntilMs = toMs((task as any).deferredUntil);
+      if (deferredUntilMs != null && startOfDayMs(deferredUntilMs) > rangeEndDayMs) return;
+      const top3ForToday = isTop3ForToday(task);
+      const dueMs = linkedBlock ? toMs(linkedBlock.start) : resolveTaskDueMs(task);
+      const endMs = linkedBlock ? toMs(linkedBlock.end) : null;
+      const include = linkedBlock
+        ? true
+        : (isSingleDayRange && top3ForToday)
+          ? true
+        : dueMs == null
+          ? includeUnscheduledTasks
+          : (dueMs >= rangeStartMs && dueMs <= rangeEndMs);
+      if (!include) return;
+
+      const forceIntoSingleDayPlan = isSingleDayRange && top3ForToday && !linkedBlock && !(dueMs != null && dueMs >= rangeStartMs && dueMs <= rangeEndMs);
+      const plannerBaseMs = forceIntoSingleDayPlan ? startOfDayMs(rangeStartMs) : (dueMs ?? startOfDayMs(rangeStartMs));
+      const bucket = forceIntoSingleDayPlan
+        ? bucketFromTime(null, (task as any).timeOfDay, 'morning')
+        : bucketFromTime(dueMs, (task as any).timeOfDay, 'morning');
+      const sortMs = forceIntoSingleDayPlan ? bucketPseudoTime(plannerBaseMs, bucket) : (dueMs ?? bucketPseudoTime(startOfDayMs(plannerBaseMs), bucket));
+      const dayKey = toDayKey(sortMs ?? rangeStartMs);
+
+      push({
+        id: `${choreKind ? 'chore' : 'task'}-${task.id}`,
+        kind: choreKind ? 'chore' : 'task',
+        title: task.title || (choreKind ? 'Chore' : 'Task'),
+        ref: resolveTaskRef(task),
+        dayKey,
+        timeOfDay: bucket,
+        timeLabel: forceIntoSingleDayPlan
+          ? formatBucketBackfillLabel(null, null, (task as any).timeOfDay)
+          : formatBucketBackfillLabel(dueMs, endMs, (task as any).timeOfDay),
+        sortMs,
+        bucket,
+        sourceId: task.id,
+        isTop3: top3ForToday,
+        deferredUntilMs,
+        dueAt: dueMs,
+        statusLabel: taskStatusText((task as any).status),
+        progressPct: Number.isFinite(Number((task as any).progressPct)) ? Number((task as any).progressPct) : null,
+        scheduledSourceLabel: linkedBlock ? scheduledSourceLabelForBlock(linkedBlock) : null,
+        goalId,
+        goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
+        goalTheme: goal ? String((goal as any).theme || '') || null : null,
+        isFocusAligned: isGoalAlignedToFocus(goalId, goals, activeFocusGoalIds),
+        rawTask: task,
+        rawStory: null,
+        scheduledBlockStart: linkedBlock ? toMs(linkedBlock.start) : null,
+        scheduledBlockEnd: linkedBlock ? toMs(linkedBlock.end) : null,
+        scheduledBlockId: linkedBlock?.id || null,
+      });
+    });
+
+  stories
+    .filter((story) => !isDoneStatus((story as any).status))
+    .filter((story) => (selectedSprintId ? String((story as any).sprintId || '') === String(selectedSprintId) : true))
+    .forEach((story) => {
+      const linkedBlock = blockByStoryId.get(story.id) || null;
+      const deferredUntilMs = toMs((story as any).deferredUntil);
+      if (deferredUntilMs != null && startOfDayMs(deferredUntilMs) > rangeEndDayMs) return;
+      const top3ForToday = isTop3ForToday(story);
+      const dueMs = linkedBlock ? toMs(linkedBlock.start) : toMs((story as any).targetDate || (story as any).dueDate || (story as any).plannedStartDate);
+      const endMs = linkedBlock ? toMs(linkedBlock.end) : null;
+      const include = linkedBlock
+        ? true
+        : (isSingleDayRange && top3ForToday)
+          ? true
+        : dueMs == null
+          ? includeUnscheduledTasks
+          : (dueMs >= rangeStartMs && dueMs <= rangeEndMs);
+      if (!include) return;
+
+      const forceIntoSingleDayPlan = isSingleDayRange && top3ForToday && !linkedBlock && !(dueMs != null && dueMs >= rangeStartMs && dueMs <= rangeEndMs);
+      const plannerBaseMs = forceIntoSingleDayPlan ? startOfDayMs(rangeStartMs) : (dueMs ?? startOfDayMs(rangeStartMs));
+      const bucket = forceIntoSingleDayPlan
+        ? bucketFromTime(null, (story as any).timeOfDay, 'morning')
+        : bucketFromTime(dueMs, (story as any).timeOfDay, 'morning');
+      const sortMs = forceIntoSingleDayPlan ? bucketPseudoTime(plannerBaseMs, bucket) : (dueMs ?? bucketPseudoTime(startOfDayMs(plannerBaseMs), bucket));
+      const dayKey = toDayKey(sortMs ?? rangeStartMs);
+      const goalId = String((story as any).goalId || '').trim() || null;
+      const goal = goalId ? goalMap.get(goalId) || null : null;
+
+      push({
+        id: `story-${story.id}`,
+        kind: 'story',
+        title: story.title || 'Story',
+        ref: resolveStoryRef(story),
+        dayKey,
+        timeOfDay: bucket,
+        timeLabel: forceIntoSingleDayPlan
+          ? formatBucketBackfillLabel(null, null, (story as any).timeOfDay)
+          : formatBucketBackfillLabel(dueMs, endMs, (story as any).timeOfDay),
+        sortMs,
+        bucket,
+        sourceId: story.id,
+        isTop3: top3ForToday,
+        deferredUntilMs,
+        dueAt: dueMs,
+        statusLabel: storyStatusText((story as any).status),
+        progressPct: Number.isFinite(Number((story as any).progressPct)) ? Number((story as any).progressPct) : null,
+        scheduledSourceLabel: linkedBlock ? scheduledSourceLabelForBlock(linkedBlock) : null,
+        goalId,
+        goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
+        goalTheme: goal ? String((goal as any).theme || '') || null : null,
+        isFocusAligned: isGoalAlignedToFocus(goalId, goals, activeFocusGoalIds),
+        rawTask: null,
+        rawStory: story,
+        scheduledBlockStart: linkedBlock ? toMs(linkedBlock.start) : null,
+        scheduledBlockEnd: linkedBlock ? toMs(linkedBlock.end) : null,
+        scheduledBlockId: linkedBlock?.id || null,
+      });
+    });
+
+  calendarBlocks
+    .filter((block) => !String(block.taskId || '').trim() && !String(block.storyId || block.linkedStoryId || '').trim())
+    .forEach((block) => {
+      const startMs = toMs(block.start);
+      if (startMs == null || startMs < rangeStartMs || startMs > rangeEndMs) return;
+      const endMs = toMs(block.end);
+      const bucket = bucketFromTime(startMs, null, 'morning');
+      const timeLabel = formatBucketBackfillLabel(startMs, endMs);
+      const dedupeKey = `event:${String(block.title || '').toLowerCase()}:${timeLabel}`;
+      push({
+        id: `event-block-${block.id}`,
+        kind: 'event',
+        title: String(block.title || 'Calendar event').trim() || 'Calendar event',
+        ref: null,
+        dayKey: toDayKey(startMs),
+        timeOfDay: bucket,
+        timeLabel,
+        sortMs: startMs ?? bucketPseudoTime(startOfDayMs(rangeStartMs), bucket),
+        bucket,
+        goalTitle: null,
+        goalTheme: null,
+        isFocusAligned: false,
+        rawTask: null,
+        rawStory: null,
+        scheduledBlockStart: startMs,
+        scheduledBlockEnd: endMs,
+      }, dedupeKey);
+    });
+
+  summaryEvents.forEach((event) => {
+    if (event.startMs != null && (event.startMs < rangeStartMs || event.startMs > rangeEndMs)) return;
+    const anchorMs = event.startMs ?? rangeStartMs;
+    const bucket = bucketFromTime(event.startMs, null, 'anytime');
+    const timeLabel = formatBucketBackfillLabel(event.startMs, event.endMs);
+    const dedupeKey = `event:${event.title.toLowerCase()}:${timeLabel}`;
+    push({
+      id: `event-summary-${event.id}`,
+      kind: 'event',
+      title: event.title,
+      ref: null,
+      dayKey: toDayKey(anchorMs),
+      timeOfDay: bucket,
+      timeLabel,
+      sortMs: event.startMs ?? bucketPseudoTime(startOfDayMs(anchorMs), bucket),
+      bucket,
+      goalTitle: null,
+      goalTheme: null,
+      isFocusAligned: false,
+      rawTask: null,
+      rawStory: null,
+      scheduledBlockStart: event.startMs,
+      scheduledBlockEnd: event.endMs,
+    }, dedupeKey);
+  });
+
+  return rows.sort((a, b) => {
+    const aMs = a.sortMs ?? Number.MAX_SAFE_INTEGER;
+    const bMs = b.sortMs ?? Number.MAX_SAFE_INTEGER;
+    if (aMs !== bMs) return aMs - bMs;
+    return a.title.localeCompare(b.title);
+  });
+};

--- a/react-app/src/utils/plannerRecommendations.ts
+++ b/react-app/src/utils/plannerRecommendations.ts
@@ -1,0 +1,124 @@
+import type { Sprint, Task } from '../types';
+import type { PlannerItem } from './plannerItems';
+import type { TimelineBucket } from './timelineBuckets';
+import { bucketLabel } from './timelineBuckets';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface PlannerRecommendation {
+  action: 'keep_week' | 'move_day' | 'next_sprint' | 'next_recurrence';
+  label: string;
+  rationale: string;
+  targetDateMs?: number | null;
+  targetBucket?: TimelineBucket | null;
+}
+
+const startOfDayMs = (value: number) => {
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+};
+
+const titleForDay = (ms: number) =>
+  new Date(ms).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
+
+const normaliseRecurringFrequency = (data: any) => {
+  const direct = String(data?.repeatFrequency || data?.recurrence?.frequency || data?.recurrence?.freq || '').trim().toLowerCase();
+  if (['daily', 'weekly', 'monthly', 'yearly'].includes(direct)) return direct;
+  const rrule = String(data?.rrule || '').toUpperCase();
+  if (rrule.includes('DAILY')) return 'daily';
+  if (rrule.includes('WEEKLY')) return 'weekly';
+  if (rrule.includes('MONTHLY')) return 'monthly';
+  if (rrule.includes('YEARLY') || rrule.includes('ANNUAL')) return 'yearly';
+  return null;
+};
+
+export const recurrenceAwareDeferDays = (data: Task | any) => {
+  const frequency = normaliseRecurringFrequency(data);
+  if (!frequency) return null;
+  const interval = Math.max(1, Number(data?.repeatInterval || data?.recurrence?.interval || 1) || 1);
+  if (frequency === 'daily') return interval;
+  if (frequency === 'weekly') return 7 * interval;
+  if (frequency === 'monthly') return 14 * interval;
+  if (frequency === 'yearly') return 60 * interval;
+  return null;
+};
+
+interface BuildParams {
+  item: PlannerItem;
+  weekStartMs: number;
+  weekEndMs: number;
+  dailyLoadHours: Map<string, number>;
+  nextSprint: Sprint | null;
+  dailyCapacityHours?: number;
+}
+
+export const buildPlannerRecommendation = ({
+  item,
+  weekStartMs,
+  weekEndMs,
+  dailyLoadHours,
+  nextSprint,
+  dailyCapacityHours = 8,
+}: BuildParams): PlannerRecommendation => {
+  const parsedDayMs = Date.parse(`${item.dayKey}T12:00:00`);
+  const itemDayMs = startOfDayMs(item.dueAt ?? (Number.isNaN(parsedDayMs) ? weekStartMs : parsedDayMs));
+  const thisDayKey = new Date(itemDayMs).toISOString().slice(0, 10);
+  const thisDayLoad = Number(dailyLoadHours.get(thisDayKey) || 0);
+  const weekLoads: Array<{ dayMs: number; dayKey: string; load: number }> = [];
+  for (let cursor = weekStartMs; cursor <= weekEndMs; cursor += DAY_MS) {
+    const dayMs = startOfDayMs(cursor);
+    const dayKey = new Date(dayMs).toISOString().slice(0, 10);
+    weekLoads.push({ dayMs, dayKey, load: Number(dailyLoadHours.get(dayKey) || 0) });
+  }
+  const lowestLoad = [...weekLoads].sort((a, b) => {
+    if (a.load !== b.load) return a.load - b.load;
+    return a.dayMs - b.dayMs;
+  })[0] || null;
+  const isOverCapacity = thisDayLoad > dailyCapacityHours;
+
+  if (item.kind === 'chore' && item.rawTask) {
+    const recurrenceDays = recurrenceAwareDeferDays(item.rawTask);
+    if (recurrenceDays != null) {
+      const targetDateMs = itemDayMs + recurrenceDays * DAY_MS;
+      return {
+        action: 'next_recurrence',
+        label: 'Defer to next recurrence',
+        rationale: `Matches the ${String(item.rawTask.type || 'recurring').toLowerCase()} cadence and keeps the schedule aligned.`,
+        targetDateMs,
+        targetBucket: item.timeOfDay,
+      };
+    }
+  }
+
+  if (!item.isFocusAligned && !item.isTop3 && nextSprint?.startDate) {
+    return {
+      action: 'next_sprint',
+      label: `Move to next sprint`,
+      rationale: 'Outside active focus goals and this protects current sprint capacity.',
+      targetDateMs: Number(nextSprint.startDate),
+      targetBucket: item.timeOfDay,
+    };
+  }
+
+  if (lowestLoad && (isOverCapacity || lowestLoad.dayKey !== thisDayKey) && lowestLoad.load + 1 < thisDayLoad) {
+    const targetBucket = item.timeOfDay || 'morning';
+    return {
+      action: 'move_day',
+      label: `Move to ${titleForDay(lowestLoad.dayMs)} ${bucketLabel(targetBucket).toLowerCase()}`,
+      rationale: `Best low-load day is ${titleForDay(lowestLoad.dayMs)} at about ${lowestLoad.load.toFixed(1)} planned hours.`,
+      targetDateMs: lowestLoad.dayMs,
+      targetBucket,
+    };
+  }
+
+  return {
+    action: 'keep_week',
+    label: 'Keep this week',
+    rationale: item.isFocusAligned
+      ? 'Aligned to an active focus goal and fits this week.'
+      : 'Current week capacity can absorb this item.',
+    targetDateMs: itemDayMs,
+    targetBucket: item.timeOfDay,
+  };
+};

--- a/react-app/src/utils/plannerScheduling.test.ts
+++ b/react-app/src/utils/plannerScheduling.test.ts
@@ -1,0 +1,26 @@
+import { normalizePlannerSchedulingError } from './plannerScheduling';
+
+jest.mock('../firebase', () => ({
+  functions: {},
+}));
+
+describe('normalizePlannerSchedulingError', () => {
+  test('maps raw internal callable failures to a user-facing planner explanation', () => {
+    const result = normalizePlannerSchedulingError({
+      code: 'functions/failed-precondition',
+      message: 'internal',
+    });
+
+    expect(result.code).toBe('failed-precondition');
+    expect(result.message.toLowerCase()).toContain('planner could not place this item automatically');
+  });
+
+  test('preserves actionable backend messages when they are provided', () => {
+    const result = normalizePlannerSchedulingError({
+      code: 'functions/failed-precondition',
+      message: 'No feasible slot was available without conflicting with current calendar constraints.',
+    });
+
+    expect(result.message).toBe('No feasible slot was available without conflicting with current calendar constraints.');
+  });
+});

--- a/react-app/src/utils/plannerScheduling.ts
+++ b/react-app/src/utils/plannerScheduling.ts
@@ -1,0 +1,168 @@
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '../firebase';
+
+export type PlannerScheduleIntent = 'move' | 'defer';
+
+export interface SchedulePlannerItemRequest {
+  itemType: 'task' | 'story';
+  itemId: string;
+  targetDateMs: number;
+  targetBucket?: 'morning' | 'afternoon' | 'evening' | 'anytime' | null;
+  intent?: PlannerScheduleIntent;
+  source?: string;
+  rationale?: string | null;
+  linkedBlockId?: string | null;
+  targetSprintId?: string | null;
+  durationMinutes?: number | null;
+  planningMode?: 'smart' | 'strict' | null;
+  searchDays?: number | null;
+  maxTargetDateMs?: number | null;
+  allowSplit?: boolean;
+  debugRequestId?: string | null;
+}
+
+export interface SchedulePlannerItemResponse {
+  ok: boolean;
+  debugRequestId?: string | null;
+  planningMode: 'smart' | 'strict';
+  appliedStartMs: number;
+  appliedEndMs: number;
+  appliedDayMs: number;
+  appliedBucket: 'morning' | 'afternoon' | 'evening' | 'anytime' | null;
+  appliedWeekKey?: string | null;
+  appliedWeekStartMs?: number | null;
+  scheduledMinutes?: number;
+  blockCount?: number;
+  sprintId: string | null;
+  blockId: string | null;
+}
+
+export interface PlannerScheduleErrorInfo {
+  code: string;
+  rawMessage: string;
+  message: string;
+}
+
+export function normalizePlannerSchedulingError(error: any): PlannerScheduleErrorInfo {
+  const rawCode = String(error?.code || '').replace(/^functions\//, '').trim();
+  const rawMessage = String(error?.message || '').trim();
+  const detailsMessage = String(error?.details?.message || error?.details || '').trim();
+  const lowerMessage = rawMessage.toLowerCase();
+  const lowerDetails = detailsMessage.toLowerCase();
+  const code = rawCode || 'unknown';
+
+  if (rawMessage && rawMessage !== 'internal' && rawMessage !== 'unknown' && rawMessage !== rawCode) {
+    return {
+      code,
+      rawMessage,
+      message: rawMessage,
+    };
+  }
+
+  if (detailsMessage && detailsMessage !== 'internal' && detailsMessage !== 'unknown') {
+    return {
+      code,
+      rawMessage: detailsMessage,
+      message: detailsMessage,
+    };
+  }
+
+  if (code === 'permission-denied' || lowerMessage.includes('permission denied')) {
+    return {
+      code,
+      rawMessage: rawMessage || detailsMessage,
+      message: 'The planner could not update this item because you do not have permission to edit it.',
+    };
+  }
+
+  if (code === 'unauthenticated') {
+    return {
+      code,
+      rawMessage: rawMessage || detailsMessage,
+      message: 'You need to sign in again before deferring or moving this item.',
+    };
+  }
+
+  if (code === 'invalid-argument') {
+    return {
+      code,
+      rawMessage: rawMessage || detailsMessage,
+      message: 'The planner request was incomplete. Refresh the page and try again.',
+    };
+  }
+
+  if (
+    code === 'failed-precondition' ||
+    code === 'internal' ||
+    lowerMessage === 'internal' ||
+    lowerMessage === 'unknown' ||
+    lowerDetails === 'internal' ||
+    lowerDetails === 'unknown'
+  ) {
+    return {
+      code,
+      rawMessage: rawMessage || detailsMessage,
+      message: 'The planner could not place this item automatically. This usually means the suggested date conflicts with existing calendar blocks, sprint limits, or another scheduling constraint.',
+    };
+  }
+
+  return {
+    code,
+    rawMessage: rawMessage || detailsMessage || code,
+    message: rawMessage || detailsMessage || 'The planner could not update this item.',
+  };
+}
+
+const createPlannerDebugRequestId = () => (
+  `planner-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+);
+
+export async function schedulePlannerItem(
+  payload: SchedulePlannerItemRequest,
+): Promise<SchedulePlannerItemResponse> {
+  const callable = httpsCallable<SchedulePlannerItemRequest, SchedulePlannerItemResponse>(functions, 'schedulePlannerItem');
+  const requestPayload: SchedulePlannerItemRequest = {
+    ...payload,
+    debugRequestId: payload.debugRequestId || createPlannerDebugRequestId(),
+  };
+  try {
+    console.info('[plannerScheduling] request', {
+      debugRequestId: requestPayload.debugRequestId,
+      itemType: requestPayload.itemType,
+      itemId: requestPayload.itemId,
+      intent: requestPayload.intent || 'move',
+      source: requestPayload.source || 'planner',
+      targetDateMs: requestPayload.targetDateMs,
+      targetBucket: requestPayload.targetBucket || null,
+      linkedBlockId: requestPayload.linkedBlockId || null,
+      targetSprintId: requestPayload.targetSprintId || null,
+    });
+    const response = await callable(requestPayload);
+    console.info('[plannerScheduling] success', {
+      debugRequestId: requestPayload.debugRequestId,
+      itemType: requestPayload.itemType,
+      itemId: requestPayload.itemId,
+      result: response.data,
+    });
+    return {
+      ...response.data,
+      debugRequestId: response.data?.debugRequestId || requestPayload.debugRequestId || null,
+    };
+  } catch (error: any) {
+    const normalized = normalizePlannerSchedulingError(error);
+    console.error('[plannerScheduling] failure', {
+      debugRequestId: requestPayload.debugRequestId,
+      itemType: requestPayload.itemType,
+      itemId: requestPayload.itemId,
+      code: normalized.code,
+      rawMessage: normalized.rawMessage,
+      message: normalized.message,
+      error,
+    });
+    const nextError = new Error(normalized.message);
+    (nextError as any).code = normalized.code;
+    (nextError as any).rawMessage = normalized.rawMessage;
+    (nextError as any).debugRequestId = requestPayload.debugRequestId;
+    throw nextError;
+  }
+}

--- a/react-app/src/utils/timelineBuckets.ts
+++ b/react-app/src/utils/timelineBuckets.ts
@@ -1,0 +1,59 @@
+export type TimelineBucket = 'morning' | 'afternoon' | 'evening' | 'anytime';
+export const bucketOrder: TimelineBucket[] = ['morning', 'afternoon', 'evening', 'anytime'];
+
+const normalizeTimeOfDay = (value: string | null | undefined): TimelineBucket | null => {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (normalized === 'morning' || normalized === 'afternoon' || normalized === 'evening') {
+    return normalized;
+  }
+  return null;
+};
+
+export const bucketLabel = (bucket: TimelineBucket): string => {
+  if (bucket === 'morning') return 'Morning';
+  if (bucket === 'afternoon') return 'Afternoon';
+  if (bucket === 'evening') return 'Evening';
+  return 'Anytime';
+};
+
+export const bucketFromTime = (
+  ms: number | null | undefined,
+  timeOfDay?: string | null,
+  fallback: TimelineBucket = 'morning',
+): TimelineBucket => {
+  const explicit = normalizeTimeOfDay(timeOfDay);
+  if (!ms || !Number.isFinite(ms)) return explicit || fallback;
+  const date = new Date(ms);
+  const minute = date.getHours() * 60 + date.getMinutes();
+  // Real scheduled times should win over stale bucket flags, except when the stored timestamp is date-only midnight.
+  if (minute === 0 && explicit) return explicit;
+  if (minute >= 300 && minute <= 779) return 'morning';
+  if (minute >= 780 && minute <= 1139) return 'afternoon';
+  if (minute >= 1140 || minute < 300) return 'evening';
+  return explicit || fallback;
+};
+
+export const bucketPseudoTime = (dayStartMs: number, bucket: TimelineBucket): number => {
+  if (bucket === 'morning') return dayStartMs + (9 * 60 * 60 * 1000);
+  if (bucket === 'afternoon') return dayStartMs + (14 * 60 * 60 * 1000);
+  if (bucket === 'evening') return dayStartMs + (19.5 * 60 * 60 * 1000);
+  return dayStartMs + (12 * 60 * 60 * 1000);
+};
+
+export const formatBucketBackfillLabel = (
+  startMs: number | null | undefined,
+  endMs?: number | null,
+  timeOfDay?: string | null,
+): string => {
+  if (!startMs || !Number.isFinite(startMs)) {
+    return `Unscheduled (${bucketLabel(bucketFromTime(null, timeOfDay))})`;
+  }
+  const start = new Date(startMs);
+  const startLabel = start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  if (endMs && Number.isFinite(endMs)) {
+    const end = new Date(endMs);
+    const endLabel = end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return `${startLabel} - ${endLabel}`;
+  }
+  return startLabel;
+};


### PR DESCRIPTION
## Summary
- improve mobile UX consistency with shared filters, clearer badges, and labeled planner actions
- add planner move/defer diagnostics with correlation ids through client and server scheduling
- prevent duplicate Google Calendar syncs and add a repair callable for existing Bob-created duplicates

## Included
- mobile Top 3 / chores / focus filters and explanatory copy
- dropdown-chip status/priority controls on planner/mobile surfaces
- move/defer logging and scheduling path fixes
- Google Calendar sync lease protection and repairDuplicateCalendarEvents

## Validation
- targeted frontend eslint passed on touched files
- backend syntax checks passed on touched functions files
- npm --prefix react-app run build still fails on the pre-existing unrelated CheckInDaily typing issue in react-app/src/components/DailyPlanPage.tsx

## Notes
- existing duplicate Google events are not auto-repaired until the new callable is run
- the local worktree still contains unrelated uncommitted changes that are intentionally not part of this PR