### PR TITLE
chore: reconcile current web state and release backlog

### DIFF
--- a/functions/calendarSync.js
+++ b/functions/calendarSync.js
@@ -11,9 +11,65 @@ const ALLOWED_ROUTINE_TYPES = new Set(['chore', 'routine', 'habit']);
 const TASK_TABLE_LIMIT = 12;
 const MAX_PRIVATE_TASK_REFS = 6;
 const GOOGLE_EVENT_COLORS_TTL_MS = 6 * 60 * 60 * 1000;
+const SYNC_LEASE_MS = 2 * 60 * 1000;
 
 let cachedGoogleEventColors = null;
 let cachedGoogleEventColorsAt = 0;
+
+function createSyncLeaseId(blockId, action) {
+  return `${action}-${blockId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function getCalendarSyncLeaseRef(blockId) {
+  return admin.firestore().collection('calendar_sync_leases').doc(String(blockId));
+}
+
+async function acquireCalendarSyncLease(blockId, uid, action) {
+  const leaseRef = getCalendarSyncLeaseRef(blockId);
+  const leaseId = createSyncLeaseId(blockId, action);
+  const now = Date.now();
+  const expiresAtMs = now + SYNC_LEASE_MS;
+  try {
+    await admin.firestore().runTransaction(async (tx) => {
+      const snap = await tx.get(leaseRef);
+      const data = snap.exists ? (snap.data() || {}) : {};
+      const currentLeaseId = String(data.leaseId || '').trim();
+      const currentExpiresAtMs = Number(data.expiresAtMs || 0);
+      if (currentLeaseId && currentExpiresAtMs > now) {
+        throw new Error('calendar_sync_lease_busy');
+      }
+      tx.set(leaseRef, {
+        blockId,
+        ownerUid: uid,
+        action,
+        leaseId,
+        acquiredAtMs: now,
+        expiresAtMs,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+    });
+    return { leaseId, leaseRef };
+  } catch (error) {
+    if (String(error?.message || '') === 'calendar_sync_lease_busy') return null;
+    throw error;
+  }
+}
+
+async function releaseCalendarSyncLease(blockId, leaseId) {
+  if (!blockId || !leaseId) return;
+  const leaseRef = getCalendarSyncLeaseRef(blockId);
+  try {
+    await admin.firestore().runTransaction(async (tx) => {
+      const snap = await tx.get(leaseRef);
+      if (!snap.exists) return;
+      const data = snap.data() || {};
+      if (String(data.leaseId || '') !== String(leaseId)) return;
+      tx.delete(leaseRef);
+    });
+  } catch (error) {
+    console.warn('[calendarSync] failed to release sync lease', blockId, error?.message || error);
+  }
+}
 
 // Legacy numeric theme index mapping (1-based order in DEFAULT_THEMES)
 const NUMERIC_THEME_MAP = {
@@ -691,6 +747,26 @@ async function findExistingEventByPrivateProp(calendar, { key, value, timeMin, t
   return events.find((ev) => ev && ev.id) || null;
 }
 
+function getBobPrivateProps(event) {
+  return event?.extendedProperties?.private || {};
+}
+
+function getBobBlockIdFromEvent(event) {
+  const priv = getBobPrivateProps(event);
+  return String(priv['bob-block-id'] || priv['bobBlockId'] || '').trim();
+}
+
+function isConfidentBobCreatedEvent(event) {
+  const priv = getBobPrivateProps(event);
+  return Boolean(
+    getBobBlockIdFromEvent(event)
+      || priv['bob-entity-type']
+      || priv['bob-story-id']
+      || priv['bob-task-id']
+      || priv['bob-deeplink']
+  );
+}
+
 function parseEventTime(timeObj) {
   if (!timeObj) return null;
   if (timeObj.dateTime) return new Date(timeObj.dateTime).getTime();
@@ -729,6 +805,7 @@ async function getActiveSprintId(uid) {
 async function syncBlockToGoogle(blockId, action, uid, blockData = null) {
   let block = blockData;
   let eventId = null;
+  let syncLease = null;
   const errorContext = {};
   const debugLogs = [];
   const testMode = !!process.env.CALENDAR_SYNC_TEST_MODE;
@@ -739,6 +816,32 @@ async function syncBlockToGoogle(blockId, action, uid, blockData = null) {
       const snap = await admin.firestore().collection('calendar_blocks').doc(blockId).get();
       if (!snap.exists) throw new Error('Block not found');
       block = snap.data();
+    }
+
+    if (action === 'create' || action === 'update') {
+      syncLease = await acquireCalendarSyncLease(blockId, uid, action);
+      if (!syncLease) {
+        debugLogs.push({ step: 'sync_skipped', reason: 'sync_lease_busy' });
+        await logCalendarIntegration(uid, {
+          action: 'push',
+          direction: action,
+          status: 'skipped',
+          blockId,
+          blockTitle: block?.title || null,
+          reason: 'sync_lease_busy',
+        });
+        return { skipped: true, reason: 'sync_lease_busy' };
+      }
+      const freshSnap = await admin.firestore().collection('calendar_blocks').doc(blockId).get();
+      if (!freshSnap.exists) {
+        debugLogs.push({ step: 'sync_skipped', reason: 'block_missing_after_lease' });
+        return { skipped: true, reason: 'block_missing_after_lease' };
+      }
+      block = freshSnap.data();
+      if (action === 'create' && block?.googleEventId) {
+        debugLogs.push({ step: 'sync_skipped', reason: 'google_event_already_linked', eventId: block.googleEventId });
+        return { skipped: true, reason: 'google_event_already_linked', eventId: block.googleEventId };
+      }
     }
 
     if (block && block.syncToGoogle === false && action !== 'delete') {
@@ -1651,8 +1754,133 @@ async function syncBlockToGoogle(blockId, action, uid, blockData = null) {
       debug: debugLogs,
     });
     throw err;
+  } finally {
+    if (syncLease?.leaseId) {
+      await releaseCalendarSyncLease(blockId, syncLease.leaseId);
+    }
   }
 }
+
+exports.repairDuplicateCalendarEvents = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'Must be authenticated');
+  }
+  const uid = context.auth.uid;
+  const dryRun = data?.dryRun !== false;
+  const lookbackDays = Math.max(1, Math.min(Number(data?.lookbackDays || 21), 180));
+  const forwardDays = Math.max(1, Math.min(Number(data?.forwardDays || 90), 365));
+  const now = Date.now();
+  const timeMin = new Date(now - (lookbackDays * MS_IN_DAY)).toISOString();
+  const timeMax = new Date(now + (forwardDays * MS_IN_DAY)).toISOString();
+
+  await logCalendarIntegration(uid, {
+    action: 'repair_duplicates',
+    status: 'started',
+    dryRun,
+    timeMin,
+    timeMax,
+  });
+
+  try {
+    const { calendar } = await getCalendarClientForUser(uid);
+    const events = await listAllEvents(calendar, { timeMin, timeMax });
+    const duplicateGroups = new Map();
+    events.forEach((event) => {
+      if (!isConfidentBobCreatedEvent(event)) return;
+      const blockId = getBobBlockIdFromEvent(event);
+      if (!blockId) return;
+      const list = duplicateGroups.get(blockId) || [];
+      list.push(event);
+      duplicateGroups.set(blockId, list);
+    });
+
+    let groupsFound = 0;
+    let eventsDeleted = 0;
+    let blocksRelinked = 0;
+    let skipped = 0;
+    const repairs = [];
+
+    for (const [blockId, group] of duplicateGroups.entries()) {
+      if (!Array.isArray(group) || group.length <= 1) continue;
+      groupsFound += 1;
+      const blockRef = admin.firestore().collection('calendar_blocks').doc(String(blockId));
+      const blockSnap = await blockRef.get().catch(() => null);
+      const block = blockSnap && blockSnap.exists ? (blockSnap.data() || {}) : null;
+      const linkedGoogleEventId = String(block?.googleEventId || '').trim();
+      const sortedGroup = [...group].sort((a, b) => {
+        const aUpdated = Date.parse(String(a?.updated || '')) || 0;
+        const bUpdated = Date.parse(String(b?.updated || '')) || 0;
+        return bUpdated - aUpdated;
+      });
+      const survivor = sortedGroup.find((event) => String(event?.id || '') === linkedGoogleEventId) || sortedGroup[0];
+      if (!survivor?.id) {
+        skipped += group.length;
+        continue;
+      }
+      const duplicates = sortedGroup.filter((event) => String(event?.id || '') !== String(survivor.id));
+      repairs.push({
+        blockId,
+        survivorEventId: survivor.id,
+        duplicateEventIds: duplicates.map((event) => event.id).filter(Boolean),
+      });
+
+      if (!dryRun && blockSnap && blockSnap.exists && linkedGoogleEventId !== String(survivor.id)) {
+        await blockRef.set({
+          googleEventId: survivor.id,
+          externalLink: survivor.htmlLink || block?.externalLink || admin.firestore.FieldValue.delete(),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        }, { merge: true });
+        blocksRelinked += 1;
+      } else if (dryRun && linkedGoogleEventId !== String(survivor.id)) {
+        blocksRelinked += 1;
+      }
+
+      for (const duplicate of duplicates) {
+        if (!duplicate?.id) {
+          skipped += 1;
+          continue;
+        }
+        if (!dryRun) {
+          await calendar.events.delete({ calendarId: 'primary', eventId: duplicate.id });
+        }
+        eventsDeleted += 1;
+      }
+    }
+
+    await logCalendarIntegration(uid, {
+      action: 'repair_duplicates',
+      status: 'success',
+      dryRun,
+      timeMin,
+      timeMax,
+      groupsFound,
+      eventsDeleted,
+      blocksRelinked,
+      skipped,
+      repairs: repairs.slice(0, 50),
+    });
+
+    return {
+      ok: true,
+      dryRun,
+      groupsFound,
+      eventsDeleted,
+      blocksRelinked,
+      skipped,
+      repairs,
+    };
+  } catch (error) {
+    await logCalendarIntegration(uid, {
+      action: 'repair_duplicates',
+      status: 'error',
+      dryRun,
+      timeMin,
+      timeMax,
+      error: error?.message || String(error),
+    });
+    throw new functions.https.HttpsError('internal', error?.message || 'Failed to repair duplicate calendar events');
+  }
+});
 
 exports._syncBlockToGoogle = syncBlockToGoogle;
 

--- a/functions/capacityPlanning.js
+++ b/functions/capacityPlanning.js
@@ -159,6 +159,7 @@ exports.calculateNextWeekCapacity = onCall({
  */
 async function calculateCapacityInternal(db, userId, sprintId) {
     try {
+        const timezone = await resolveUserTimezone(db, userId);
         // 1. Fetch Sprint Data
         const sprintDoc = await db.collection('sprints').doc(sprintId).get();
         if (!sprintDoc.exists) {

--- a/functions/deferralSuggestions.js
+++ b/functions/deferralSuggestions.js
@@ -1,30 +1,17 @@
 const httpsV2 = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
+const {
+  DAY_MS,
+  buildDayLoadPointsMap,
+  inferItemPoints,
+  startOfDayMs,
+  summarizeCapacity,
+  toDayKey,
+  toMillis,
+} = require('./services/capacityService');
 
 if (!admin.apps.length) {
   admin.initializeApp();
-}
-
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-function toMillis(value) {
-  if (value == null) return null;
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (typeof value?.toMillis === 'function') return value.toMillis();
-  if (typeof value?.toDate === 'function') return value.toDate().getTime();
-  if (typeof value?.seconds === 'number') return value.seconds * 1000;
-  const parsed = Date.parse(String(value));
-  return Number.isNaN(parsed) ? null : parsed;
-}
-
-function startOfDayMs(ts = Date.now()) {
-  const d = new Date(ts);
-  d.setHours(0, 0, 0, 0);
-  return d.getTime();
-}
-
-function toDayKey(ms) {
-  return new Date(ms).toISOString().slice(0, 10);
 }
 
 function titleForDay(ms) {
@@ -35,6 +22,67 @@ function titleForDay(ms) {
   });
 }
 
+function normaliseRecurringFrequency(data) {
+  const direct = String(data?.repeatFrequency || data?.recurrence?.frequency || data?.recurrence?.freq || '').trim().toLowerCase();
+  if (['daily', 'weekly', 'monthly', 'yearly'].includes(direct)) return direct;
+  const rrule = String(data?.rrule || '').toUpperCase();
+  if (rrule.includes('DAILY')) return 'daily';
+  if (rrule.includes('WEEKLY')) return 'weekly';
+  if (rrule.includes('MONTHLY')) return 'monthly';
+  if (rrule.includes('YEARLY') || rrule.includes('ANNUAL')) return 'yearly';
+  return null;
+}
+
+function recurrenceAwareDeferDays(data) {
+  const frequency = normaliseRecurringFrequency(data);
+  if (!frequency) return null;
+  const interval = Math.max(1, Number(data?.repeatInterval || data?.recurrence?.interval || 1) || 1);
+  if (frequency === 'daily') return interval;
+  if (frequency === 'weekly') return 7 * interval;
+  if (frequency === 'monthly') return 14 * interval;
+  if (frequency === 'yearly') return 60 * interval;
+  return null;
+}
+
+function buildFocusCapacityNote(focusContext) {
+  if (!focusContext || focusContext.isFocusAligned !== false) return '';
+  const goals = Array.isArray(focusContext.activeFocusGoals) ? focusContext.activeFocusGoals : [];
+  if (goals.length === 0) return '';
+  const titles = goals
+    .map((goal) => String(goal?.title || '').trim())
+    .filter(Boolean)
+    .slice(0, 2);
+  if (titles.length === 0) {
+    return ' This also frees capacity for active focus work.';
+  }
+  const summary = titles.join(' and ');
+  const suffix = goals.length > 2 ? ' and other active focus goals' : '';
+  return ` This also frees capacity for ${summary}${suffix}.`;
+}
+
+function capacityLabel(rank, projectedUtilization) {
+  if (projectedUtilization > 100) {
+    return rank === 0 ? 'Least overloaded day' : 'Still over capacity';
+  }
+  if (projectedUtilization > 80) {
+    return rank === 0 ? 'Best fit day' : 'Near-capacity day';
+  }
+  return rank === 0 ? 'Best capacity day' : 'Low load day';
+}
+
+function capacityRationale(candidate, itemPoints, focusCapacityNote) {
+  const projectedPoints = candidate.projectedPoints;
+  const projectedUtilization = candidate.projectedUtilization;
+  const base = `${titleForDay(candidate.dayMs)} would be about ${projectedUtilization}% utilization after moving this item (${projectedPoints.toFixed(1)} pts planned).`;
+  if (projectedUtilization > 100) {
+    return `${base} It is still over capacity, but is the least overloaded option in the near term.${focusCapacityNote}`;
+  }
+  if (projectedUtilization > 80) {
+    return `${base} This keeps the day close to capacity without overbooking it.${focusCapacityNote}`;
+  }
+  return `${base} This keeps the day comfortably within capacity.${focusCapacityNote}`;
+}
+
 const suggestDeferralOptions = httpsV2.onCall({ region: 'europe-west2', memory: '512MiB' }, async (req) => {
   if (!req.auth?.uid) {
     throw new httpsV2.HttpsError('unauthenticated', 'Authentication required');
@@ -43,20 +91,17 @@ const suggestDeferralOptions = httpsV2.onCall({ region: 'europe-west2', memory: 
   const uid = req.auth.uid;
   const horizonDays = Math.max(7, Math.min(42, Number(req.data?.horizonDays || 21)));
   const dailyCapacityHours = Math.max(2, Math.min(16, Number(req.data?.dailyCapacityHours || 8)));
+  const focusCapacityNote = buildFocusCapacityNote(req.data?.focusContext || null);
 
   const db = admin.firestore();
   const nowMs = Date.now();
   const todayMs = startOfDayMs(nowMs);
   const horizonEndMs = todayMs + horizonDays * DAY_MS;
+  const itemType = String(req.data?.itemType || '').trim().toLowerCase();
+  const itemId = String(req.data?.itemId || '').trim();
 
-  const [sprintsSnap, blocksSnap] = await Promise.all([
+  const [sprintsSnap] = await Promise.all([
     db.collection('sprints').where('ownerUid', '==', uid).get().catch(() => ({ docs: [] })),
-    db.collection('calendar_blocks')
-      .where('ownerUid', '==', uid)
-      .where('start', '>=', todayMs)
-      .where('start', '<=', horizonEndMs)
-      .get()
-      .catch(() => ({ docs: [] })),
   ]);
 
   const sprints = (sprintsSnap.docs || []).map((d) => {
@@ -74,28 +119,56 @@ const suggestDeferralOptions = httpsV2.onCall({ region: 'europe-west2', memory: 
     .filter((s) => (s.startMs || 0) > nowMs)
     .sort((a, b) => (a.startMs || 0) - (b.startMs || 0))[0] || null;
 
-  const dayLoadHours = new Map();
-  for (const doc of (blocksSnap.docs || [])) {
-    const data = doc.data() || {};
-    const startMs = toMillis(data.start);
-    const endMs = toMillis(data.end);
-    if (!startMs || !endMs || endMs <= startMs) continue;
-    const dayKey = toDayKey(startMs);
-    const hours = Math.max(0.25, (endMs - startMs) / (60 * 60 * 1000));
-    dayLoadHours.set(dayKey, (dayLoadHours.get(dayKey) || 0) + hours);
+  let recurrenceAwareOption = null;
+  let itemData = null;
+  if (itemId && (itemType === 'task' || itemType === 'story')) {
+    try {
+      const itemSnap = await db.collection(itemType === 'task' ? 'tasks' : 'stories').doc(itemId).get();
+      if (itemSnap.exists) {
+        const item = itemSnap.data() || {};
+        itemData = item;
+        const inferredTaskType = String(item?.type || '').trim().toLowerCase();
+        const recurrenceDays = recurrenceAwareDeferDays(item);
+        if (itemType === 'task' && recurrenceDays != null && ['chore', 'routine', 'habit'].includes(inferredTaskType)) {
+          const recurrenceMs = todayMs + (recurrenceDays * DAY_MS);
+          recurrenceAwareOption = {
+            key: 'recurrence_aware',
+            dateMs: recurrenceMs,
+            label: 'Next sensible recurrence defer',
+            rationale: `This ${inferredTaskType} repeats ${normaliseRecurringFrequency(item)}${Number(item?.repeatInterval || 1) > 1 ? ` every ${Number(item?.repeatInterval || 1)}` : ''}, so deferring it to ${titleForDay(recurrenceMs)} keeps the schedule aligned with its cadence.${focusCapacityNote}`,
+            source: 'recurrence_interval',
+          };
+        }
+      }
+    } catch (error) {
+      console.warn('[suggestDeferralOptions] recurrence-aware task lookup failed', error?.message || error);
+    }
   }
+  const itemPoints = inferItemPoints(itemType, itemData);
+
+  const dayLoadPoints = await buildDayLoadPointsMap(db, uid, todayMs, horizonEndMs);
 
   const candidates = [];
   for (let offset = 1; offset <= Math.min(21, horizonDays); offset += 1) {
     const dayMs = todayMs + offset * DAY_MS;
     const dayKey = toDayKey(dayMs);
-    const loadHours = Number(dayLoadHours.get(dayKey) || 0);
-    const utilization = Math.round((loadHours / dailyCapacityHours) * 100);
-    candidates.push({ dayMs, dayKey, loadHours, utilization });
+    const loadPoints = Number(dayLoadPoints.get(dayKey) || 0);
+    const baseSummary = summarizeCapacity(loadPoints, dailyCapacityHours);
+    const projectedPoints = loadPoints + itemPoints;
+    const projectedSummary = summarizeCapacity(projectedPoints, dailyCapacityHours);
+    candidates.push({
+      dayMs,
+      dayKey,
+      loadPoints,
+      utilization: baseSummary.utilizationPct,
+      projectedPoints,
+      projectedUtilization: projectedSummary.utilizationPct,
+    });
   }
 
   const lowUtilOptions = candidates
     .sort((a, b) => {
+      if (a.projectedUtilization !== b.projectedUtilization) return a.projectedUtilization - b.projectedUtilization;
       if (a.utilization !== b.utilization) return a.utilization - b.utilization;
       return a.dayMs - b.dayMs;
     })
@@ -103,20 +176,23 @@ const suggestDeferralOptions = httpsV2.onCall({ region: 'europe-west2', memory: 
     .map((c, idx) => ({
       key: `capacity_${idx + 1}`,
       dateMs: c.dayMs,
-      label: idx === 0 ? 'Best capacity day' : 'Low load day',
-      rationale: `${titleForDay(c.dayMs)} is at about ${c.utilization}% utilization (${c.loadHours.toFixed(1)}h planned), so this avoids overbooking.`,
+      label: capacityLabel(idx, c.projectedUtilization),
+      rationale: capacityRationale(c, itemPoints, focusCapacityNote),
       source: 'capacity_forecast',
-      utilizationPercent: c.utilization,
+      utilizationPercent: c.projectedUtilization,
       rank: idx + 1,
     }));
 
   const options = [];
+  if (recurrenceAwareOption) {
+    options.push(recurrenceAwareOption);
+  }
   if (nextSprint && nextSprint.startMs) {
     options.push({
       key: 'next_sprint',
       dateMs: nextSprint.startMs,
       label: `Move to next sprint (${nextSprint.title})`,
-      rationale: `Shifting to ${titleForDay(nextSprint.startMs)} keeps this out of the current sprint load and lines up with the next sprint window.`,
+      rationale: `Shifting to ${titleForDay(nextSprint.startMs)} keeps this out of the current sprint load and lines up with the next sprint window.${focusCapacityNote}`,
       source: 'sprint_window',
     });
   }
@@ -129,7 +205,7 @@ const suggestDeferralOptions = httpsV2.onCall({ region: 'europe-west2', memory: 
       key: 'tomorrow',
       dateMs: fallbackMs,
       label: 'Tomorrow',
-      rationale: 'No forecast data found, so this uses a simple one-day defer fallback.',
+      rationale: `No forecast data found, so this uses a simple one-day defer fallback.${focusCapacityNote}`,
       source: 'fallback',
     });
   }

--- a/functions/index.js
+++ b/functions/index.js
@@ -94,11 +94,11 @@ try {
   if (calendarSync) {
     exports.syncCalendarBlock = calendarSync.syncCalendarBlock;
     exports.onCalendarBlockWrite = calendarSync.onCalendarBlockWrite;
-    exports.onStoryCalendarAutoLink = calendarSync.onStoryCalendarAutoLink;
     exports.syncFromGoogleCalendar = calendarSync.syncFromGoogleCalendar;
     exports.syncCalendarNow = calendarSync.syncCalendarNow;
     exports.scheduledCalendarSync = calendarSync.scheduledCalendarSync;
     exports.gcalLinkUnlinkedEvents = calendarSync.gcalLinkUnlinkedEvents;
+    exports.repairDuplicateCalendarEvents = calendarSync.repairDuplicateCalendarEvents;
   }
 } catch (e) {
   console.warn('[init] calendarSync not loaded', e?.message || e);
@@ -253,9 +253,6 @@ try {
     if (nightlyOrchestration.deltaPriorityRescore) {
       exports.deltaPriorityRescore = nightlyOrchestration.deltaPriorityRescore;
     }
-    if (nightlyOrchestration.applyEveningPullForward) {
-      exports.applyEveningPullForward = nightlyOrchestration.applyEveningPullForward;
-    }
   }
 } catch (e) {
   console.warn('[init] nightlyOrchestration not loaded', e?.message || e);
@@ -293,221 +290,10 @@ exports.updateGoalTargetYears = schedulerV2.onSchedule(
   });
 
 // Nightly fitness KPI sync: updates goal KPI progress from Strava/HealthKit workouts
-const buildWeeklySnapshotKey = (dt) => {
-  const resolved = DateTime.isDateTime(dt) ? dt : DateTime.fromJSDate(new Date(dt || Date.now()));
-  return `${resolved.weekYear}-W${String(resolved.weekNumber).padStart(2, '0')}`;
-};
-
-const parseWeeklySnapshotKey = (weekKey, zone = DEFAULT_TIMEZONE) => {
-  const match = /^(\d{4})-W(\d{2})$/.exec(String(weekKey || '').trim());
-  if (!match) return null;
-  const weekYear = Number(match[1]);
-  const weekNumber = Number(match[2]);
-  if (!Number.isFinite(weekYear) || !Number.isFinite(weekNumber)) return null;
-  const dt = DateTime.fromObject({ weekYear, weekNumber, weekday: 1 }, { zone });
-  return dt.isValid ? dt.startOf('day') : null;
-};
-
-const buildBackfilledResolvedKpis = (leafSummary = {}) => {
-  const topKpis = Array.isArray(leafSummary?.topKpis) ? leafSummary.topKpis : [];
-  return topKpis.map((kpi, index) => {
-    const progressPct = Number(kpi?.progressPct);
-    const healthy = kpi?.healthy === true;
-    return {
-      index,
-      id: String(kpi?.id || `${leafSummary.goalId || 'goal'}_${index}`),
-      name: String(kpi?.name || `KPI ${index + 1}`),
-      currentDisplay: kpi?.currentDisplay ?? null,
-      progressPct: Number.isFinite(progressPct) ? progressPct : null,
-      healthy,
-      stale: !healthy,
-      backfilled: true,
-      source: 'weekly_checkin_focus_summary',
-      snapshotQuality: 'summary_only',
-    };
-  });
-};
-
-const snapshotGoalKpiMetricsForUser = async (uid, { reason = 'manual', now = null } = {}) => {
-  const db = admin.firestore();
-  const profile = await loadProfile(db, uid).catch(() => ({ id: uid }));
-  const zone = resolveTimezone(profile, DEFAULT_TIMEZONE);
-  const snapshotDt = (DateTime.isDateTime(now)
-    ? now
-    : now
-      ? DateTime.fromJSDate(new Date(now))
-      : DateTime.now()).setZone(zone);
-  const weekKey = buildWeeklySnapshotKey(snapshotDt);
-  const metricsSnap = await db.collection('goal_kpi_metrics').where('ownerUid', '==', uid).get();
-  if (metricsSnap.empty) {
-    return { uid, zone, weekKey, snapshotCount: 0 };
-  }
-
-  let batch = db.batch();
-  let pendingWrites = 0;
-  let snapshotCount = 0;
-  const commitBatch = async () => {
-    if (pendingWrites === 0) return;
-    await batch.commit();
-    batch = db.batch();
-    pendingWrites = 0;
-  };
-
-  for (const docSnap of metricsSnap.docs) {
-    const data = docSnap.data() || {};
-    const goalId = String(data.goalId || '').trim();
-    if (!goalId) continue;
-    const snapshotRef = db.collection('weekly_goal_kpi_snapshots').doc(`${uid}_${weekKey}_${goalId}`);
-    batch.set(snapshotRef, {
-      ownerUid: uid,
-      goalId,
-      goalRef: data.goalRef || null,
-      goalTitle: data.goalTitle || null,
-      resolvedKpis: Array.isArray(data.resolvedKpis) ? data.resolvedKpis : [],
-      weekKey,
-      snapshotType: 'weekly',
-      snapshotReason: reason,
-      snapshotTimeZone: zone,
-      sourceUpdatedAt: data.updatedAt || null,
-      snapshotAt: admin.firestore.FieldValue.serverTimestamp(),
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    }, { merge: true });
-    pendingWrites += 1;
-    snapshotCount += 1;
-    if (pendingWrites >= 400) {
-      await commitBatch();
-    }
-  }
-
-  await commitBatch();
-  return { uid, zone, weekKey, snapshotCount };
-};
-
-const backfillWeeklyGoalKpiSnapshotsForUser = async (uid, { maxWeeks = 26, overwrite = false } = {}) => {
-  const db = admin.firestore();
-  const profile = await loadProfile(db, uid).catch(() => ({ id: uid }));
-  const zone = resolveTimezone(profile, DEFAULT_TIMEZONE);
-  const boundedMaxWeeks = Math.max(1, Math.min(Number(maxWeeks) || 26, 104));
-
-  const [weeklyCheckinsSnap, existingSnapshotsSnap] = await Promise.all([
-    db.collection('weekly_checkins').where('ownerUid', '==', uid).get(),
-    db.collection('weekly_goal_kpi_snapshots').where('ownerUid', '==', uid).get(),
-  ]);
-
-  const existingSnapshotIds = new Set(existingSnapshotsSnap.docs.map((docSnap) => docSnap.id));
-  const candidateWeeks = weeklyCheckinsSnap.docs
-    .map((docSnap) => {
-      const data = docSnap.data() || {};
-      const weekKey = String(data.weekKey || '').trim();
-      const weekDt = parseWeeklySnapshotKey(weekKey, zone);
-      const focusSummary = data?.metrics?.focusSummary || null;
-      const leafGoals = Array.isArray(focusSummary?.leafGoals) ? focusSummary.leafGoals : [];
-      return {
-        id: docSnap.id,
-        weekKey,
-        weekDt,
-        updatedAt: data.updatedAt || data.createdAt || null,
-        leafGoals,
-      };
-    })
-    .filter((entry) => entry.weekDt && entry.leafGoals.length > 0)
-    .sort((a, b) => b.weekDt.toMillis() - a.weekDt.toMillis())
-    .slice(0, boundedMaxWeeks);
-
-  let batch = db.batch();
-  let pendingWrites = 0;
-  let snapshotsWritten = 0;
-  let snapshotsSkipped = 0;
-
-  const commitBatch = async () => {
-    if (pendingWrites === 0) return;
-    await batch.commit();
-    batch = db.batch();
-    pendingWrites = 0;
-  };
-
-  for (const weekly of candidateWeeks) {
-    for (const leafGoal of weekly.leafGoals) {
-      const goalId = String(leafGoal?.goalId || '').trim();
-      if (!goalId) continue;
-      const snapshotId = `${uid}_${weekly.weekKey}_${goalId}`;
-      if (!overwrite && existingSnapshotIds.has(snapshotId)) {
-        snapshotsSkipped += 1;
-        continue;
-      }
-      const snapshotRef = db.collection('weekly_goal_kpi_snapshots').doc(snapshotId);
-      batch.set(snapshotRef, {
-        ownerUid: uid,
-        goalId,
-        goalRef: null,
-        goalTitle: leafGoal?.title || null,
-        resolvedKpis: buildBackfilledResolvedKpis(leafGoal),
-        weekKey: weekly.weekKey,
-        snapshotType: 'weekly',
-        snapshotReason: 'backfillWeeklyGoalKpiSnapshots',
-        snapshotTimeZone: zone,
-        sourceUpdatedAt: weekly.updatedAt || null,
-        snapshotAt: admin.firestore.FieldValue.serverTimestamp(),
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        backfilled: true,
-        snapshotQuality: 'summary_only',
-        backfilledFromWeeklyCheckinId: weekly.id,
-        totalKpis: Number(leafGoal?.totalKpis || 0) || 0,
-        healthyKpis: Number(leafGoal?.healthyKpis || 0) || 0,
-        staleKpis: Number(leafGoal?.staleKpis || 0) || 0,
-      }, { merge: true });
-      existingSnapshotIds.add(snapshotId);
-      snapshotsWritten += 1;
-      pendingWrites += 1;
-      if (pendingWrites >= 400) {
-        await commitBatch();
-      }
-    }
-  }
-
-  await commitBatch();
-  const currentWeekSnapshot = await snapshotGoalKpiMetricsForUser(uid, { reason: 'backfillWeeklyGoalKpiSnapshots_current' });
-
-  return {
-    uid,
-    zone,
-    weeksScanned: candidateWeeks.length,
-    snapshotsWritten,
-    snapshotsSkipped,
-    currentWeekSnapshotsWritten: Number(currentWeekSnapshot?.snapshotCount || 0),
-    currentWeekKey: currentWeekSnapshot?.weekKey || buildWeeklySnapshotKey(DateTime.now().setZone(zone)),
-  };
-};
-
 const syncFitnessKpis = async () => {
   try {
-    const [fitnessResult, usersSnap] = await Promise.all([
-      syncAllUsersFitnessKpis(),
-      admin.firestore().collection('profiles').get(),
-    ]);
-
-    let metricsDocsUpdated = 0;
-    let weeklySnapshotsUpdated = 0;
-    for (const userDoc of usersSnap.docs) {
-      const uid = String(userDoc.id || '').trim();
-      if (!uid) continue;
-      const rows = await computeGoalFitnessKpisForUser(uid, { persist: true });
-      metricsDocsUpdated += Array.isArray(rows) ? rows.length : 0;
-      const snapshotResult = await snapshotGoalKpiMetricsForUser(uid, { reason: 'syncFitnessKpisNightly' });
-      weeklySnapshotsUpdated += Number(snapshotResult?.snapshotCount || 0);
-    }
-
-    const result = {
-      ...fitnessResult,
-      metricsDocsUpdated,
-      weeklySnapshotsUpdated,
-    };
-
-    console.log(
-      `✅ Fitness KPI sync completed: ${result.totalSynced} goals updated, ` +
-      `${metricsDocsUpdated} goal_kpi_metrics docs refreshed, ` +
-      `${weeklySnapshotsUpdated} weekly KPI snapshots written`
-    );
+    const result = await syncAllUsersFitnessKpis();
+    console.log(`✅ Fitness KPI sync completed: ${result.totalSynced} goals updated`);
     return result;
   } catch (e) {
     console.error('[fitnessKpiSync] failed', e?.message || e);
@@ -527,36 +313,11 @@ exports.syncFitnessKpisNow = httpsV2.onCall({ region: 'europe-west2' }, async (r
     throw new httpsV2.HttpsError('unauthenticated', 'Sign in required');
   }
   try {
-    const [result, metricsRows] = await Promise.all([
-      syncUserFitnessKpis(uid),
-      computeGoalFitnessKpisForUser(uid, { persist: true }),
-    ]);
-    const snapshotResult = await snapshotGoalKpiMetricsForUser(uid, { reason: 'syncFitnessKpisNow' });
-    return {
-      ok: true,
-      ...result,
-      metricsDocsUpdated: Array.isArray(metricsRows) ? metricsRows.length : 0,
-      weeklySnapshotsUpdated: Number(snapshotResult?.snapshotCount || 0),
-    };
+    const result = await syncUserFitnessKpis(uid);
+    return { ok: true, ...result };
   } catch (e) {
     console.error('[fitnessKpiSync] user sync failed:', e);
     throw new httpsV2.HttpsError('internal', e?.message || 'Sync failed');
-  }
-});
-
-exports.backfillWeeklyGoalKpiSnapshots = httpsV2.onCall({ region: 'europe-west2' }, async (req) => {
-  const uid = req?.auth?.uid;
-  if (!uid) {
-    throw new httpsV2.HttpsError('unauthenticated', 'Sign in required');
-  }
-  const maxWeeks = Math.max(1, Math.min(Number(req?.data?.maxWeeks) || 26, 104));
-  const overwrite = req?.data?.overwrite === true;
-  try {
-    const result = await backfillWeeklyGoalKpiSnapshotsForUser(uid, { maxWeeks, overwrite });
-    return { ok: true, ...result };
-  } catch (e) {
-    console.error('[weekly-kpi-backfill] failed', { uid, maxWeeks, overwrite, error: e });
-    throw new httpsV2.HttpsError('internal', e?.message || 'Weekly KPI snapshot backfill failed');
   }
 });
 
@@ -902,36 +663,6 @@ function applyTimeOfDay(day, timeMs) {
   return d.getTime();
 }
 
-const CHORE_TIMEZONE = 'Europe/London';
-
-function extractZoneHourMinute(ms, timeZone = CHORE_TIMEZONE) {
-  const d = new Date(ms);
-  const parts = new Intl.DateTimeFormat('en-GB', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-    timeZone,
-  }).formatToParts(d);
-  const hour = Number(parts.find((p) => p.type === 'hour')?.value || '0');
-  const minute = Number(parts.find((p) => p.type === 'minute')?.value || '0');
-  return { hour, minute };
-}
-
-function formatDueTime(ms) {
-  const { hour, minute } = extractZoneHourMinute(ms);
-  const hh = String(hour).padStart(2, '0');
-  const mm = String(minute).padStart(2, '0');
-  return `${hh}:${mm}`;
-}
-
-function classifyTimeOfDay(ms) {
-  const { hour, minute } = extractZoneHourMinute(ms);
-  const minutes = hour * 60 + minute;
-  if (minutes >= (5 * 60) && minutes < (12 * 60)) return 'morning';
-  if (minutes >= (12 * 60) && minutes < (17 * 60)) return 'afternoon';
-  return 'evening';
-}
-
 function durationMinutesFromTask(task) {
   const points = Number(task?.points || 0);
   const estimateMin = Number(task?.estimateMin || 0);
@@ -995,7 +726,7 @@ async function findSlotForDay(db, ownerUid, dayStartMs, dayEndMs, durationMs) {
   return null;
 }
 
-async function upsertChoreBlocksForTask(db, task, lookaheadDays = 28) {
+async function upsertChoreBlocksForTask(db, task, lookaheadDays = 14) {
   if (!task?.ownerUid || !task?.id) return { created: 0, updated: 0 };
   const ownerUid = task.ownerUid;
   const today = startOfDay(new Date());
@@ -1064,50 +795,6 @@ async function upsertChoreBlocksForTask(db, task, lookaheadDays = 28) {
     }
     return null;
   };
-
-  const findSlotFromDay = async (startDay, existingDocId = null, preferredMs = null) => {
-    for (const candidateDay of iterateNextDays(startDay, lookaheadDays)) {
-      const candidateStartMs = startOfDay(candidateDay).getTime();
-      if (snoozedUntil && candidateStartMs < startOfDay(new Date(snoozedUntil)).getTime()) continue;
-      const candidateKey = toDayKey(candidateDay);
-      const candidateDayStartMs = candidateStartMs;
-      const candidateDayEndMs = candidateDayStartMs + (24 * 60 * 60 * 1000) - 1;
-      const candidateCtx = await loadDayCtx(candidateDayStartMs, candidateDayEndMs, candidateKey);
-      if (!candidateCtx.windows.length) continue;
-      const occupiedWithoutSelf = candidateCtx.occupied.filter((o) => o.id !== existingDocId);
-
-      if (preferredMs && startOfDay(new Date(preferredMs)).getTime() === candidateDayStartMs) {
-        const preferredEnd = preferredMs + durationMs;
-        if (
-          fitsInWindows(preferredMs, preferredEnd, candidateCtx.windows) &&
-          !overlapsAny(preferredMs, preferredEnd, occupiedWithoutSelf)
-        ) {
-          return {
-            startMs: preferredMs,
-            endMs: preferredEnd,
-            dayCtx: candidateCtx,
-            dayKey: candidateKey,
-            day: candidateDay,
-            occupiedWithoutSelf,
-          };
-        }
-      }
-
-      const slot = findSlotInWindows(candidateCtx.windows, occupiedWithoutSelf, durationMs);
-      if (slot != null) {
-        return {
-          startMs: slot,
-          endMs: slot + durationMs,
-          dayCtx: candidateCtx,
-          dayKey: candidateKey,
-          day: candidateDay,
-          occupiedWithoutSelf,
-        };
-      }
-    }
-    return null;
-  };
-
   for (const day of iterateNextDays(today, lookaheadDays)) {
     if (snoozedUntil && day.getTime() < startOfDay(new Date(snoozedUntil)).getTime()) continue;
     if (!shouldScheduleOnDay(task, day)) continue;
@@ -1155,23 +842,15 @@ async function upsertChoreBlocksForTask(db, task, lookaheadDays = 28) {
 
     if (startMs == null) {
       const slot = findSlotInWindows(dayCtx.windows, occupiedWithoutSelf, durationMs);
-      if (slot != null) {
-        startMs = slot;
-        endMs = slot + durationMs;
-      }
-    }
-
-    if (startMs == null) {
-      const fallback = await findSlotFromDay(day, docId, taskDueMs && dueHasTime ? applyTimeOfDay(day, taskDueMs) : null);
-      if (!fallback) {
+      if (!slot) {
         if (snap.exists) {
           await ref.delete();
           dayCtx.occupied = occupiedWithoutSelf;
         }
         continue;
       }
-      startMs = fallback.startMs;
-      endMs = fallback.endMs;
+      startMs = slot;
+      endMs = slot + durationMs;
     }
 
     if (startMs >= nowMs && (nextStartMs == null || startMs < nextStartMs)) {
@@ -1218,23 +897,16 @@ async function upsertChoreBlocksForTask(db, task, lookaheadDays = 28) {
 
   if (nextStartMs && isRecurringChoreTask(task) && !isTaskLocked(task)) {
     const dueMs = toMillis(task?.dueDate || task?.dueDateMs || task?.targetDate);
-    const nextDueTime = formatDueTime(nextStartMs);
-    const nextTimeOfDay = classifyTimeOfDay(nextStartMs);
-    const currentDueTime = String(task?.dueTime || '').trim();
-    const currentTimeOfDay = String(task?.timeOfDay || '').trim().toLowerCase();
     const isMissing = !dueMs;
     const isOverdueBeyondGrace = !!dueMs && dueMs < (nowMs - CHORE_DUE_ROLLOVER_MS);
     const isFutureMismatch = !!dueMs && dueMs >= nowMs && Math.abs(dueMs - nextStartMs) > (5 * MS_IN_MINUTE);
-    const isTimeMismatch = currentDueTime !== nextDueTime || currentTimeOfDay !== nextTimeOfDay;
-    if (isMissing || isOverdueBeyondGrace || isFutureMismatch || isTimeMismatch) {
+    if (isMissing || isOverdueBeyondGrace || isFutureMismatch) {
       const hasStory = !!(task?.storyId || (task?.parentType === 'story' && task?.parentId));
       const sprintId = hasStory
         ? (task?.sprintId || null)
         : await resolveSprintIdForDate(db, ownerUid, task?.persona || null, nextStartMs, sprintCache);
       await db.collection('tasks').doc(task.id).set({
         dueDate: nextStartMs,
-        dueTime: nextDueTime,
-        timeOfDay: nextTimeOfDay,
         sprintId: sprintId ?? null,
         dueDateReason: isOverdueBeyondGrace ? 'chore_rollover' : 'chore_block',
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -2984,7 +2656,6 @@ exports.priorityNow = httpsV2.onRequest({ invoker: 'public', secrets: [GOOGLE_AI
       await recordAiLog(uid, 'priority_now_trace', 'success', 'Priority now response generated', {
         ...priorityTraceBase,
         parseStatus: llmText ? 'ok' : 'ok_empty',
-        rawOutput: String(llmText || '').slice(0, 12000),
         rawOutputText: String(llmText || '').slice(0, 12000),
         rawOutputLength: String(llmText || '').length,
         latencyMs: Date.now() - priorityStartedAtMs,
@@ -2996,7 +2667,6 @@ exports.priorityNow = httpsV2.onRequest({ invoker: 'public', secrets: [GOOGLE_AI
       await recordAiLog(uid, 'priority_now_trace', 'warning', 'Priority now LLM parse/runtime failure', {
         ...priorityTraceBase,
         parseStatus: 'failed',
-        rawOutput: String(llmText || '').slice(0, 12000),
         rawOutputText: String(llmText || '').slice(0, 12000),
         rawOutputLength: String(llmText || '').length,
         error: String(error?.message || error || 'unknown'),
@@ -11024,7 +10694,7 @@ exports.suggestTaskStoryConversions = httpsV2.onCall({ secrets: [GOOGLE_AI_STUDI
   };
 });
 
-exports.monzoGoalPotRefLinker = schedulerV2.onSchedule('every 12 hours', async () => {
+exports.monzoGoalPotRefLinker = schedulerV2.onSchedule('every 30 minutes', async () => {
   const db = admin.firestore();
   const tokens = await db.collection('tokens').where('provider', '==', 'monzo').get();
   let usersChecked = 0;
@@ -11069,134 +10739,6 @@ exports.monzoGoalPotRefLinker = schedulerV2.onSchedule('every 12 hours', async (
     totalLinked,
     totalTimedOut,
     totalPending,
-  };
-});
-
-function normalizeSprintFocusGoalIds(value) {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((goalId) => String(goalId || '').trim())
-    .filter((goalId) => !!goalId);
-}
-
-function normalizeAlignmentMode(value) {
-  const normalized = String(value || 'warn').trim().toLowerCase();
-  return normalized === 'strict' ? 'strict' : 'warn';
-}
-
-exports.enforceSprintFocusAlignment = firestoreV2.onDocumentWritten('stories/{storyId}', async (event) => {
-  const afterSnap = event.data?.after;
-  if (!afterSnap?.exists) return;
-
-  const storyId = String(event.params?.storyId || '').trim();
-  const story = afterSnap.data() || {};
-  const sprintId = String(story.sprintId || '').trim();
-  if (!sprintId) return;
-
-  const ownerUid = String(story.ownerUid || '').trim();
-  if (!ownerUid) return;
-
-  const db = admin.firestore();
-  const sprintSnap = await db.collection('sprints').doc(sprintId).get();
-  if (!sprintSnap.exists) return;
-
-  const sprint = sprintSnap.data() || {};
-  const mode = normalizeAlignmentMode(sprint.alignmentMode);
-  if (mode !== 'strict') return;
-
-  const focusGoalIds = normalizeSprintFocusGoalIds(sprint.focusGoalIds);
-  if (!focusGoalIds.length) return;
-
-  const goalId = String(story.goalId || '').trim();
-  const aligned = !!goalId && focusGoalIds.includes(goalId);
-  if (aligned) return;
-
-  await afterSnap.ref.set({
-    sprintId: null,
-    sprintAlignmentViolation: {
-      sprintId,
-      alignmentMode: 'strict',
-      reason: 'goal_not_in_sprint_focus_goals',
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    },
-    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-  }, { merge: true });
-
-  await db.collection('integration_logs').add({
-    integration: 'sprint_alignment',
-    type: 'strict_enforcement',
-    status: 'blocked',
-    userId: ownerUid,
-    storyId,
-    sprintId,
-    goalId: goalId || null,
-    reason: 'goal_not_in_sprint_focus_goals',
-    timestamp: admin.firestore.FieldValue.serverTimestamp(),
-  });
-});
-
-exports.sprintAlignmentAuditNightly = schedulerV2.onSchedule('every day 03:10', async () => {
-  const db = admin.firestore();
-  const activeSprintSnap = await db.collection('sprints').where('status', '==', 1).get();
-  let sprintsChecked = 0;
-  let sprintsWithRules = 0;
-  let totalUnaligned = 0;
-
-  for (const sprintDoc of activeSprintSnap.docs) {
-    const sprint = sprintDoc.data() || {};
-    const focusGoalIds = normalizeSprintFocusGoalIds(sprint.focusGoalIds);
-    if (!focusGoalIds.length) continue;
-
-    sprintsChecked += 1;
-    sprintsWithRules += 1;
-    const focusGoalSet = new Set(focusGoalIds);
-    const ownerUid = String(sprint.ownerUid || '').trim();
-    const persona = String(sprint.persona || 'personal');
-
-    if (!ownerUid) continue;
-
-    const storiesSnap = await db.collection('stories')
-      .where('ownerUid', '==', ownerUid)
-      .where('persona', '==', persona)
-      .where('sprintId', '==', sprintDoc.id)
-      .get();
-
-    const totalStories = storiesSnap.size;
-    const unalignedStories = storiesSnap.docs.filter((docSnap) => {
-      const row = docSnap.data() || {};
-      const goalId = String(row.goalId || '').trim();
-      return !goalId || !focusGoalSet.has(goalId);
-    }).length;
-    totalUnaligned += unalignedStories;
-
-    await db.collection('sprint_alignment_audit').doc(`${ownerUid}_${sprintDoc.id}`).set({
-      ownerUid,
-      sprintId: sprintDoc.id,
-      sprintName: sprint.name || sprint.ref || sprintDoc.id,
-      persona,
-      alignmentMode: normalizeAlignmentMode(sprint.alignmentMode),
-      focusGoalIds,
-      totalStories,
-      unalignedStories,
-      alignedStories: Math.max(totalStories - unalignedStories, 0),
-      alignmentPct: totalStories > 0
-        ? Math.max(0, Math.round(((totalStories - unalignedStories) / totalStories) * 100))
-        : 100,
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    }, { merge: true });
-  }
-
-  console.log('[sprintAlignmentAuditNightly] complete', {
-    sprintsChecked,
-    sprintsWithRules,
-    totalUnaligned,
-  });
-
-  return {
-    ok: true,
-    sprintsChecked,
-    sprintsWithRules,
-    totalUnaligned,
   };
 });
 
@@ -12146,20 +11688,6 @@ async function buildDailySummaryAiFocus({ summaryData, userId }) {
         timezone: zone,
         activeWorkContext: context,
         calendarContext,
-        healthContext: {
-          source: ['authorized', 'synced'].includes(String(summaryData?.profile?.healthkitStatus || '').toLowerCase()) ? 'healthkit' : 'manual',
-          stepsToday: Number(summaryData?.profile?.healthkitStepsToday ?? summaryData?.profile?.manualStepsToday ?? 0) || null,
-          workoutMinutesToday: Number(summaryData?.profile?.healthkitWorkoutMinutesToday ?? summaryData?.profile?.manualWorkoutMinutesToday ?? 0) || null,
-          bodyFatPct: Number(summaryData?.profile?.healthkitBodyFatPct ?? summaryData?.profile?.manualBodyFatPct ?? 0) || null,
-          macroTargetsPresent: !!(
-            summaryData?.profile?.targetProteinG
-            || summaryData?.profile?.dailyProteinTargetG
-            || summaryData?.profile?.healthTargetProteinG
-            || summaryData?.profile?.targetCaloriesKcal
-            || summaryData?.profile?.dailyCaloriesTargetKcal
-            || summaryData?.profile?.healthTargetCaloriesKcal
-          ),
-        },
       },
     };
 
@@ -12180,7 +11708,6 @@ async function buildDailySummaryAiFocus({ summaryData, userId }) {
       await recordAiLog(userId, 'daily_summary_focus_trace', 'warning', 'Daily summary focus parse failure', {
         ...llmTraceBase,
         parseStatus: 'failed',
-        rawOutput: String(raw || '').slice(0, 12000),
         rawOutputText: String(raw || '').slice(0, 12000),
         rawOutputLength: String(raw || '').length,
         parseError: String(error?.message || error || 'unknown'),
@@ -12250,7 +11777,6 @@ async function buildDailySummaryAiFocus({ summaryData, userId }) {
       await recordAiLog(userId, 'daily_summary_focus_trace', 'warning', 'Daily summary focus returned no actionable items', {
         ...llmTraceBase,
         parseStatus: 'ok_empty',
-        rawOutput: String(raw || '').slice(0, 12000),
         rawOutputText: String(raw || '').slice(0, 12000),
         rawOutputLength: String(raw || '').length,
         latencyMs: Date.now() - startedAtMs,
@@ -12273,7 +11799,6 @@ async function buildDailySummaryAiFocus({ summaryData, userId }) {
     await recordAiLog(userId, 'daily_summary_focus_trace', 'success', 'Daily summary focus generated', {
       ...llmTraceBase,
       parseStatus: 'ok',
-      rawOutput: String(raw || '').slice(0, 12000),
       rawOutputText: String(raw || '').slice(0, 12000),
       rawOutputLength: String(raw || '').length,
       resultItemCount: result.items.length,
@@ -12573,13 +12098,13 @@ function assembleDailyChecklist(summaryData) {
       await ref.set(patch, { merge: true });
     }
 
-    // Materialize chore/routine calendar blocks for next 28 days (active only)
+    // Materialize chore/routine calendar blocks for next 14 days (active only)
     const type = effectiveType;
     const effectiveStatus = Number(patch?.status ?? afterStatus);
     const active = Number(effectiveStatus) !== 2;
     if (isChoreLike && active) {
       const task = { id, ...(after || {}), ...(patch || {}) };
-      await upsertChoreBlocksForTask(db, task, 28);
+      await upsertChoreBlocksForTask(db, task, 14);
     }
 
     // If just completed, mark nearest block done and update lastDoneAt
@@ -12707,7 +12232,7 @@ function assembleDailyChecklist(summaryData) {
       const snap = await db.collection('tasks').where('type', '==', t).where('status', '==', 0).get();
       for (const doc of snap.docs) {
         scanned++;
-        const res = await upsertChoreBlocksForTask(db, { id: doc.id, ...(doc.data() || {}) }, 28);
+        const res = await upsertChoreBlocksForTask(db, { id: doc.id, ...(doc.data() || {}) }, 14);
         created += res.created; updated += res.updated;
       }
     }
@@ -17387,15 +16912,6 @@ exports.onStoryDueDateAutoSprint = functionsV2.firestore.onDocumentUpdated("stor
   if (!ownerUid) return;
   const persona = afterData.persona || beforeData.persona || null;
   const db = admin.firestore();
-  const profileSnap = await db.collection('profiles').doc(ownerUid).get().catch(() => null);
-  const profile = profileSnap && profileSnap.exists ? (profileSnap.data() || {}) : {};
-  // Safety guard: due-date based sprint mapping is opt-in only.
-  if (profile.autoMapStorySprintFromDueDate !== true) return;
-
-  // Never overwrite an existing sprint from due-date churn.
-  const currentSprintId = afterData.sprintId || null;
-  if (currentSprintId && afterDue) return;
-
   const sprintId = afterDue
     ? await resolveSprintIdForDate(db, ownerUid, persona, afterDue, new Map())
     : null;
@@ -18163,30 +17679,10 @@ async function recordAiLog(uid, event, status, message, metadata = {}) {
     const level = status === 'error' ? 'error' : (status === 'warning' ? 'warning' : 'info');
     const expiresAt = createExpiryTimestamp();
     const now = admin.firestore.FieldValue.serverTimestamp();
-    const randomSuffix = Math.random().toString(36).slice(2, 8);
-    const traceIdRaw = metadata.traceId || metadata.trace_id || metadata.correlationId || metadata.correlation_id;
-    const traceId = String(traceIdRaw || `${String(event || 'ai_event')}_${Date.now()}_${randomSuffix}`).trim();
-    const promptTemplateId = String(metadata.promptTemplateId || metadata.templateId || metadata.template || '').trim() || null;
-    const parseStatus = String(metadata.parseStatus || (status === 'error' ? 'runtime_error' : 'ok')).trim().toLowerCase() || null;
-    const latencyRaw = Number(metadata.latencyMs ?? metadata.durationMs ?? metadata.latency ?? NaN);
-    const latencyMs = Number.isFinite(latencyRaw) && latencyRaw >= 0 ? Math.round(latencyRaw) : null;
-    const tokenRaw = Number(metadata.tokenCount ?? metadata.tokens ?? metadata.totalTokens ?? NaN);
-    const tokenCount = Number.isFinite(tokenRaw) && tokenRaw >= 0 ? Math.round(tokenRaw) : null;
-    const promptText = metadata.promptText || metadata.prompt || null;
-    const inputPayload = metadata.inputPayload || metadata.input || null;
-    const rawOutput = metadata.rawOutput || metadata.output || null;
     await ref.set({
       id: ref.id,
       ownerUid: uid,
       event,
-      traceId,
-      promptTemplateId,
-      parseStatus,
-      latencyMs,
-      tokenCount,
-      prompt: promptText,
-      input: inputPayload,
-      output: rawOutput,
       status,
       level,
       message,
@@ -19825,7 +19321,6 @@ async function buildFinanceCommentary({ summary, userId, windowLabel }) {
       await recordAiLog(userId, 'finance_commentary_trace', 'warning', 'Finance commentary returned empty output', {
         ...llmTraceBase,
         parseStatus: 'ok_empty',
-        rawOutput: '',
         rawOutputText: '',
         rawOutputLength: 0,
         latencyMs: Date.now() - startedAtMs,
@@ -19837,7 +19332,6 @@ async function buildFinanceCommentary({ summary, userId, windowLabel }) {
     await recordAiLog(userId, 'finance_commentary_trace', 'success', 'Finance commentary generated', {
       ...llmTraceBase,
       parseStatus: 'ok',
-      rawOutput: String(text).slice(0, 12000),
       rawOutputText: String(text).slice(0, 12000),
       rawOutputLength: String(text).length,
       outputLength: normalised.length,

--- a/functions/lib/reporting.js
+++ b/functions/lib/reporting.js
@@ -134,86 +134,6 @@ const resolveTimezone = (profile, fallback) => {
   );
 };
 
-const readFiniteNumber = (...values) => {
-  for (const value of values) {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return null;
-};
-
-const clampPercent = (value) => {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) return null;
-  return Math.max(0, Math.min(100, Math.round(parsed)));
-};
-
-const buildHealthDashboardAlert = (profile = {}) => {
-  const stepsToday = readFiniteNumber(profile.healthkitStepsToday, profile.manualStepsToday);
-  const workoutMinutesToday = readFiniteNumber(profile.healthkitWorkoutMinutesToday, profile.manualWorkoutMinutesToday);
-  const proteinTodayG = readFiniteNumber(profile.healthkitProteinTodayG, profile.manualProteinTodayG);
-  const fatTodayG = readFiniteNumber(profile.healthkitFatTodayG, profile.manualFatTodayG);
-  const carbsTodayG = readFiniteNumber(profile.healthkitCarbsTodayG, profile.manualCarbsTodayG);
-  const caloriesTodayKcal = readFiniteNumber(profile.healthkitCaloriesTodayKcal, profile.manualCaloriesTodayKcal);
-  const bodyFatPct = readFiniteNumber(profile.healthkitBodyFatPct, profile.manualBodyFatPct);
-  const targetBodyFatPct = readFiniteNumber(profile.targetBodyFatPct, profile.healthTargetBodyFatPct, profile.bodyFatTarget);
-  const targetProteinG = readFiniteNumber(profile.targetProteinG, profile.dailyProteinTargetG, profile.healthTargetProteinG);
-  const targetFatG = readFiniteNumber(profile.targetFatG, profile.dailyFatTargetG, profile.healthTargetFatG);
-  const targetCarbsG = readFiniteNumber(profile.targetCarbsG, profile.dailyCarbsTargetG, profile.healthTargetCarbsG);
-  const targetCaloriesKcal = readFiniteNumber(profile.targetCaloriesKcal, profile.dailyCaloriesTargetKcal, profile.healthTargetCaloriesKcal);
-
-  const hasAnySignal = [stepsToday, workoutMinutesToday, proteinTodayG, fatTodayG, carbsTodayG, caloriesTodayKcal, bodyFatPct]
-    .some((value) => value != null);
-  if (!hasAnySignal) return null;
-
-  const adherencePct = (actual, target) => {
-    if (actual == null || target == null || target <= 0) return null;
-    return clampPercent((actual / target) * 100);
-  };
-
-  const macroComponents = [
-    adherencePct(proteinTodayG, targetProteinG),
-    adherencePct(fatTodayG, targetFatG),
-    adherencePct(carbsTodayG, targetCarbsG),
-    adherencePct(caloriesTodayKcal, targetCaloriesKcal),
-  ].filter((value) => value != null);
-
-  const macroAdherencePct = macroComponents.length
-    ? Math.round(macroComponents.reduce((sum, value) => sum + value, 0) / macroComponents.length)
-    : null;
-
-  const bodyFatDelta = (bodyFatPct != null && targetBodyFatPct != null)
-    ? Number((bodyFatPct - targetBodyFatPct).toFixed(1))
-    : null;
-
-  let severity = 'info';
-  if ((macroAdherencePct != null && macroAdherencePct < 60) || (bodyFatDelta != null && bodyFatDelta >= 3)) {
-    severity = 'critical';
-  } else if ((macroAdherencePct != null && macroAdherencePct < 80) || (bodyFatDelta != null && bodyFatDelta > 0) || (stepsToday != null && stepsToday < 6000)) {
-    severity = 'warning';
-  }
-
-  const summaryBits = [];
-  if (bodyFatPct != null) {
-    summaryBits.push(
-      targetBodyFatPct != null
-        ? `Body fat ${bodyFatPct.toFixed(1)}% (target ${targetBodyFatPct.toFixed(1)}%)`
-        : `Body fat ${bodyFatPct.toFixed(1)}%`
-    );
-  }
-  if (stepsToday != null) summaryBits.push(`${Math.round(stepsToday).toLocaleString('en-GB')} steps`);
-  if (workoutMinutesToday != null) summaryBits.push(`${Math.round(workoutMinutesToday)}m workout`);
-  if (macroAdherencePct != null) summaryBits.push(`${macroAdherencePct}% macro adherence`);
-
-  return {
-    type: 'health',
-    severity,
-    title: 'Health snapshot today',
-    message: summaryBits.join(' | ') || 'Health data updated for today.',
-    ctaPath: buildAbsoluteUrl('/fitness'),
-  };
-};
-
 const toList = (snap) => snap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
 
 const computeNextOccurrenceInWindow = (recurrence, dtstart, windowStart, windowEnd) => {
@@ -1447,11 +1367,6 @@ const buildDailySummaryData = async (db, userId, { day, timezone, locale = 'en-G
       ctaPath: buildAbsoluteUrl('/focus-goals'),
     });
   });
-
-  const healthAlert = buildHealthDashboardAlert(profile);
-  if (healthAlert) {
-    dashboardAlerts.push(healthAlert);
-  }
 
   const savingsRunway = (() => {
     const alignmentGoals = Array.isArray(monzo?.goalAlignment?.goals)

--- a/functions/nightlyOrchestration.js
+++ b/functions/nightlyOrchestration.js
@@ -25,6 +25,15 @@ const {
   groupTasksByStory,
   writeScheduledTimesToSources,
 } = require('./scheduler/syncToFirestore');
+const {
+  buildDayLoadPointsMap,
+  nextWeekendDateByCapacity,
+  inferItemPoints,
+  deriveSprintCapacityPoints,
+} = require('./services/capacityService');
+const {
+  schedulePlannerItemMutation,
+} = require('./services/schedulingService');
 
 // Secrets
 const GOOGLE_AI_STUDIO_API_KEY = defineSecret('GOOGLEAISTUDIOAPIKEY');
@@ -572,6 +581,12 @@ function normalizeUserPriority(value) {
   return null;
 }
 
+function getManualPriorityRank(value) {
+  const explicit = Number(value?.userPriorityRank);
+  if (explicit === 1 || explicit === 2 || explicit === 3) return explicit;
+  return value?.userPriorityFlag === true ? 1 : null;
+}
+
 function priorityBoostFor(level) {
   switch (level) {
     case 'critical':
@@ -850,7 +865,7 @@ async function collectStoryTop3CandidateDocs(db, ownerUid, pageSize = 400) {
 
 function storyForcesTop3Tasks(storyData) {
   if (!storyData) return false;
-  if (storyData.userPriorityFlag === true) return true;
+  if (getManualPriorityRank(storyData)) return true;
   const level = normalizeUserPriority(storyData.userPriority || storyData.priority || storyData.priorityLabel);
   return level === 'critical';
 }
@@ -872,8 +887,18 @@ function selectTopStoriesFresh(items) {
     selectedIds.add(entry.id);
   };
 
-  const manualStories = sorted.filter((story) => story?.data?.userPriorityFlag === true);
-  if (manualStories.length) pick(manualStories[0]);
+  const manualStories = sorted
+    .filter((story) => getManualPriorityRank(story?.data))
+    .sort((a, b) => {
+      const ar = getManualPriorityRank(a?.data) || 99;
+      const br = getManualPriorityRank(b?.data) || 99;
+      if (ar !== br) return ar - br;
+      return scoreCreatedSort(a, b);
+    });
+  manualStories.forEach((story) => {
+    if (selected.length >= 3) return;
+    pick(story);
+  });
 
   const criticalStories = sorted.filter((story) => storyForcesTop3Tasks(story?.data));
   for (const story of criticalStories) {
@@ -901,11 +926,18 @@ function selectTopTasksFresh(items, storyMap = new Map()) {
     selectedIds.add(entry.id);
   };
 
-  const manualTasks = sorted.filter((task) => task?.data?.userPriorityFlag === true);
-  if (manualTasks.length) {
-    // Explicit user #1 flag always owns rank 1.
-    pick(manualTasks[0]);
-  }
+  const manualTasks = sorted
+    .filter((task) => getManualPriorityRank(task?.data))
+    .sort((a, b) => {
+      const ar = getManualPriorityRank(a?.data) || 99;
+      const br = getManualPriorityRank(b?.data) || 99;
+      if (ar !== br) return ar - br;
+      return scoreCreatedSort(a, b);
+    });
+  manualTasks.forEach((task) => {
+    if (selected.length >= 3) return;
+    pick(task);
+  });
 
   const storyDrivenTasks = sorted.filter((task) => {
     const storyId = task?.data?.storyId;
@@ -1011,40 +1043,8 @@ function nextOccurrenceForRecurring(entity, nowLocal) {
   return base.plus({ days: interval }).endOf('day').toMillis();
 }
 
-function nextWeekendDateByCapacity(nowLocal, dayLoadHours = new Map(), maxHours = 6) {
-  const base = (nowLocal || DateTime.now()).startOf('day');
-  let fallback = null;
-  for (let offset = 1; offset <= 56; offset += 1) {
-    const candidate = base.plus({ days: offset });
-    if (![6, 7].includes(candidate.weekday)) continue;
-    if (!fallback) fallback = candidate;
-    const key = candidate.toISODate();
-    const load = Number(dayLoadHours.get(key) || 0);
-    if (load < maxHours) {
-      return candidate.endOf('day').toMillis();
-    }
-  }
-  return (fallback || base.plus({ days: 6 })).endOf('day').toMillis();
-}
-
 async function buildDayLoadHoursMap(db, userId, startMs, endMs) {
-  const map = new Map();
-  const snap = await db.collection('calendar_blocks')
-    .where('ownerUid', '==', userId)
-    .where('start', '>=', startMs)
-    .where('start', '<=', endMs)
-    .get()
-    .catch(() => ({ docs: [] }));
-  for (const doc of (snap.docs || [])) {
-    const data = doc.data() || {};
-    const start = Number(data.start || 0);
-    const end = Number(data.end || 0);
-    if (!(start > 0) || !(end > start)) continue;
-    const key = DateTime.fromMillis(start).toISODate();
-    const hours = Math.max(0.25, (end - start) / (60 * 60 * 1000));
-    map.set(key, (map.get(key) || 0) + hours);
-  }
-  return map;
+  return buildDayLoadPointsMap(db, userId, startMs, endMs);
 }
 
 function entityIsCritical({
@@ -1056,7 +1056,7 @@ function entityIsCritical({
 }) {
   if (!entity) return false;
   if (isTop) return true;
-  if (entity.userPriorityFlag === true) return true;
+  if (getManualPriorityRank(entity)) return true;
   const level = normalizeUserPriority(entity.userPriority || entity.priority || entity.priorityLabel);
   if (level === 'critical') return true;
   const score = Number(entity.aiCriticalityScore || 0);
@@ -1064,7 +1064,7 @@ function entityIsCritical({
   const goalId = String(entity.goalId || '').trim();
   if (goalId && focusGoalIds?.has(goalId)) return true;
   if (entityType === 'task' && parentStory) {
-    if (parentStory.userPriorityFlag === true) return true;
+    if (getManualPriorityRank(parentStory)) return true;
     const parentLevel = normalizeUserPriority(parentStory.userPriority || parentStory.priority || parentStory.priorityLabel);
     if (parentLevel === 'critical') return true;
     const parentScore = Number(parentStory.aiCriticalityScore || 0);
@@ -1321,6 +1321,10 @@ async function applyAggressiveDueDateReplanForUser({
  * No max cap — the scheduler fills available slots up to this total.
  */
 function estimateRequiredMinutes(candidate, kind) {
+  const pointsRemaining = Number(candidate?.pointsRemaining);
+  if (Number.isFinite(pointsRemaining) && pointsRemaining > 0) {
+    return Math.max(kind === 'task' ? 30 : 60, Math.round(pointsRemaining * 60));
+  }
   const points = Number(candidate?.points) || 0;
   const rawProgress = candidate?.progressPct ?? candidate?.progress ?? candidate?.completionPct ?? 0;
   const progressPct = Math.min(100, Math.max(0, Number(rawProgress || 0)));
@@ -1365,9 +1369,9 @@ function sortPlannerCandidates(items, {
   extraPriorityFn,
 }) {
   return [...(items || [])].sort((a, b) => {
-    const aManual = a?.userPriorityFlag === true ? 1 : 0;
-    const bManual = b?.userPriorityFlag === true ? 1 : 0;
-    if (aManual !== bManual) return bManual - aManual;
+    const aManual = getManualPriorityRank(a);
+    const bManual = getManualPriorityRank(b);
+    if ((aManual || 99) !== (bManual || 99)) return (aManual || 99) - (bManual || 99);
 
     const aExtra = extraPriorityFn?.(a) ? 1 : 0;
     const bExtra = extraPriorityFn?.(b) ? 1 : 0;
@@ -1412,7 +1416,7 @@ function buildUnifiedPlacementQueue({
     ...stories.map((story) => ({
       kind: 'story',
       candidate: story,
-      manual: story?.userPriorityFlag === true ? 1 : 0,
+      manual: getManualPriorityRank(story) || 99,
       extra: storyForcesTop3Tasks(story) ? 1 : 0,
       top: isTopStory?.(story) ? 1 : 0,
       rank: Number(story?.aiFocusStoryRank || 0) || 99,
@@ -1426,7 +1430,7 @@ function buildUnifiedPlacementQueue({
       return {
         kind: 'task',
         candidate: task,
-        manual: task?.userPriorityFlag === true ? 1 : 0,
+        manual: getManualPriorityRank(task) || 99,
         extra: storyForcesTop3Tasks(parentStory) ? 1 : 0,
         top: isTopTask?.(task) ? 1 : 0,
         rank: Number(task?.aiPriorityRank || 0) || 99,
@@ -1439,7 +1443,7 @@ function buildUnifiedPlacementQueue({
   ];
 
   rows.sort((a, b) => {
-    if (a.manual !== b.manual) return b.manual - a.manual;
+    if (a.manual !== b.manual) return a.manual - b.manual;
     if (a.extra !== b.extra) return b.extra - a.extra;
     if (a.top !== b.top) return b.top - a.top;
     if (a.rank !== b.rank) return a.rank - b.rank;
@@ -1517,6 +1521,269 @@ function buildPlannerCoverageSummary({ stories, tasks, scheduledMinutesByEntity 
     shortfallMinutes: storyShortfallMinutes + taskShortfallMinutes,
     unscheduledStories,
     unscheduledTasks,
+  };
+}
+
+function plannerWeekStart(dt) {
+  return dt.startOf('week').startOf('day');
+}
+
+function buildSprintWeekBuckets({
+  sprintMap,
+  windowStart,
+  windowEnd,
+  defaultWeeklyCapacityPoints = 20,
+}) {
+  const bucketsBySprintId = new Map();
+  const fallbackBuckets = [];
+
+  const createBuckets = ({ sprintId = null, sprintMeta = null, startMs, endMs }) => {
+    const start = DateTime.fromMillis(startMs, { zone: windowStart.zoneName }).startOf('day');
+    const end = DateTime.fromMillis(endMs, { zone: windowStart.zoneName }).endOf('day');
+    if (end < start) return [];
+    const weekStarts = [];
+    let cursor = plannerWeekStart(start);
+    while (cursor.toMillis() <= end.toMillis()) {
+      const bucketEnd = cursor.plus({ days: 6 }).endOf('day');
+      const effectiveStartMs = Math.max(cursor.toMillis(), start.toMillis());
+      const effectiveEndMs = Math.min(bucketEnd.toMillis(), end.toMillis());
+      if (effectiveEndMs >= effectiveStartMs) {
+        weekStarts.push({
+          sprintId,
+          weekKey: cursor.toISODate(),
+          startMs: effectiveStartMs,
+          endMs: effectiveEndMs,
+          plannedPoints: 0,
+          capacityPoints: 0,
+        });
+      }
+      cursor = cursor.plus({ weeks: 1 });
+    }
+    const sprintCapacityPoints = deriveSprintCapacityPoints(sprintMeta || {}, defaultWeeklyCapacityPoints);
+    const perWeekCapacity = weekStarts.length > 0
+      ? sprintCapacityPoints / weekStarts.length
+      : defaultWeeklyCapacityPoints;
+    weekStarts.forEach((bucket) => {
+      bucket.capacityPoints = perWeekCapacity;
+    });
+    return weekStarts;
+  };
+
+  for (const [sprintId, sprintMeta] of sprintMap.entries()) {
+    const sprintStart = toMillis(sprintMeta?.start);
+    const sprintEnd = toMillis(sprintMeta?.end);
+    if (!Number.isFinite(sprintStart) || !Number.isFinite(sprintEnd)) continue;
+    const boundedStartMs = Math.max(sprintStart, windowStart.toMillis());
+    const boundedEndMs = Math.min(sprintEnd, windowEnd.toMillis());
+    if (boundedEndMs < boundedStartMs) continue;
+    bucketsBySprintId.set(sprintId, createBuckets({
+      sprintId,
+      sprintMeta,
+      startMs: boundedStartMs,
+      endMs: boundedEndMs,
+    }));
+  }
+
+  fallbackBuckets.push(...createBuckets({
+    sprintId: null,
+    sprintMeta: null,
+    startMs: windowStart.toMillis(),
+    endMs: windowEnd.toMillis(),
+  }));
+
+  return { bucketsBySprintId, fallbackBuckets };
+}
+
+function seedWeekBucketLoads({
+  bucketsBySprintId,
+  fallbackBuckets,
+  existingBlocks,
+}) {
+  const addLoadToBuckets = (buckets, startMs, points) => {
+    if (!Array.isArray(buckets) || !buckets.length) return false;
+    const bucket = buckets.find((entry) => startMs >= entry.startMs && startMs <= entry.endMs);
+    if (!bucket) return false;
+    bucket.plannedPoints += points;
+    return true;
+  };
+
+  (existingBlocks || []).forEach((block) => {
+    if (!(block?.storyId || block?.taskId)) return;
+    const startMs = toMillis(block.start);
+    const endMs = toMillis(block.end);
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return;
+    const points = Math.max(0.25, (endMs - startMs) / (60 * 60 * 1000));
+    const sprintId = String(block.sprintId || '').trim() || null;
+    if (sprintId && addLoadToBuckets(bucketsBySprintId.get(sprintId) || [], startMs, points)) return;
+    addLoadToBuckets(fallbackBuckets, startMs, points);
+  });
+}
+
+function chooseSprintWeekBucket({
+  candidate,
+  kind,
+  isTop,
+  parentStory,
+  storyWeekById,
+  sprintMap,
+  bucketsBySprintId,
+  fallbackBuckets,
+  windowStart,
+}) {
+  const candidateSprintId = String(candidate?.sprintId || parentStory?.sprintId || '').trim() || null;
+  const buckets = (candidateSprintId && bucketsBySprintId.get(candidateSprintId)?.length)
+    ? bucketsBySprintId.get(candidateSprintId)
+    : fallbackBuckets;
+  if (!Array.isArray(buckets) || buckets.length === 0) return null;
+
+  if (kind === 'task' && candidate?.storyId && storyWeekById.has(candidate.storyId)) {
+    const parentWeekKey = storyWeekById.get(candidate.storyId);
+    const sameWeek = buckets.find((bucket) => bucket.weekKey === parentWeekKey);
+    if (sameWeek) return sameWeek;
+  }
+
+  const candidatePoints = inferItemPoints(kind, candidate);
+  const dueMs = getDueDateMs(candidate);
+  const currentWeekKey = plannerWeekStart(windowStart).toISODate();
+  const currentWeekBucket = buckets.find((bucket) => bucket.weekKey === currentWeekKey) || buckets[0];
+
+  if (isTop && currentWeekBucket) {
+    currentWeekBucket.plannedPoints += candidatePoints;
+    return currentWeekBucket;
+  }
+
+  let preferredBucket = null;
+  if (Number.isFinite(dueMs)) {
+    preferredBucket = buckets.find((bucket) => dueMs >= bucket.startMs && dueMs <= bucket.endMs) || null;
+  }
+  const ordered = preferredBucket
+    ? [preferredBucket, ...buckets.filter((bucket) => bucket !== preferredBucket)]
+    : buckets;
+
+  const fitting = ordered.find((bucket) => (bucket.capacityPoints - bucket.plannedPoints) >= candidatePoints);
+  const chosen = fitting || ordered
+    .slice()
+    .sort((a, b) => {
+      const overA = a.plannedPoints - a.capacityPoints;
+      const overB = b.plannedPoints - b.capacityPoints;
+      if (overA !== overB) return overA - overB;
+      return a.startMs - b.startMs;
+    })[0];
+  if (!chosen) return null;
+  chosen.plannedPoints += candidatePoints;
+  return chosen;
+}
+
+async function schedulePlacementQueueWithCanonicalScheduler({
+  db,
+  userId,
+  placementQueue,
+  storyMap,
+  sprintMap,
+  existingBlocks,
+  windowStart,
+  windowEnd,
+  planningMode = 'smart',
+  source = 'nightly_calendar_planner',
+}) {
+  const scheduledMinutesByEntity = collectScheduledMinutesByEntity(existingBlocks);
+  const manuallyScheduledEntityKeys = new Set(
+    (existingBlocks || [])
+      .filter((block) => {
+        const isAi = block.aiGenerated === true || block.isAiGenerated === true || block.createdBy === 'ai';
+        return !isAi && (block.storyId || block.taskId);
+      })
+      .map((block) => (block.storyId ? getEntityKey('story', block.storyId) : getEntityKey('task', block.taskId)))
+      .filter(Boolean),
+  );
+
+  const { bucketsBySprintId, fallbackBuckets } = buildSprintWeekBuckets({
+    sprintMap,
+    windowStart,
+    windowEnd,
+  });
+  seedWeekBucketLoads({ bucketsBySprintId, fallbackBuckets, existingBlocks });
+
+  const storyWeekById = new Map();
+  let created = 0;
+  let blocked = 0;
+
+  for (const entry of placementQueue) {
+    const { kind, candidate } = entry;
+    const entityKey = getEntityKey(kind, candidate?.id);
+    if (!entityKey || manuallyScheduledEntityKeys.has(entityKey)) continue;
+
+    const totalNeededMs = estimateRequiredMinutes(candidate, kind) * 60000;
+    const alreadyMs = (scheduledMinutesByEntity.get(entityKey) || 0) * 60000;
+    if (alreadyMs >= totalNeededMs) continue;
+
+    const rawScore = Number(candidate?.aiCriticalityScore || 0);
+    const isCriticalPriority = Number(candidate?.priority || 0) >= 4;
+    const isTop = candidate?.aiTop3ForDay === true;
+    if (rawScore > 0 && rawScore < 40 && !isCriticalPriority && !isTop) {
+      continue;
+    }
+
+    const parentStory = kind === 'task' && candidate?.storyId ? storyMap.get(candidate.storyId) : null;
+    const bucket = chooseSprintWeekBucket({
+      candidate,
+      kind,
+      isTop,
+      parentStory,
+      storyWeekById,
+      sprintMap,
+      bucketsBySprintId,
+      fallbackBuckets,
+      windowStart,
+    });
+    if (!bucket) {
+      blocked += 1;
+      continue;
+    }
+
+    const targetStartMs = Math.max(bucket.startMs, windowStart.toMillis());
+    const targetSprintId = String(candidate?.sprintId || parentStory?.sprintId || bucket.sprintId || '').trim() || null;
+    const remainingDays = Math.max(
+      1,
+      Math.floor((windowEnd.toMillis() - targetStartMs) / (24 * 60 * 60 * 1000)) + 1,
+    );
+
+    try {
+      const result = await schedulePlannerItemMutation({
+        db,
+        userId,
+        itemType: kind,
+        itemId: candidate.id,
+        targetDateMs: targetStartMs,
+        targetBucket: candidate.timeOfDay || null,
+        intent: 'move',
+        source,
+        rationale: `Nightly sprint placement for week of ${bucket.weekKey}`,
+        linkedBlockId: null,
+        targetSprintId,
+        durationMinutes: estimateRequiredMinutes(candidate, kind),
+        planningMode,
+        searchDays: remainingDays,
+        allowSplit: true,
+      });
+      created += 1;
+      addScheduledMinutes(
+        scheduledMinutesByEntity,
+        kind,
+        candidate.id,
+        Math.max(15, Math.round(Number(result.scheduledMinutes || 0) || 0)),
+      );
+      if (kind === 'story') storyWeekById.set(candidate.id, String(result.appliedWeekKey || bucket.weekKey));
+    } catch (error) {
+      console.warn(`[${source}] failed to schedule ${kind}:${candidate.id}`, error?.message || error);
+      blocked += 1;
+    }
+  }
+
+  return {
+    created,
+    blocked,
+    scheduledMinutesByEntity,
   };
 }
 
@@ -3253,7 +3520,7 @@ async function runCalendarPlannerJob() {
     if (dedupeResult.removed > 0) {
       console.log(`[calendar-planner] removed ${dedupeResult.removed} duplicate blocks for ${userId}`);
     }
-    const existingBlocks = dedupeResult.blocks;
+    let existingBlocks = dedupeResult.blocks;
 
     const fitnessBlocksAutoCreate = profile?.fitnessBlocksAutoCreate !== false;
     const plannerBlockResult = await materializePlannerThemeBlocks({
@@ -3267,6 +3534,13 @@ async function runCalendarPlannerJob() {
     });
     if (plannerBlockResult.created > 0) {
       console.log(`[calendar-planner] planner blocks created for ${userId}: ${plannerBlockResult.created}`);
+      const refreshedBlocksSnap = await db.collection('calendar_blocks')
+        .where('ownerUid', '==', userId)
+        .where('start', '>=', windowStart.toMillis())
+        .where('start', '<=', windowEnd.toMillis())
+        .get()
+        .catch(() => ({ docs: [] }));
+      existingBlocks = refreshedBlocksSnap.docs.map((d) => ({ id: d.id, ...(d.data() || {}) }));
     }
 
     const rescheduleResult = await replanExistingBlocksForUser({
@@ -3395,30 +3669,6 @@ async function runCalendarPlannerJob() {
       }
     }
 
-    const scheduledMinutesByEntity = collectScheduledMinutesByEntity(remainingBlocks);
-    const manuallyScheduledEntityKeys = new Set(
-      remainingBlocks
-        .filter((block) => {
-          const isAi = block.aiGenerated === true || block.isAiGenerated === true || block.createdBy === 'ai';
-          return !isAi && (block.storyId || block.taskId);
-        })
-        .map((block) => (block.storyId ? getEntityKey('story', block.storyId) : getEntityKey('task', block.taskId)))
-    );
-
-    const mainGigBlocks = []; // Track main gig planner blocks separately
-    remainingBlocks.forEach((b) => {
-      if (b.start && b.end) {
-        const blockTheme = b.theme || b.category || '';
-        if (isMainGigBlock(b)) {
-          mainGigBlocks.push({ start: b.start, end: b.end, theme: blockTheme });
-          busyPersonal.push({ start: b.start, end: b.end });
-        } else {
-          busyPersonal.push({ start: b.start, end: b.end });
-          busyWork.push({ start: b.start, end: b.end });
-        }
-      }
-    });
-
     const placementQueue = buildUnifiedPlacementQueue({
       stories: storyQueue,
       tasks: taskQueue,
@@ -3427,150 +3677,23 @@ async function runCalendarPlannerJob() {
       storyMap,
     });
 
-    let created = 0;
-    let blocked = 0;
-
-    // Greedy multi-block scheduler: fills all available free time until total needed is covered
-    const placeEntry = async (candidate, kind) => {
-      const sprint = candidate.sprintId ? sprintMap.get(candidate.sprintId) : null;
-      const sprintStart = sprint?.start ? toMillis(sprint.start) : null;
-      const sprintEnd = sprint?.end ? toMillis(sprint.end) : null;
-      const isWorkPersona = String(candidate?.persona || '').toLowerCase() === 'work';
-      const busyList = isWorkPersona ? busyWork : busyPersonal;
-
-      const totalNeededMs = estimateRequiredMinutes(candidate, kind) * 60000;
-      const entityKey = getEntityKey(kind, candidate.id);
-      const alreadyScheduledMs = (scheduledMinutesByEntity.get(entityKey) || 0) * 60000;
-      let stillNeededMs = totalNeededMs - alreadyScheduledMs;
-      if (stillNeededMs <= 0) return { created: 0, blocked: 0 };
-
-      const MIN_BLOCK_MS = 30 * 60000;
-      const title = candidate.title;
-      const basePayload = {
-        ownerUid: userId,
-        title,
-        entityType: kind,
-        taskId: kind === 'task' ? candidate.id : null,
-        storyId: kind === 'story' ? candidate.id : null,
-        sprintId: candidate.sprintId || null,
-        theme: candidate.theme || null,
-        goalId: candidate.goalId || null,
-        status: 'planned',
-        aiGenerated: true,
-        aiScore: candidate.aiScore || null,
-        aiReason: candidate.aiCriticalityReason || null,
-        placementReason: 'Nightly planner: greedy fill for remaining work',
-        calendarMatchSource: 'calendar_event_created_via_planner',
-        calendarMatchNote: 'Calendar event created via planner',
-        deepLink: buildEntityUrl(kind === 'story' ? 'story' : 'task', candidate.id, candidate.ref || null),
-        persona: candidate.persona || (isWorkPersona ? 'work' : 'personal'),
-        createdAt: admin.firestore.FieldValue.serverTimestamp(),
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-      };
-
-      let created = 0;
-
-      if (isWorkPersona) {
-        if (!mainGigBlocks.length) return { created: 0, blocked: 1 };
-        const sortedMainGig = mainGigBlocks.filter((mg) => mg.start && mg.end).sort((a, b) => a.start - b.start);
-        for (const mg of sortedMainGig) {
-          if (stillNeededMs <= 0) break;
-          if (sprintStart && mg.end < sprintStart) continue;
-          if (sprintEnd && mg.start > sprintEnd) continue;
-          const gaps = findFreeGapsInSlot(mg.start, mg.end, busyList, MIN_BLOCK_MS);
-          for (const gap of gaps) {
-            if (stillNeededMs <= 0) break;
-            const blockMs = Math.min(gap.end - gap.start, stillNeededMs);
-            if (blockMs < MIN_BLOCK_MS) continue;
-            const blockRef = db.collection('calendar_blocks').doc();
-            const payload = { ...basePayload, start: gap.start, end: gap.start + blockMs };
-            await blockRef.set(payload);
-            busyPersonal.push({ start: payload.start, end: payload.end });
-            busyWork.push({ start: payload.start, end: payload.end });
-            const minutesAdded = Math.round(blockMs / 60000);
-            addScheduledMinutes(scheduledMinutesByEntity, kind, candidate.id, minutesAdded);
-            stillNeededMs -= blockMs;
-            created++;
-            const slotDt = DateTime.fromMillis(gap.start, { zone: windowStart.zoneName });
-            await db.collection('activity_stream').add(activityPayload({
-              ownerUid: userId,
-              entityId: candidate.id,
-              entityType: kind,
-              activityType: 'calendar_insertion',
-              description: `Calendar block created (${slotDt.toISODate()} ${slotDt.toFormat('HH:mm')}–${DateTime.fromMillis(gap.start + blockMs, { zone: windowStart.zoneName }).toFormat('HH:mm')})`,
-              metadata: { blockId: blockRef.id, reason: payload.placementReason, theme: payload.theme || null, goalId: payload.goalId || null },
-            }));
-          }
-        }
-        return { created, blocked: stillNeededMs > MIN_BLOCK_MS ? 1 : 0 };
-      }
-
-      for (let offset = 0; offset < planningDays && stillNeededMs > MIN_BLOCK_MS; offset++) {
-        const day = windowStart.plus({ days: offset });
-        const dayStartMs = day.toMillis();
-        const dayEndMs = day.endOf('day').toMillis();
-        if ((sprintStart && dayEndMs < sprintStart) || (sprintEnd && dayStartMs > sprintEnd)) continue;
-
-        const allSlots = pickSlots(candidate.theme || candidate.goal || null, day);
-        const slots = filterSlotsByTimeOfDay(allSlots, candidate.timeOfDay || null);
-        for (const slot of slots) {
-          if (stillNeededMs <= 0) break;
-          if (isMainGigLabel(slot.label)) continue;
-          const slotDays = slot.days || [1, 2, 3, 4, 5, 6, 7];
-          if (!slotDays.includes(day.weekday)) continue;
-          const slotStart = day.set({ hour: Math.floor(slot.start), minute: Math.round((slot.start % 1) * 60), second: 0, millisecond: 0 });
-          const slotEnd = day.set({ hour: Math.floor(slot.end), minute: Math.round((slot.end % 1) * 60), second: 0, millisecond: 0 });
-          if (sprintStart && slotEnd.toMillis() < sprintStart) continue;
-          if (sprintEnd && slotStart.toMillis() > sprintEnd) continue;
-
-          const gaps = findFreeGapsInSlot(slotStart.toMillis(), slotEnd.toMillis(), busyList, MIN_BLOCK_MS);
-          for (const gap of gaps) {
-            if (stillNeededMs <= 0) break;
-            if (mainGigBlocks.some((mg) => mg.end > gap.start && mg.start < gap.end)) continue;
-            const blockMs = Math.min(gap.end - gap.start, stillNeededMs);
-            if (blockMs < MIN_BLOCK_MS) continue;
-            const blockRef = db.collection('calendar_blocks').doc();
-            const payload = { ...basePayload, start: gap.start, end: gap.start + blockMs };
-            await blockRef.set(payload);
-            busyPersonal.push({ start: payload.start, end: payload.end });
-            busyWork.push({ start: payload.start, end: payload.end });
-            const minutesAdded = Math.round(blockMs / 60000);
-            addScheduledMinutes(scheduledMinutesByEntity, kind, candidate.id, minutesAdded);
-            stillNeededMs -= blockMs;
-            created++;
-            const slotDt = DateTime.fromMillis(gap.start, { zone: windowStart.zoneName });
-            await db.collection('activity_stream').add(activityPayload({
-              ownerUid: userId,
-              entityId: candidate.id,
-              entityType: kind,
-              activityType: 'calendar_insertion',
-              description: `Calendar block created (${slotDt.toISODate()} ${slotDt.toFormat('HH:mm')}–${DateTime.fromMillis(gap.start + blockMs, { zone: windowStart.zoneName }).toFormat('HH:mm')})`,
-              metadata: { blockId: blockRef.id, reason: payload.placementReason, theme: payload.theme || null, goalId: payload.goalId || null },
-            }));
-          }
-        }
-      }
-      return { created, blocked: stillNeededMs > MIN_BLOCK_MS ? 1 : 0 };
-    };
-
-    for (const entry of placementQueue) {
-      const { kind, candidate } = entry;
-      const entityKey = getEntityKey(kind, candidate?.id);
-      if (manuallyScheduledEntityKeys.has(entityKey)) {
-        continue;
-      }
-      const totalNeededMs = estimateRequiredMinutes(candidate, kind) * 60000;
-      const alreadyMs = (scheduledMinutesByEntity.get(entityKey) || 0) * 60000;
-      if (alreadyMs >= totalNeededMs) continue; // fully covered
-      const res = await placeEntry(candidate, kind);
-      created += res.created || 0;
-      blocked += res.blocked || 0;
-    }
+    const plannerScheduleResult = await schedulePlacementQueueWithCanonicalScheduler({
+      db,
+      userId,
+      placementQueue,
+      storyMap,
+      sprintMap,
+      existingBlocks: remainingBlocks,
+      windowStart,
+      windowEnd,
+      planningMode: 'smart',
+      source: 'nightly_calendar_planner',
+    });
 
     const coverage = buildPlannerCoverageSummary({
       stories: storyQueue,
       tasks: taskQueue,
-      scheduledMinutesByEntity,
+      scheduledMinutesByEntity: plannerScheduleResult.scheduledMinutesByEntity,
     });
 
     await writePlannerStats({
@@ -3580,8 +3703,8 @@ async function runCalendarPlannerJob() {
       windowStart,
       windowEnd,
       result: {
-        created,
-        blocked,
+        created: plannerScheduleResult.created || 0,
+        blocked: plannerScheduleResult.blocked || 0,
         rescheduled: rescheduleResult.rescheduled || 0,
         replaced: dedupeResult.removed || 0,
         totalMovable: rescheduleResult.totalMovable || 0,
@@ -3974,7 +4097,7 @@ exports.replanCalendarNow = onCall({
     .where('start', '<=', windowEnd.toMillis())
     .get()
     .catch(() => ({ docs: [] }));
-  const existingBlocks = blocksSnap.docs.map((d) => ({ id: d.id, ...(d.data() || {}) }));
+  let existingBlocks = blocksSnap.docs.map((d) => ({ id: d.id, ...(d.data() || {}) }));
 
   let storiesSnap = { docs: [] };
   try {
@@ -4182,175 +4305,54 @@ exports.replanCalendarNow = onCall({
     existingBlocks: remainingBlocks,
     fitnessBlocksAutoCreate,
   });
-
-  const scheduledMinutesByEntity = collectScheduledMinutesByEntity(remainingBlocks);
-
-  const busyPersonal = [];
-  const busyWork = [];
-  const mainGigBlocks = []; // Track main gig planner blocks separately
-  const addBusyPersonal = (start, end) => {
-    if (start && end) busyPersonal.push({ start, end });
-  };
-  const addBusyWork = (start, end) => {
-    if (start && end) busyWork.push({ start, end });
-  };
-
-  remainingBlocks.forEach((b) => {
-    // In smart mode only hard-busy blocks (user GCal / work / fitness) block time.
-    // In strict mode every remaining block blocks time.
-    if (planningMode === 'smart' && !isHardBusy(b)) return;
-
-    if (isMainGigBlock(b)) {
-      mainGigBlocks.push({ start: b.start, end: b.end, theme: b.theme || b.category || '' });
-      addBusyPersonal(b.start, b.end);
-    } else {
-      addBusyPersonal(b.start, b.end);
-      addBusyWork(b.start, b.end);
-    }
-  });
-
-  const { pickSlots } = buildPickSlots(themeAllocations);
-
-  /**
-   * Schedule a candidate greedily across multiple free slots/days until the
-   * total remaining time is covered.  Blocks fill all available free time in
-   * each slot (no hard per-block cap), split across as many days as needed.
-   */
-  const placeEntry = async (candidate, kind) => {
-    const sprint = candidate.sprintId ? sprintMap.get(candidate.sprintId) : null;
-    const sprintStart = sprint?.start ? toMillis(sprint.start) : null;
-    const sprintEnd = sprint?.end ? toMillis(sprint.end) : null;
-    const isWorkPersona = String(candidate?.persona || '').toLowerCase() === 'work';
-    const busyList = isWorkPersona ? busyWork : busyPersonal;
-
-    const totalNeededMs = estimateRequiredMinutes(candidate, kind) * 60000;
-    const entityKey = getEntityKey(kind, candidate.id);
-    const alreadyScheduledMs = (scheduledMinutesByEntity.get(entityKey) || 0) * 60000;
-    let stillNeededMs = totalNeededMs - alreadyScheduledMs;
-    if (stillNeededMs <= 0) return { created: 0, blocked: 0 };
-
-      // Skip low-scored items — only schedule if Top 3, critical priority, or score >= 40
-      const rawScore = Number(candidate?.aiCriticalityScore || 0);
-      const isCriticalPriority = Number(candidate?.priority || 0) >= 4;
-      const isTop = candidate?.aiTop3ForDay === true;
-      if (rawScore > 0 && rawScore < 40 && !isCriticalPriority && !isTop) {
-        return { created: 0, blocked: 0 };
-      }
-
-    const MIN_BLOCK_MS = 30 * 60000; // 30-minute minimum useful block
-    const title = candidate.title;
-    const basePayload = {
-      ownerUid: uid,
-      title,
-      entityType: kind,
-      taskId: kind === 'task' ? candidate.id : null,
-      storyId: kind === 'story' ? candidate.id : null,
-      sprintId: candidate.sprintId || null,
-      theme: candidate.theme || null,
-      goalId: candidate.goalId || null,
-      status: 'planned',
-      aiGenerated: true,
-      aiScore: candidate.aiScore || null,
-      aiReason: candidate.aiCriticalityReason || null,
-      placementReason: 'Replan: greedy fill for remaining work',
-      deepLink: buildEntityUrl(kind === 'story' ? 'story' : 'task', candidate.id, candidate.ref || null),
-      persona: candidate.persona || (isWorkPersona ? 'work' : 'personal'),
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    };
-
-    let created = 0;
-
-    if (isWorkPersona) {
-      if (!mainGigBlocks.length) return { created: 0, blocked: 1 };
-      const sortedMainGig = mainGigBlocks.filter((mg) => mg.start && mg.end).sort((a, b) => a.start - b.start);
-      for (const mg of sortedMainGig) {
-        if (stillNeededMs <= 0) break;
-        if (sprintStart && mg.end < sprintStart) continue;
-        if (sprintEnd && mg.start > sprintEnd) continue;
-        const gaps = findFreeGapsInSlot(mg.start, mg.end, busyList, MIN_BLOCK_MS);
-        for (const gap of gaps) {
-          if (stillNeededMs <= 0) break;
-          const blockMs = Math.min(gap.end - gap.start, stillNeededMs);
-          if (blockMs < MIN_BLOCK_MS) continue;
-          const blockRef = db.collection('calendar_blocks').doc();
-          const payload = { ...basePayload, start: gap.start, end: gap.start + blockMs };
-          await blockRef.set(payload);
-          busyPersonal.push({ start: payload.start, end: payload.end });
-          busyWork.push({ start: payload.start, end: payload.end });
-          const minutesAdded = Math.round(blockMs / 60000);
-          addScheduledMinutes(scheduledMinutesByEntity, kind, candidate.id, minutesAdded);
-          stillNeededMs -= blockMs;
-          created++;
+  {
+    const refreshedBlocksSnap = await db.collection('calendar_blocks')
+      .where('ownerUid', '==', uid)
+      .where('start', '>=', windowStart.toMillis())
+      .where('start', '<=', windowEnd.toMillis())
+      .get()
+      .catch(() => ({ docs: [] }));
+    existingBlocks = refreshedBlocksSnap.docs.map((d) => ({ id: d.id, ...(d.data() || {}) }));
+    const retainedIds = new Set(remainingBlocks.map((block) => block.id));
+    for (const block of existingBlocks) {
+      if (retainedIds.has(block.id)) continue;
+      const isAi = isAiPlannerBlock(block);
+      const key = block.storyId ? getEntityKey('story', block.storyId) : block.taskId ? getEntityKey('task', block.taskId) : null;
+      if (planningMode === 'smart') {
+        if (isHardBusy(block)) {
+          remainingBlocks.push(block);
+          retainedIds.add(block.id);
         }
-      }
-      return { created, blocked: stillNeededMs > MIN_BLOCK_MS ? 1 : 0 };
-    }
-
-    for (let offset = 0; offset < planningDays && stillNeededMs > MIN_BLOCK_MS; offset++) {
-      const day = windowStart.plus({ days: offset });
-      const dayStartMs = day.toMillis();
-      const dayEndMs = day.endOf('day').toMillis();
-      if ((sprintStart && dayEndMs < sprintStart) || (sprintEnd && dayStartMs > sprintEnd)) continue;
-
-      const allSlots = pickSlots(candidate.theme || candidate.goal || null, day);
-      const slots = filterSlotsByTimeOfDay(allSlots, candidate.timeOfDay || null);
-      for (const slot of slots) {
-        if (stillNeededMs <= 0) break;
-        if (isMainGigLabel(slot.label)) continue;
-        const slotDays = slot.days || [1, 2, 3, 4, 5, 6, 7];
-        if (!slotDays.includes(day.weekday)) continue;
-        const slotStart = day.set({ hour: Math.floor(slot.start), minute: Math.round((slot.start % 1) * 60), second: 0, millisecond: 0 });
-        const slotEnd = day.set({ hour: Math.floor(slot.end), minute: Math.round((slot.end % 1) * 60), second: 0, millisecond: 0 });
-        if (sprintStart && slotEnd.toMillis() < sprintStart) continue;
-        if (sprintEnd && slotStart.toMillis() > sprintEnd) continue;
-
-        const gaps = findFreeGapsInSlot(slotStart.toMillis(), slotEnd.toMillis(), busyList, MIN_BLOCK_MS);
-        for (const gap of gaps) {
-          if (stillNeededMs <= 0) break;
-          // Never place in main gig overlap
-          if (mainGigBlocks.some((mg) => mg.end > gap.start && mg.start < gap.start + Math.min(gap.end - gap.start, stillNeededMs))) continue;
-          const blockMs = Math.min(gap.end - gap.start, stillNeededMs);
-          if (blockMs < MIN_BLOCK_MS) continue;
-          const blockRef = db.collection('calendar_blocks').doc();
-          const payload = { ...basePayload, start: gap.start, end: gap.start + blockMs };
-          await blockRef.set(payload);
-          busyPersonal.push({ start: payload.start, end: payload.end });
-          busyWork.push({ start: payload.start, end: payload.end });
-          const minutesAdded = Math.round(blockMs / 60000);
-          addScheduledMinutes(scheduledMinutesByEntity, kind, candidate.id, minutesAdded);
-          stillNeededMs -= blockMs;
-          created++;
-        }
+      } else if (!(isAi && key && !candidateIds.has(key))) {
+        remainingBlocks.push(block);
+        retainedIds.add(block.id);
       }
     }
-    return { created, blocked: stillNeededMs > MIN_BLOCK_MS ? 1 : 0 };
-  };
-
-  let created = 0;
-  let blocked = 0;
-  let gcalLinks = [];
-
-  for (const entry of placementQueue) {
-    const { kind, candidate } = entry;
-    const entityKey = getEntityKey(kind, candidate?.id);
-    const totalNeededMs = estimateRequiredMinutes(candidate, kind) * 60000;
-    const alreadyMs = (scheduledMinutesByEntity.get(entityKey) || 0) * 60000;
-    if (alreadyMs >= totalNeededMs) continue; // fully covered already
-    const res = await placeEntry(candidate, kind);
-    created += res.created || 0;
-    blocked += res.blocked || 0;
   }
+
+  const plannerScheduleResult = await schedulePlacementQueueWithCanonicalScheduler({
+    db,
+    userId: uid,
+    placementQueue,
+    storyMap,
+    sprintMap,
+    existingBlocks: remainingBlocks,
+    windowStart,
+    windowEnd,
+    planningMode,
+    source: 'replan_calendar',
+  });
+  let gcalLinks = [];
 
   const coverage = buildPlannerCoverageSummary({
     stories: storyQueue,
     tasks: taskQueue,
-    scheduledMinutesByEntity,
+    scheduledMinutesByEntity: plannerScheduleResult.scheduledMinutesByEntity,
   });
 
   const result = {
-    created,
-    blocked,
+    created: plannerScheduleResult.created || 0,
+    blocked: plannerScheduleResult.blocked || 0,
     rescheduled: 0,
     replaced,
     gcalLinks,
@@ -4436,6 +4438,58 @@ exports.replanCalendarNow = onCall({
     ok: true,
     ...result,
   };
+});
+
+exports.schedulePlannerItem = onCall({
+  region: 'europe-west2',
+  memory: '512MiB',
+}, async (req) => {
+  const uid = req?.auth?.uid;
+  if (!uid) throw new https.HttpsError('unauthenticated', 'Sign in required');
+  const itemType = String(req?.data?.itemType || '').trim().toLowerCase();
+  const itemId = String(req?.data?.itemId || '').trim();
+  if (!itemId || (itemType !== 'task' && itemType !== 'story')) {
+    throw new https.HttpsError('invalid-argument', 'A valid task or story target is required.');
+  }
+
+  const db = ensureFirestore();
+  try {
+    const result = await schedulePlannerItemMutation({
+      db,
+      userId: uid,
+      itemType,
+      itemId,
+      targetDateMs: req?.data?.targetDateMs,
+      targetBucket: req?.data?.targetBucket || null,
+      intent: req?.data?.intent || 'move',
+      source: req?.data?.source || 'planner',
+      rationale: req?.data?.rationale || null,
+      linkedBlockId: req?.data?.linkedBlockId || null,
+      targetSprintId: req?.data?.targetSprintId || null,
+      durationMinutes: req?.data?.durationMinutes || null,
+      planningMode: req?.data?.planningMode || null,
+      searchDays: req?.data?.searchDays || null,
+      maxTargetDateMs: req?.data?.maxTargetDateMs || null,
+      allowSplit: req?.data?.allowSplit === true,
+      debugRequestId: req?.data?.debugRequestId || null,
+    });
+    return result;
+  } catch (error) {
+    const message = error?.message || 'Failed to schedule planner item';
+    console.error('[schedulePlannerItem] failure', {
+      debugRequestId: req?.data?.debugRequestId || null,
+      uid,
+      itemType,
+      itemId,
+      intent: req?.data?.intent || 'move',
+      source: req?.data?.source || 'planner',
+      targetDateMs: req?.data?.targetDateMs || null,
+      targetBucket: req?.data?.targetBucket || null,
+      linkedBlockId: req?.data?.linkedBlockId || null,
+      error: message,
+    });
+    throw new https.HttpsError('failed-precondition', message);
+  }
 });
 
 // Manual trigger to run the nightly chain (pointing → conversions → scoring+Top3 → calendar)
@@ -4616,6 +4670,7 @@ exports.deltaPriorityRescore = onCall({
       aiTop3Date: admin.firestore.FieldValue.delete(),
       aiTop3Reason: admin.firestore.FieldValue.delete(),
       userPriorityFlag: false,
+      userPriorityRank: admin.firestore.FieldValue.delete(),
       userPriorityFlagAt: admin.firestore.FieldValue.delete(),
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       syncState: 'dirty',
@@ -4662,10 +4717,11 @@ exports.deltaPriorityRescore = onCall({
 
   const isHobbyTheme = effectiveTheme && String(effectiveTheme).toLowerCase().includes('hobb');
 
-  // User #1 priority flag gives massive boost
-  if (entity.userPriorityFlag === true) {
-    bonus += 1000;
-    bonusReasons.push('User #1 priority flag');
+  const manualPriorityRank = getManualPriorityRank(entity);
+  if (manualPriorityRank != null) {
+    const manualBoost = manualPriorityRank === 1 ? 1000 : manualPriorityRank === 2 ? 900 : 800;
+    bonus += manualBoost;
+    bonusReasons.push(`User manual priority #${manualPriorityRank}`);
   }
 
   if (entityType === 'task' && !entity.storyId) {
@@ -4751,10 +4807,25 @@ async function _deltaTop3ForPersona(db, userId, persona) {
   const topTasks = selectTopTasksFresh(taskCandidates, storyMap);
   const topTaskIds = new Set(topTasks.map((task) => task.id));
   const topStoryIds = new Set(topStories.map((story) => story.id));
+  const forcedStoryTaskCandidates = taskCandidates.filter((task) => {
+    const storyId = task?.data?.storyId;
+    if (!storyId) return false;
+    const parentStory = storyMap.get(storyId);
+    return !!getManualPriorityRank(parentStory?.data);
+  });
+  const promotedTasks = [
+    ...topTasks,
+    ...forcedStoryTaskCandidates.filter((task) => !topTaskIds.has(task.id)),
+  ];
+  const promotedTaskIds = new Set(promotedTasks.map((task) => task.id));
 
   const promoteTaskBatch = db.batch();
-  topTasks.forEach((task, idx) => {
-    const reason = ['Top 3 priority', `score=${Math.round(task.score || 0)}`].filter(Boolean).join(' | ');
+  promotedTasks.forEach((task, idx) => {
+    const parentStory = task?.data?.storyId ? storyMap.get(task.data.storyId) : null;
+    const parentManualRank = getManualPriorityRank(parentStory?.data);
+    const reason = parentManualRank
+      ? [`Manual story priority #${parentManualRank}`, `score=${Math.round(task.score || 0)}`].filter(Boolean).join(' | ')
+      : ['Top 3 priority', `score=${Math.round(task.score || 0)}`].filter(Boolean).join(' | ');
     const patch = {
       aiFlaggedTop: true,
       aiPriorityRank: idx + 1,
@@ -4773,12 +4844,12 @@ async function _deltaTop3ForPersona(db, userId, persona) {
     }
     promoteTaskBatch.set(task.refObj, patch, { merge: true });
   });
-  if (topTasks.length > 0) await promoteTaskBatch.commit();
+  if (promotedTasks.length > 0) await promoteTaskBatch.commit();
 
   const demoteTaskMap = await collectTaskTop3CandidateDocs(db, userId, 200);
   const demoteTaskWriter = db.bulkWriter();
   demoteTaskMap.forEach((doc) => {
-    if (topTaskIds.has(doc.id)) return;
+    if (promotedTaskIds.has(doc.id)) return;
     const data = doc.data() || {};
     if (resolvePersona(data.persona) !== persona) return;
     const cleanedTags = stripTop3Tags(data.tags);

--- a/functions/services/capacityService.js
+++ b/functions/services/capacityService.js
@@ -1,0 +1,116 @@
+const { DateTime } = require('luxon');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function toMillis(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value?.toMillis === 'function') return value.toMillis();
+  if (typeof value?.toDate === 'function') return value.toDate().getTime();
+  if (typeof value?.seconds === 'number') return value.seconds * 1000;
+  const parsed = Date.parse(String(value));
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function startOfDayMs(ts = Date.now()) {
+  const d = new Date(ts);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+function toDayKey(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function inferItemPoints(itemType, data) {
+  const normalizedType = String(itemType || '').trim().toLowerCase();
+  if (normalizedType === 'task') {
+    const direct = Number(data?.points || 0);
+    if (Number.isFinite(direct) && direct > 0) return direct;
+    const estimateMin = Number(data?.estimateMin || 0);
+    if (Number.isFinite(estimateMin) && estimateMin > 0) return Math.max(0.25, estimateMin / 60);
+    return 1;
+  }
+  if (normalizedType === 'story') {
+    const direct = Number(data?.points || 0);
+    if (Number.isFinite(direct) && direct > 0) return direct;
+    const estimateMin = Number(data?.estimateMin || 0);
+    if (Number.isFinite(estimateMin) && estimateMin > 0) return Math.max(0.5, estimateMin / 60);
+    return 2;
+  }
+  return 1;
+}
+
+function summarizeCapacity(plannedPoints, capacityPoints) {
+  const safeCapacity = Math.max(1, Number(capacityPoints || 0) || 1);
+  const planned = Number(plannedPoints || 0);
+  const remainingPoints = safeCapacity - planned;
+  const utilizationPct = Math.round((planned / safeCapacity) * 100);
+  return {
+    capacityPoints: safeCapacity,
+    plannedPoints: planned,
+    remainingPoints,
+    utilizationPct,
+    overCapacity: remainingPoints < 0,
+  };
+}
+
+async function buildDayLoadPointsMap(db, userId, startMs, endMs) {
+  const map = new Map();
+  const snap = await db.collection('calendar_blocks')
+    .where('ownerUid', '==', userId)
+    .where('start', '>=', startMs)
+    .where('start', '<=', endMs)
+    .get()
+    .catch(() => ({ docs: [] }));
+  for (const doc of (snap.docs || [])) {
+    const data = doc.data() || {};
+    const start = Number(data.start || 0);
+    const end = Number(data.end || 0);
+    if (!(start > 0) || !(end > start)) continue;
+    const key = toDayKey(start);
+    const points = Math.max(0.25, (end - start) / (60 * 60 * 1000));
+    map.set(key, (map.get(key) || 0) + points);
+  }
+  return map;
+}
+
+function nextWeekendDateByCapacity(nowLocal, dayLoadPoints = new Map(), maxPoints = 6) {
+  const base = (nowLocal || DateTime.now()).startOf('day');
+  let fallback = null;
+  for (let offset = 1; offset <= 56; offset += 1) {
+    const candidate = base.plus({ days: offset });
+    if (![6, 7].includes(candidate.weekday)) continue;
+    if (!fallback) fallback = candidate;
+    const key = candidate.toISODate();
+    const load = Number(dayLoadPoints.get(key) || 0);
+    if (load < maxPoints) {
+      return candidate.endOf('day').toMillis();
+    }
+  }
+  return (fallback || base.plus({ days: 6 })).endOf('day').toMillis();
+}
+
+function deriveSprintCapacityPoints(sprint, weeklyCapacityPoints = 20) {
+  const explicit = Number(sprint?.capacityPoints || 0);
+  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+  const startMs = toMillis(sprint?.startDate || sprint?.start);
+  const endMs = toMillis(sprint?.endDate || sprint?.end);
+  if (Number.isFinite(startMs) && Number.isFinite(endMs) && endMs >= startMs) {
+    const sprintWeeks = Math.max(1, Math.ceil((endMs - startMs + DAY_MS) / (7 * DAY_MS)));
+    return sprintWeeks * weeklyCapacityPoints;
+  }
+  return weeklyCapacityPoints;
+}
+
+module.exports = {
+  DAY_MS,
+  toMillis,
+  startOfDayMs,
+  toDayKey,
+  inferItemPoints,
+  summarizeCapacity,
+  buildDayLoadPointsMap,
+  nextWeekendDateByCapacity,
+  deriveSprintCapacityPoints,
+};

--- a/functions/services/schedulingService.js
+++ b/functions/services/schedulingService.js
@@ -1,0 +1,666 @@
+const admin = require('firebase-admin');
+const { DateTime } = require('luxon');
+const { normalizeThemeAllocationPlan, resolveThemeAllocationsForDate } = require('../lib/themeAllocations');
+const { inferItemPoints, startOfDayMs, toMillis } = require('./capacityService');
+
+const DEFAULT_ZONE = 'Europe/London';
+const MIN_BLOCK_MS = 15 * 60 * 1000;
+const DEFAULT_SEARCH_DAYS = 14;
+
+const THEME_RULES = [
+  { match: ['growth'], slots: [{ days: [1, 2, 3, 4, 5], start: 7, end: 9, label: 'Growth AM' }, { days: [1, 2, 3, 4, 5], start: 17, end: 19, label: 'Growth PM' }] },
+  { match: ['finance', 'wealth'], slots: [{ days: [1, 2, 3, 4, 5], start: 18, end: 21, label: 'Wealth weekday evening' }, { days: [6, 7], start: 9, end: 12, label: 'Wealth weekend AM' }, { days: [6, 7], start: 13, end: 17, label: 'Wealth weekend PM' }] },
+  { match: ['side gig', 'side-gig', 'sidegig'], slots: [{ days: [1, 2, 3, 4, 5], start: 18, end: 22, label: 'Side gig evenings' }, { days: [6, 7], start: 10, end: 16, label: 'Side gig weekend' }] },
+  { match: ['hobby', 'hobbies'], slots: [{ days: [1, 2, 3, 4, 5, 6, 7], start: 18, end: 22, label: 'Hobbies evenings' }] },
+  { match: ['game', 'gaming', 'tv'], slots: [{ days: [5, 6], start: 19, end: 23, label: 'Gaming/TV Fri/Sat evening' }] },
+  { match: ['health'], slots: [{ days: [1, 2, 3, 4, 5], start: 6, end: 20, label: 'Health focus' }] },
+  { match: ['learning', 'spiritual'], slots: [{ days: [1, 2, 3, 4, 5], start: 6, end: 20, label: 'Growth/Learning' }] },
+];
+
+const FALLBACK_SLOTS = [
+  { days: [1, 2, 3, 4, 5, 6, 7], start: 8, end: 12, label: 'Fallback AM' },
+  { days: [1, 2, 3, 4, 5, 6, 7], start: 13, end: 17, label: 'Fallback PM' },
+  { days: [1, 2, 3, 4, 5, 6, 7], start: 18, end: 22, label: 'Fallback evening' },
+];
+
+function resolvePlanningMode(profile, requestedMode) {
+  const fromReq = String(requestedMode || '').toLowerCase();
+  const fromProfile = String(profile?.plannerMode || '').toLowerCase();
+  return (fromReq || fromProfile) === 'strict' ? 'strict' : 'smart';
+}
+
+function normalizeBucket(value) {
+  const raw = String(value || '').trim().toLowerCase();
+  return raw === 'morning' || raw === 'afternoon' || raw === 'evening' || raw === 'anytime' ? raw : null;
+}
+
+function toMinutes(hhmm) {
+  const [h = '0', m = '0'] = String(hhmm || '0:0').split(':');
+  return (Number(h) * 60) + Number(m);
+}
+
+function isMainGigLabel(value) {
+  const raw = String(value || '').toLowerCase();
+  if (!raw) return false;
+  if (raw.includes('workout')) return false;
+  if (raw.includes('main gig') || raw.includes('work shift')) return true;
+  return /\bwork\b/.test(raw);
+}
+
+function isMainGigBlock(block) {
+  if (!block) return false;
+  if (block.entityType === 'work_shift' || block.sourceType === 'work_shift_allocation') return true;
+  const label = block.theme || block.category || block.title || '';
+  return isMainGigLabel(label);
+}
+
+function isUserGcalEvent(block) {
+  const source = String(block?.source || block?.sourceType || '').toLowerCase();
+  return source === 'gcal' || source === 'google_calendar' || block?.createdBy === 'google';
+}
+
+function isFitnessBlock(block) {
+  const label = String(block?.theme || block?.category || block?.title || '').toLowerCase();
+  return label.includes('health') || label.includes('fitness') || label.includes('gym')
+    || label.includes('workout') || label.includes('exercise') || label.includes('run')
+    || label.includes('swim') || label.includes('cycle') || label.includes('sport');
+}
+
+function findFreeGapsInSlot(slotStartMs, slotEndMs, busyList, minGapMs = MIN_BLOCK_MS) {
+  const overlaps = busyList
+    .filter((b) => b.end > slotStartMs && b.start < slotEndMs)
+    .sort((a, b) => a.start - b.start);
+  const gaps = [];
+  let cursor = slotStartMs;
+  for (const overlap of overlaps) {
+    if (overlap.start > cursor && overlap.start - cursor >= minGapMs) {
+      gaps.push({ start: cursor, end: Math.min(overlap.start, slotEndMs) });
+    }
+    cursor = Math.max(cursor, overlap.end);
+    if (cursor >= slotEndMs) break;
+  }
+  if (slotEndMs - cursor >= minGapMs) {
+    gaps.push({ start: cursor, end: slotEndMs });
+  }
+  return gaps;
+}
+
+function buildPickSlots(themeAllocationPlan) {
+  const getUserSlots = (themeLabel, day) => {
+    const label = String(themeLabel || '').trim().toLowerCase();
+    if (!label) return [];
+    const dayAllocations = resolveThemeAllocationsForDate(themeAllocationPlan, day, day.zoneName);
+    const matches = dayAllocations.filter((allocation) => {
+      if (allocation.dayOfWeek !== day.weekday % 7) return false;
+      const allocationTheme = String(allocation.theme || '').trim().toLowerCase();
+      return allocationTheme && (allocationTheme === label || label.includes(allocationTheme) || allocationTheme.includes(label));
+    });
+    return matches.map((allocation) => {
+      const startMinutes = toMinutes(allocation.startTime);
+      const endMinutes = toMinutes(allocation.endTime);
+      return {
+        days: [day.weekday],
+        start: startMinutes / 60,
+        end: endMinutes / 60,
+        label: `Theme block: ${allocation.theme}`,
+      };
+    });
+  };
+
+  const pickSlots = (themeLabel, day) => {
+    const userSlots = getUserSlots(themeLabel, day);
+    if (userSlots.length) return userSlots;
+    const key = String(themeLabel || '').trim().toLowerCase();
+    for (const rule of THEME_RULES) {
+      if (rule.match.some((match) => key.includes(match))) return rule.slots;
+    }
+    return FALLBACK_SLOTS;
+  };
+
+  return { pickSlots };
+}
+
+function filterSlotsByTimeOfDay(slots, timeOfDay) {
+  const normalized = normalizeBucket(timeOfDay);
+  if (!normalized || normalized === 'anytime') return slots;
+  const filtered = slots.filter((slot) => {
+    const hour = Number(slot.start);
+    if (normalized === 'morning') return hour >= 5 && hour < 13;
+    if (normalized === 'afternoon') return hour >= 13 && hour < 19;
+    if (normalized === 'evening') return hour >= 19 || hour < 5;
+    return true;
+  });
+  return filtered.length ? filtered : slots;
+}
+
+function inferDurationMinutes(itemType, entity, existingBlock, requestedMinutes) {
+  const requested = Number(requestedMinutes || 0);
+  if (Number.isFinite(requested) && requested >= 15) return Math.round(requested);
+  const blockDuration = Number(existingBlock?.end || 0) - Number(existingBlock?.start || 0);
+  if (Number.isFinite(blockDuration) && blockDuration >= MIN_BLOCK_MS) {
+    return Math.max(15, Math.round(blockDuration / 60000));
+  }
+  const estimateMin = Number(entity?.estimateMin || 0);
+  if (Number.isFinite(estimateMin) && estimateMin > 0) return Math.max(15, Math.round(estimateMin));
+  return Math.max(15, Math.round(inferItemPoints(itemType, entity) * 60));
+}
+
+function buildBusyIntervals(blocks, { planningMode, persona, excludedBlockIds }) {
+  const busy = [];
+  blocks.forEach((block) => {
+    const blockId = String(block?.id || '').trim();
+    if (blockId && excludedBlockIds.has(blockId)) return;
+    const start = Number(block?.start || 0);
+    const end = Number(block?.end || 0);
+    if (!(start > 0) || !(end > start)) return;
+    if (planningMode === 'strict') {
+      busy.push({ start, end });
+      return;
+    }
+    if (persona === 'work' && isMainGigBlock(block)) return;
+    busy.push({ start, end });
+  });
+  return busy;
+}
+
+function formatTimeString(ms, zone) {
+  return DateTime.fromMillis(ms, { zone }).toFormat('HH:mm');
+}
+
+function plannerWeekStartMs(ms, zone) {
+  return DateTime.fromMillis(ms, { zone }).startOf('week').startOf('day').toMillis();
+}
+
+function plannerWeekKey(ms, zone) {
+  return DateTime.fromMillis(ms, { zone }).startOf('week').toISODate();
+}
+
+async function loadCalendarBlocksForWindow(db, userId, startMs, endMs) {
+  try {
+    const snap = await db.collection('calendar_blocks')
+      .where('ownerUid', '==', userId)
+      .where('start', '<=', endMs)
+      .get();
+    return snap.docs
+      .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }))
+      .filter((row) => {
+        const start = Number(row.start || 0);
+        const end = Number(row.end || 0);
+        return Number.isFinite(start) && Number.isFinite(end) && end >= startMs && start <= endMs;
+      });
+  } catch (_) {
+    const fallback = await db.collection('calendar_blocks')
+      .where('ownerUid', '==', userId)
+      .get()
+      .catch(() => ({ docs: [] }));
+    return fallback.docs
+      .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }))
+      .filter((row) => {
+        const start = Number(row.start || 0);
+        return Number.isFinite(start) && start >= startMs && start <= endMs;
+      });
+  }
+}
+
+async function loadRelatedBlocks(db, userId, itemType, itemId) {
+  const field = itemType === 'task' ? 'taskId' : 'storyId';
+  try {
+    const snap = await db.collection('calendar_blocks')
+      .where('ownerUid', '==', userId)
+      .where(field, '==', itemId)
+      .get();
+    return snap.docs.map((docSnap) => ({ id: docSnap.id, ref: docSnap.ref, ...(docSnap.data() || {}) }));
+  } catch (_) {
+    const fallback = await db.collection('calendar_blocks')
+      .where('ownerUid', '==', userId)
+      .get()
+      .catch(() => ({ docs: [] }));
+    return fallback.docs
+      .map((docSnap) => ({ id: docSnap.id, ref: docSnap.ref, ...(docSnap.data() || {}) }))
+      .filter((row) => String(row[field] || '').trim() === itemId);
+  }
+}
+
+async function resolveSprintIdForDate(db, userId, dateMs) {
+  const snap = await db.collection('sprints').where('ownerUid', '==', userId).get().catch(() => ({ docs: [] }));
+  const exact = snap.docs.find((docSnap) => {
+    const data = docSnap.data() || {};
+    const start = toMillis(data.startDate || data.start);
+    const end = toMillis(data.endDate || data.end);
+    return Number.isFinite(start) && Number.isFinite(end) && start <= dateMs && end >= dateMs;
+  });
+  return exact?.id || null;
+}
+
+function choosePlacement({
+  targetDateMs,
+  targetBucket,
+  durationMinutes,
+  busyIntervals,
+  pickSlots,
+  themeLabel,
+  zone,
+  searchDays,
+  maxTargetDateMs = null,
+}) {
+  const baseDay = DateTime.fromMillis(targetDateMs, { zone }).startOf('day');
+  const durationMs = Math.max(MIN_BLOCK_MS, Math.round(durationMinutes) * 60 * 1000);
+  const requestedBucket = normalizeBucket(targetBucket);
+
+  for (let offset = 0; offset < searchDays; offset += 1) {
+    const day = baseDay.plus({ days: offset });
+    if (Number.isFinite(maxTargetDateMs) && day.toMillis() > Number(maxTargetDateMs)) break;
+    const slots = filterSlotsByTimeOfDay(pickSlots(themeLabel, day), targetBucket);
+    for (const slot of slots) {
+      const slotDays = Array.isArray(slot.days) && slot.days.length ? slot.days : [1, 2, 3, 4, 5, 6, 7];
+      if (!slotDays.includes(day.weekday)) continue;
+      const slotStart = day.set({
+        hour: Math.floor(Number(slot.start || 0)),
+        minute: Math.round((Number(slot.start || 0) % 1) * 60),
+        second: 0,
+        millisecond: 0,
+      }).toMillis();
+      const slotEnd = day.set({
+        hour: Math.floor(Number(slot.end || 0)),
+        minute: Math.round((Number(slot.end || 0) % 1) * 60),
+        second: 0,
+        millisecond: 0,
+      }).toMillis();
+      const gaps = findFreeGapsInSlot(slotStart, slotEnd, busyIntervals, durationMs);
+      const chosenGap = gaps.find((gap) => gap.end - gap.start >= durationMs);
+      if (!chosenGap) continue;
+      let appliedBucket = requestedBucket;
+      if (!appliedBucket) {
+        const lowerLabel = String(slot.label || '').toLowerCase();
+        if (lowerLabel.includes('evening')) appliedBucket = 'evening';
+        else if (lowerLabel.includes('afternoon') || lowerLabel.includes('pm')) appliedBucket = 'afternoon';
+        else if (lowerLabel.includes('morning') || lowerLabel.includes('am')) appliedBucket = 'morning';
+        else appliedBucket = 'anytime';
+      }
+      return {
+        appliedStartMs: chosenGap.start,
+        appliedEndMs: chosenGap.start + durationMs,
+        appliedBucket,
+      };
+    }
+  }
+
+  return null;
+}
+
+function chooseSplitPlacements({
+  targetDateMs,
+  targetBucket,
+  durationMinutes,
+  busyIntervals,
+  pickSlots,
+  themeLabel,
+  zone,
+  searchDays,
+  maxTargetDateMs = null,
+}) {
+  const baseDay = DateTime.fromMillis(targetDateMs, { zone }).startOf('day');
+  let remainingMs = Math.max(MIN_BLOCK_MS, Math.round(durationMinutes) * 60 * 1000);
+  const placements = [];
+  const mutableBusy = Array.isArray(busyIntervals) ? [...busyIntervals] : [];
+  const requestedBucket = normalizeBucket(targetBucket);
+
+  for (let offset = 0; offset < searchDays && remainingMs > 0; offset += 1) {
+    const day = baseDay.plus({ days: offset });
+    if (Number.isFinite(maxTargetDateMs) && day.toMillis() > Number(maxTargetDateMs)) break;
+    const slots = filterSlotsByTimeOfDay(pickSlots(themeLabel, day), targetBucket);
+    for (const slot of slots) {
+      if (remainingMs <= 0) break;
+      const slotDays = Array.isArray(slot.days) && slot.days.length ? slot.days : [1, 2, 3, 4, 5, 6, 7];
+      if (!slotDays.includes(day.weekday)) continue;
+      const slotStart = day.set({
+        hour: Math.floor(Number(slot.start || 0)),
+        minute: Math.round((Number(slot.start || 0) % 1) * 60),
+        second: 0,
+        millisecond: 0,
+      }).toMillis();
+      const slotEnd = day.set({
+        hour: Math.floor(Number(slot.end || 0)),
+        minute: Math.round((Number(slot.end || 0) % 1) * 60),
+        second: 0,
+        millisecond: 0,
+      }).toMillis();
+      const gaps = findFreeGapsInSlot(slotStart, slotEnd, mutableBusy, MIN_BLOCK_MS);
+      for (const gap of gaps) {
+        if (remainingMs <= 0) break;
+        const gapMs = gap.end - gap.start;
+        if (gapMs < MIN_BLOCK_MS) continue;
+        const blockMs = Math.min(gapMs, remainingMs);
+        let appliedBucket = requestedBucket;
+        if (!appliedBucket) {
+          const lowerLabel = String(slot.label || '').toLowerCase();
+          if (lowerLabel.includes('evening')) appliedBucket = 'evening';
+          else if (lowerLabel.includes('afternoon') || lowerLabel.includes('pm')) appliedBucket = 'afternoon';
+          else if (lowerLabel.includes('morning') || lowerLabel.includes('am')) appliedBucket = 'morning';
+          else appliedBucket = 'anytime';
+        }
+        placements.push({
+          appliedStartMs: gap.start,
+          appliedEndMs: gap.start + blockMs,
+          appliedBucket,
+        });
+        mutableBusy.push({ start: gap.start, end: gap.start + blockMs });
+        remainingMs -= blockMs;
+      }
+    }
+  }
+
+  return placements;
+}
+
+async function logSchedulingActivity({
+  db,
+  ownerUid,
+  entityId,
+  entityType,
+  referenceNumber,
+  persona,
+  description,
+  metadata,
+  oldSprintId,
+  newSprintId,
+}) {
+  await db.collection('activity_stream').add({
+    entityId,
+    entityType,
+    activityType: oldSprintId !== newSprintId ? 'sprint_changed' : 'updated',
+    ownerUid,
+    userId: ownerUid,
+    actor: 'planner_schedule_service',
+    description,
+    persona: persona || null,
+    referenceNumber: referenceNumber || null,
+    source: 'function',
+    sourceDetails: 'schedulePlannerItem',
+    metadata,
+    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+}
+
+async function schedulePlannerItemMutation({
+  db,
+  userId,
+  itemType,
+  itemId,
+  targetDateMs,
+  targetBucket,
+  intent = 'move',
+  source = 'planner',
+  rationale = null,
+  linkedBlockId = null,
+  targetSprintId = null,
+  durationMinutes = null,
+  planningMode = null,
+  searchDays = null,
+  maxTargetDateMs = null,
+  allowSplit = false,
+  debugRequestId = null,
+}) {
+  const logContext = {
+    debugRequestId: debugRequestId || null,
+    userId,
+    itemType,
+    itemId,
+    intent,
+    source,
+    targetDateMs,
+    targetBucket: normalizeBucket(targetBucket),
+    linkedBlockId: linkedBlockId || null,
+    targetSprintId: targetSprintId || null,
+    planningMode: planningMode || null,
+    searchDays: searchDays || null,
+    maxTargetDateMs: maxTargetDateMs || null,
+    allowSplit: allowSplit === true,
+  };
+  const normalizedType = String(itemType || '').trim().toLowerCase();
+  if (normalizedType !== 'task' && normalizedType !== 'story') {
+    throw new Error('schedulePlannerItem only supports tasks and stories in this slice.');
+  }
+  const targetMs = Number(targetDateMs || 0);
+  if (!Number.isFinite(targetMs) || targetMs <= 0) {
+    throw new Error('A valid targetDateMs is required.');
+  }
+
+  const profileSnap = await db.collection('profiles').doc(userId).get().catch(() => null);
+  const profile = profileSnap && profileSnap.exists ? (profileSnap.data() || {}) : {};
+  const zone = String(profile?.timezone || profile?.timeZone || DEFAULT_ZONE);
+  const effectivePlanningMode = resolvePlanningMode(profile, planningMode);
+
+  const entityRef = db.collection(normalizedType === 'task' ? 'tasks' : 'stories').doc(itemId);
+  const entitySnap = await entityRef.get();
+  if (!entitySnap.exists) throw new Error(`${normalizedType} not found.`);
+  const entity = entitySnap.data() || {};
+  if (String(entity.ownerUid || '') !== userId) throw new Error('Permission denied for this item.');
+  console.info('[schedulePlannerItemMutation] start', {
+    ...logContext,
+    entityPersona: entity.persona || null,
+    entityTheme: entity.theme || entity.category || null,
+    entityGoalId: entity.goalId || null,
+    entitySprintId: entity.sprintId || null,
+  });
+
+  const relatedBlocks = await loadRelatedBlocks(db, userId, normalizedType, itemId);
+  const explicitBlock = linkedBlockId ? relatedBlocks.find((block) => block.id === linkedBlockId) || null : null;
+  const primaryBlock = explicitBlock || relatedBlocks
+    .slice()
+    .sort((a, b) => Math.abs(Number(a.start || 0) - targetMs) - Math.abs(Number(b.start || 0) - targetMs))[0] || null;
+
+  const effectiveDurationMinutes = inferDurationMinutes(normalizedType, entity, primaryBlock, durationMinutes);
+  const windowStartMs = startOfDayMs(targetMs);
+  const windowEndMs = windowStartMs + (DEFAULT_SEARCH_DAYS * 24 * 60 * 60 * 1000) - 1;
+  const allBlocks = await loadCalendarBlocksForWindow(db, userId, windowStartMs, windowEndMs);
+  const excludedBlockIds = new Set(relatedBlocks.map((block) => block.id).filter(Boolean));
+  const persona = String(entity.persona || 'personal').toLowerCase() === 'work' ? 'work' : 'personal';
+  const themeLabel = entity.theme || entity.category || null;
+  const themePlanSnap = await db.collection('theme_allocations').doc(userId).get().catch(() => null);
+  const themePlan = normalizeThemeAllocationPlan(themePlanSnap && themePlanSnap.exists ? (themePlanSnap.data() || {}) : {});
+  const { pickSlots } = buildPickSlots(themePlan);
+  const normalizedSearchDays = Math.max(1, Math.min(Number(searchDays || DEFAULT_SEARCH_DAYS), 84));
+  const busyIntervals = buildBusyIntervals(allBlocks, { planningMode: effectivePlanningMode, persona, excludedBlockIds });
+  const placements = allowSplit
+    ? chooseSplitPlacements({
+        targetDateMs: targetMs,
+        targetBucket,
+        durationMinutes: effectiveDurationMinutes,
+        busyIntervals,
+        pickSlots,
+        themeLabel,
+        zone,
+        searchDays: normalizedSearchDays,
+        maxTargetDateMs: Number.isFinite(Number(maxTargetDateMs)) ? Number(maxTargetDateMs) : null,
+      })
+    : (() => {
+        const single = choosePlacement({
+          targetDateMs: targetMs,
+          targetBucket,
+          durationMinutes: effectiveDurationMinutes,
+          busyIntervals,
+          pickSlots,
+          themeLabel,
+          zone,
+          searchDays: normalizedSearchDays,
+          maxTargetDateMs: Number.isFinite(Number(maxTargetDateMs)) ? Number(maxTargetDateMs) : null,
+        });
+        return single ? [single] : [];
+      })();
+
+  if (!placements.length) {
+    console.warn('[schedulePlannerItemMutation] no-placement', {
+      ...logContext,
+      effectivePlanningMode,
+      busyIntervals: busyIntervals.length,
+      relatedBlocks: relatedBlocks.length,
+      durationMinutes: effectiveDurationMinutes,
+      persona,
+      themeLabel,
+    });
+    throw new Error('No feasible slot was available without conflicting with current calendar constraints.');
+  }
+
+  const firstPlacement = placements[0];
+  const lastPlacement = placements[placements.length - 1];
+  const totalScheduledMinutes = placements.reduce((sum, placement) => (
+    sum + Math.max(0, Math.round((placement.appliedEndMs - placement.appliedStartMs) / 60000))
+  ), 0);
+  const appliedDayMs = startOfDayMs(firstPlacement.appliedStartMs);
+  const appliedWeekStartMs = plannerWeekStartMs(appliedDayMs, zone);
+  const appliedWeekKey = plannerWeekKey(appliedDayMs, zone);
+  const resolvedSprintId = targetSprintId || await resolveSprintIdForDate(db, userId, appliedDayMs);
+  const timeString = formatTimeString(firstPlacement.appliedStartMs, zone);
+  const oldSprintId = String(entity.sprintId || '');
+  const splitGroupId = db.collection('_').doc().id;
+  const reusableBlocks = [primaryBlock, ...relatedBlocks.filter((block) => !primaryBlock || block.id !== primaryBlock.id)].filter(Boolean);
+
+  const entityPatch = normalizedType === 'task'
+    ? {
+        dueDate: lastPlacement.appliedEndMs,
+        dueDateMs: lastPlacement.appliedEndMs,
+        scheduledTime: timeString,
+        actualScheduledStart: firstPlacement.appliedStartMs,
+        timeOfDay: firstPlacement.appliedBucket,
+        plannedWeekKey: appliedWeekKey,
+        plannedWeekStart: appliedWeekStartMs,
+        sprintId: resolvedSprintId || null,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }
+    : {
+        targetDate: lastPlacement.appliedEndMs,
+        dueDate: lastPlacement.appliedEndMs,
+        plannedStartDate: firstPlacement.appliedStartMs,
+        plannedTime: timeString,
+        actualScheduledStart: firstPlacement.appliedStartMs,
+        timeOfDay: firstPlacement.appliedBucket,
+        plannedWeekKey: appliedWeekKey,
+        plannedWeekStart: appliedWeekStartMs,
+        sprintId: resolvedSprintId || null,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      };
+
+  if (intent === 'defer') {
+    entityPatch.deferredUntil = appliedDayMs;
+    entityPatch.deferredReason = rationale || null;
+    entityPatch.deferredBy = source || 'planner';
+    entityPatch.deferredAt = admin.firestore.FieldValue.serverTimestamp();
+  } else {
+    entityPatch.deferredUntil = null;
+    entityPatch.deferredReason = null;
+    entityPatch.deferredBy = null;
+  }
+
+  const batch = db.batch();
+  const usedBlockIds = new Set();
+  placements.forEach((placement, index) => {
+    const reusable = reusableBlocks[index] || null;
+    const blockRef = reusable?.ref || db.collection('calendar_blocks').doc();
+    const blockPayload = {
+      ownerUid: userId,
+      title: String(entity.title || reusable?.title || normalizedType).trim(),
+      start: placement.appliedStartMs,
+      end: placement.appliedEndMs,
+      entityType: normalizedType,
+      sourceType: normalizedType,
+      source: reusable?.source || 'planner_schedule_service',
+      status: 'planned',
+      aiGenerated: reusable?.aiGenerated !== false,
+      taskId: normalizedType === 'task' ? itemId : null,
+      storyId: normalizedType === 'story' ? itemId : null,
+      goalId: entity.goalId || reusable?.goalId || null,
+      theme: entity.theme || reusable?.theme || null,
+      persona,
+      rationale: rationale || null,
+      syncToGoogle: true,
+      splitGroupId,
+      splitIndex: index,
+      splitCount: placements.length,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdAt: reusable?.createdAt || admin.firestore.FieldValue.serverTimestamp(),
+    };
+    batch.set(blockRef, blockPayload, { merge: true });
+    usedBlockIds.add(blockRef.id);
+  });
+  batch.set(entityRef, entityPatch, { merge: true });
+
+  relatedBlocks
+    .filter((block) => !usedBlockIds.has(block.id))
+    .filter((block) => block.aiGenerated === true || String(block.source || '').includes('planner') || String(block.source || '').includes('scheduler'))
+    .forEach((block) => {
+      batch.delete(db.collection('calendar_blocks').doc(block.id));
+    });
+
+  await batch.commit();
+  console.info('[schedulePlannerItemMutation] committed', {
+    ...logContext,
+    effectivePlanningMode,
+    durationMinutes: effectiveDurationMinutes,
+    persona,
+    themeLabel,
+    placementCount: placements.length,
+    placements: placements.map((placement) => ({
+      appliedStartMs: placement.appliedStartMs,
+      appliedEndMs: placement.appliedEndMs,
+      appliedBucket: placement.appliedBucket,
+    })),
+    usedBlockIds: Array.from(usedBlockIds),
+    splitGroupId,
+    resolvedSprintId: resolvedSprintId || null,
+  });
+
+  const activityPlacement = firstPlacement;
+  const description = intent === 'defer'
+    ? `Deferred to ${DateTime.fromMillis(activityPlacement.appliedStartMs, { zone }).toFormat('dd LLL yyyy HH:mm')} (${activityPlacement.appliedBucket}) via ${source}.`
+    : `Moved to ${DateTime.fromMillis(activityPlacement.appliedStartMs, { zone }).toFormat('dd LLL yyyy HH:mm')} (${activityPlacement.appliedBucket}) via ${source}.`;
+  await logSchedulingActivity({
+    db,
+    ownerUid: userId,
+    entityId: itemId,
+    entityType: normalizedType,
+    referenceNumber: entity.ref || entity.referenceNumber || null,
+    persona,
+    description,
+    metadata: {
+      source,
+      rationale: rationale || null,
+      planningMode: effectivePlanningMode,
+      requestedTargetDateMs: targetMs,
+      requestedBucket: normalizeBucket(targetBucket),
+      appliedStartMs: firstPlacement.appliedStartMs,
+      appliedEndMs: lastPlacement.appliedEndMs,
+      appliedBucket: firstPlacement.appliedBucket,
+      appliedWeekKey,
+      appliedWeekStartMs,
+      blockCount: placements.length,
+      scheduledMinutes: totalScheduledMinutes,
+      splitGroupId,
+      sprintId: resolvedSprintId || null,
+    },
+    oldSprintId,
+    newSprintId: resolvedSprintId || '',
+  });
+
+  return {
+    ok: true,
+    debugRequestId: debugRequestId || null,
+    planningMode: effectivePlanningMode,
+    appliedStartMs: firstPlacement.appliedStartMs,
+    appliedEndMs: lastPlacement.appliedEndMs,
+    appliedDayMs,
+    appliedBucket: firstPlacement.appliedBucket,
+    appliedWeekKey,
+    appliedWeekStartMs,
+    scheduledMinutes: totalScheduledMinutes,
+    blockCount: placements.length,
+    sprintId: resolvedSprintId || null,
+    blockId: Array.from(usedBlockIds)[0] || null,
+  };
+}
+
+module.exports = {
+  schedulePlannerItemMutation,
+};

--- a/orchestrate-build.sh
+++ b/orchestrate-build.sh
@@ -57,19 +57,19 @@ BUILD_USER=$(whoami)
 # ============================================================================
 
 log_info() {
-    echo -e "${BLUE}[INFO]${NC} $1"
+    echo -e "${BLUE}[INFO]${NC} $1" >&2
 }
 
 log_success() {
-    echo -e "${GREEN}[✓]${NC} $1"
+    echo -e "${GREEN}[✓]${NC} $1" >&2
 }
 
 log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
+    echo -e "${RED}[ERROR]${NC} $1" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}[!]${NC} $1"
+    echo -e "${YELLOW}[!]${NC} $1" >&2
 }
 
 get_git_commit() {
@@ -118,7 +118,7 @@ build_web() {
     
     # Install deps
     log_info "Installing dependencies..."
-    npm install --prefix react-app 2>&1 | tail -5
+    npm install --prefix react-app 2>&1 | tail -5 >&2
     
     # Build React
     log_info "Building React application..."
@@ -126,7 +126,7 @@ build_web() {
     REACT_APP_BUILD_ID="$BUILD_ID" \
     REACT_APP_VERSION="$web_version" \
     REACT_APP_GIT_COMMIT="$web_commit" \
-    npm run build --prefix react-app 2>&1 | tail -10
+    npm run build --prefix react-app 2>&1 | tail -10 >&2
     
     # Inject build info into index.html
     log_info "Injecting build metadata..."
@@ -147,11 +147,11 @@ EOF
     if [ "$DRY_RUN" != "true" ]; then
         # Deploy to Firebase Hosting
         log_info "Deploying to Firebase Hosting..."
-        firebase deploy --only hosting --force 2>&1 | grep -E "Deploy complete|Error" | head -5
+        firebase deploy --only hosting --force 2>&1 | grep -E "Deploy complete|Error" | head -5 >&2
         
         # Deploy functions
         log_info "Deploying Cloud Functions..."
-        firebase deploy --only functions --force 2>&1 | grep -E "Deploy complete|Error|functions" | head -10
+        firebase deploy --only functions --force 2>&1 | grep -E "Deploy complete|Error|functions" | head -10 >&2
     else
         log_warning "DRY RUN: Skipping Firebase deployment"
     fi
@@ -162,7 +162,7 @@ EOF
     log_success "Web build complete (${build_duration}s)"
     
     # Return build info
-    echo "$web_version:$web_commit:${build_duration}s:$BUILD_TIMESTAMP"
+    printf '%s\n' "$web_version|$web_commit|${build_duration}s|$BUILD_TIMESTAMP"
 }
 
 build_ios() {
@@ -192,7 +192,7 @@ build_ios() {
             -scheme BOB \
             -destination 'platform=macOS' \
             -derivedDataPath /tmp/bob-ios-build \
-            -configuration Release 2>&1 | grep -E "Build complete|error:" | head -5
+            -configuration Release 2>&1 | grep -E "Build complete|error:" | head -5 >&2
         
         # Copy app to Applications
         log_info "Installing to Applications..."
@@ -209,7 +209,7 @@ build_ios() {
     
     log_success "iOS build complete (${build_duration}s)"
     
-    echo "$ios_version:$ios_commit:${build_duration}s:$BUILD_TIMESTAMP"
+    printf '%s\n' "$ios_version|$ios_commit|${build_duration}s|$BUILD_TIMESTAMP"
 }
 
 build_mac() {
@@ -226,18 +226,18 @@ build_mac() {
         # Build with Cargo or Swift depending on project setup
         if [ -f "Cargo.toml" ]; then
             log_info "Building Rust project..."
-            cargo build --release 2>&1 | tail -10
+            cargo build --release 2>&1 | tail -10 >&2
             local binary_path="target/release/bob-mac-sync"
         else
             log_info "Building Swift project..."
-            swift build -c release 2>&1 | tail -10
+            swift build -c release 2>&1 | tail -10 >&2
             local binary_path=".build/release/bob-mac-sync"
         fi
         
         # Code sign
         log_info "Code signing..."
         if [ -f "$binary_path" ]; then
-            codesign -s - "$binary_path" 2>&1 | grep -v "replacing existing signature" || true
+            codesign -s - "$binary_path" 2>&1 | grep -v "replacing existing signature" >&2 || true
             log_success "Binary signed"
         fi
         
@@ -262,7 +262,7 @@ build_mac() {
     
     log_success "Mac build complete (${build_duration}s)"
     
-    echo "$mac_version:$mac_commit:${build_duration}s:$BUILD_TIMESTAMP"
+    printf '%s\n' "$mac_version|$mac_commit|${build_duration}s|$BUILD_TIMESTAMP"
 }
 
 # ============================================================================
@@ -311,7 +311,7 @@ create_build_pr() {
     local current_commit=$(git rev-parse --short HEAD)
     
     log_info "PR Summary:"
-    echo "$pr_body"
+    echo "$pr_body" >&2
     
     if command -v gh &> /dev/null; then
         log_info "Creating GitHub PR comment..."
@@ -326,33 +326,47 @@ create_build_pr() {
 
 save_build_manifest() {
     mkdir -p "$BUILD_LOGS_DIR"
-    
-    local manifest="{
-  \"buildId\": \"$BUILD_ID\",
-  \"timestamp\": \"$BUILD_TIMESTAMP\",
-  \"date\": \"$BUILD_DATE\",
-  \"branch\": \"$CURRENT_BRANCH\",
-  \"user\": \"$BUILD_USER\",
-  \"versions\": {
-    \"web\": \"$WEB_VERSION\",
-    \"ios\": \"$IOS_VERSION\",
-    \"mac\": \"$MAC_VERSION\"
-  },
-  \"commits\": {
-    \"web\": \"$WEB_COMMIT\",
-    \"ios\": \"$IOS_COMMIT\",
-    \"mac\": \"$MAC_COMMIT\"
-  },
-  \"durations\": {
-    \"web\": \"$WEB_DURATION\",
-    \"ios\": \"$IOS_DURATION\",
-    \"mac\": \"$MAC_DURATION\"
-  },
-  \"dryRun\": $DRY_RUN,
-  \"beta\": $IS_BETA
-}"
-    
-    echo "$manifest" | jq '.' > "$BUILD_MANIFEST_FILE" 2>/dev/null || echo "$manifest" > "$BUILD_MANIFEST_FILE"
+    jq -n \
+      --arg buildId "$BUILD_ID" \
+      --arg timestamp "$BUILD_TIMESTAMP" \
+      --arg date "$BUILD_DATE" \
+      --arg branch "$CURRENT_BRANCH" \
+      --arg user "$BUILD_USER" \
+      --arg webVersion "${WEB_VERSION:-}" \
+      --arg iosVersion "${IOS_VERSION:-}" \
+      --arg macVersion "${MAC_VERSION:-}" \
+      --arg webCommit "${WEB_COMMIT:-}" \
+      --arg iosCommit "${IOS_COMMIT:-}" \
+      --arg macCommit "${MAC_COMMIT:-}" \
+      --arg webDuration "${WEB_DURATION:-}" \
+      --arg iosDuration "${IOS_DURATION:-}" \
+      --arg macDuration "${MAC_DURATION:-}" \
+      --argjson dryRun "$DRY_RUN" \
+      --argjson beta "$IS_BETA" \
+      '{
+        buildId: $buildId,
+        timestamp: $timestamp,
+        date: $date,
+        branch: $branch,
+        user: $user,
+        versions: {
+          web: $webVersion,
+          ios: $iosVersion,
+          mac: $macVersion
+        },
+        commits: {
+          web: $webCommit,
+          ios: $iosCommit,
+          mac: $macCommit
+        },
+        durations: {
+          web: $webDuration,
+          ios: $iosDuration,
+          mac: $macDuration
+        },
+        dryRun: $dryRun,
+        beta: $beta
+      }' > "$BUILD_MANIFEST_FILE"
     log_success "Manifest saved: $BUILD_MANIFEST_FILE"
 }
 
@@ -446,18 +460,18 @@ log_info "========================================="
 
 case $BUILD_TARGET in
     web)
-        read -r WEB_VERSION WEB_COMMIT WEB_DURATION WEB_TIMESTAMP < <(build_web)
+        IFS='|' read -r WEB_VERSION WEB_COMMIT WEB_DURATION WEB_TIMESTAMP < <(build_web)
         ;;
     ios)
-        read -r IOS_VERSION IOS_COMMIT IOS_DURATION IOS_TIMESTAMP < <(build_ios)
+        IFS='|' read -r IOS_VERSION IOS_COMMIT IOS_DURATION IOS_TIMESTAMP < <(build_ios)
         ;;
     mac)
-        read -r MAC_VERSION MAC_COMMIT MAC_DURATION MAC_TIMESTAMP < <(build_mac)
+        IFS='|' read -r MAC_VERSION MAC_COMMIT MAC_DURATION MAC_TIMESTAMP < <(build_mac)
         ;;
     all)
-        read -r WEB_VERSION WEB_COMMIT WEB_DURATION WEB_TIMESTAMP < <(build_web)
-        read -r IOS_VERSION IOS_COMMIT IOS_DURATION IOS_TIMESTAMP < <(build_ios)
-        read -r MAC_VERSION MAC_COMMIT MAC_DURATION MAC_TIMESTAMP < <(build_mac)
+        IFS='|' read -r WEB_VERSION WEB_COMMIT WEB_DURATION WEB_TIMESTAMP < <(build_web)
+        IFS='|' read -r IOS_VERSION IOS_COMMIT IOS_DURATION IOS_TIMESTAMP < <(build_ios)
+        IFS='|' read -r MAC_VERSION MAC_COMMIT MAC_DURATION MAC_TIMESTAMP < <(build_mac)
         ;;
 esac
 

--- a/plan.md
+++ b/plan.md
@@ -1,199 +1,48 @@
 Comprehensive multi-phase rework spanning web, iOS/iPad, and health platforms:
 
-JD Updated 13 March at 15:55
-
-Current Status
-
-Completed Recently
-- Hierarchical focus goals, leaf-goal execution enforcement, structured KPI authoring, KPI dashboard surfacing, and atomic daily check-in are implemented in the live web app.
-- Weekly check-in now shows focus-goal progress and reads persisted weekly KPI snapshots, with server-side snapshot writing in place for forward coverage.
-- Focus-goal creation now supports milestone planning and sprint rollout mapping, and roadmap V6 now renders denser theme lanes with parent-goal sections and hierarchy-aware context.
-- Branch integration audit is complete: `codex/focus-goal-kpi-roadmap-pr` is the correct merge candidate for the current focus-goal / KPI / check-in slice.
-
-Still Open
-- Daily Plan remains the main unresolved UX cluster:
-  - bulk review table and remaining triage workflow
-  - full modal-first item editing flow completion
-  - filterable count chips and focus-aware deferral polish
-  - wider modal-only audit across adjacent surfaces called out later in this document
-- Repo-wide leaf-goal normalization is not fully complete yet; the primary flows are covered, but secondary legacy creation surfaces can still stamp raw parent `goalId` values directly.
-- Firebase App Check still needs console-side production verification for `bob.jc1.tech`; the current client cooldown is a mitigation, not the final fix.
-- Health / fitness roadmap items remain open later in this document, including broader health data foundation work, dashboard health surfacing, `/fitness`, and nutrition-advisor follow-through.
-- Historical KPI backfill remains optional/deferred; forward weekly snapshot coverage is in place, but exact older-week reconstruction is still limited.
-
-Next Up
-- Rebase this branch on `origin/main`, rebuild, and deploy web production.
-- Finish the Daily Plan defect cluster described later in this document under the DPO sections.
-- Verify Firebase Console App Check configuration after deploy.
-- Resume the broader health / fitness surfaces once Daily Plan and App Check are stable.
-
-Historical Log And Detailed Roadmap
-- The full execution log and the longer roadmap notes remain below unchanged for auditability and context.
-
-Latest execution log (14 March 2026)
-- 14 Mar 2026: Rebasing + deploy preparation completed for `codex/focus-goal-kpi-roadmap-pr`.
-  - Rebasing this branch onto `origin/main` succeeded using conflict preference toward the current upstream side, which automatically dropped older commits whose patch content was already effectively present upstream.
-  - Post-rebase validation: `npm run -s build --prefix react-app` completed successfully again on the rebased branch. Remaining output is still the repo’s existing ESLint noise, bundle-size warnings, and `rrule` source-map warnings.
-  - Web production deploy was run via `./build web` from the rebased branch.
-  - Follow-up note: the generated `/Users/jim/GitHub/bob/build-logs/manifest.json` contains placeholder/garbled values for web version/commit metadata, so the manifest writer in the orchestrator still needs cleanup if you want that artifact to be a reliable release record.
-- 14 Mar 2026: Audited local and recent remote branches before merge-to-main preparation.
-  - `codex/focus-goal-kpi-roadmap-pr` fully subsumes the active local implementation line from `feature/focus-goals-enhancements-consolidated-local` and the stale local copies of `feature/dashboard-mobile-priority-replan-consistency` / `feature/finance-enhancements-continue`.
-  - The only local branch with an extra commit was `backup/pre-split-0f3950a0`, but that delta was not merged because it consists of older planner/dashboard state plus generated markdown/cache artifacts; the actual planner/travel code from that branch is already present on the PR branch in current files.
-  - Recent remote branches with unique commits outside this PR were reviewed at a high level and are older unrelated workstreams (finance reconciliation, planner notes, calendar sync, legacy fixes) rather than missing pieces of the current hierarchical focus-goal/KPI/check-in slice.
-  - Merge readiness decision: PR branch `codex/focus-goal-kpi-roadmap-pr` is the correct integration branch for the current roadmap/focus-goal/KPI work and does not need an additional wholesale branch merge before landing to `main`.
-- 14 Mar 2026: Upgraded roadmap V6 to be hierarchy-aware inside theme groups and reduced lane height.
-  - `react-app/src/components/visualization/GoalRoadmapV6.tsx` now resolves goal theme context with parent-theme fallback when a leaf goal does not carry its own theme, so child goals stay inside the correct strategic theme lane.
-  - The roadmap is no longer only a flat theme grouping: theme tracks are now subdivided into parent-goal sections, with child/leaf goals rendered inside their parent section rather than as an undifferentiated list.
-  - Timeline cards now surface parent-path context directly on the goal bars/milestones so leaf goals display their hierarchy without leaving the roadmap view.
-  - `react-app/src/components/visualization/GoalRoadmapV6.css` was tightened to reduce vertical height across theme headers, section headers, lane rows, task bars, and milestone bars.
-  - Validation: `npm run -s build --prefix react-app` completed successfully after the roadmap hierarchy/density pass. Remaining output is the repo’s existing ESLint noise, bundle-size warnings, and `rrule` source-map warnings.
-- 14 Mar 2026: Extended the focus-goal flow with hierarchy-aware milestone planning and sprint rollout mapping.
-  - `react-app/src/components/FocusGoalWizard.tsx` now inserts a dedicated `Milestones + Sprint Plan` step between timeframe selection and review.
-  - Selecting a parent goal now expands to its execution leaf goals immediately in the wizard, and the wizard overlays draft child milestones so users can plan year/quarter focus periods without leaving the modal.
-  - Users can add new child milestone leaf goals inline under each selected parent goal; those draft milestones are kept in execution scope, participate in goal-type selection and sprint planning, and are persisted later via `pendingLeafGoalsToCreate`.
-  - Quarter/year focus periods now generate sprint-window segments in the wizard, and every execution leaf goal must be assigned to at least one sprint window before the wizard can continue to review/confirm.
-  - Review/confirm now show the planned sprint rollout, count draft milestones queued for creation, and warn that KPI authoring only applies to already-persisted leaf goals until the new milestones are saved.
-  - `react-app/src/components/FocusGoalsPage.tsx` now materializes those queued draft leaf milestones into real `goals` documents before creating the focus goal, remaps temporary goal IDs to the created goal IDs, persists `sprintPlanByGoalId` / `sprintPlanSegments`, and writes sprint assignments back onto overlapping sprint docs plus `assignedSprintIdsByGoalId` on the created focus goal.
-  - Active focus cards on the page now surface a `Milestone sprint rollout` view so users can see which leaf goals are meant to land in which sprint windows after the focus set is saved.
-  - Validation: `npm run -s build --prefix react-app` completed successfully after this slice. Remaining output is the repo’s existing ESLint noise, bundle-size warnings, and `rrule` source-map warnings.
-- 14 Mar 2026: Enforced leaf-goal execution links across the primary story/task/habit flows.
-  - Added shared leaf-goal resolution helpers in `react-app/src/utils/goalHierarchy.ts` so execution surfaces can distinguish valid leaf goals from parent goals, auto-resolve a parent with a single leaf descendant, and block ambiguous parent selections.
-  - Updated `react-app/src/components/AddStoryModal.tsx` and `react-app/src/components/EditStoryModal.tsx` so stories now author against leaf goals only:
-    - goal pickers only show leaf goals
-    - parent selections with one child auto-resolve
-    - parent selections with multiple child leaves are blocked until the user picks the exact leaf goal
-  - Updated `react-app/src/components/EditTaskModal.tsx` so direct task goal links and story-inherited goal links both normalize to leaf goals before save; tasks now reject ambiguous parent-goal execution links.
-  - Updated `react-app/src/components/HabitsManagement.tsx` so habits only link to leaf goals, which keeps KPI adherence scoped to actionable milestone goals rather than umbrella parents.
-  - Updated goal-driven creation surfaces in `react-app/src/components/EditGoalModal.tsx` and `react-app/src/components/ModernGoalsTable.tsx` so creating a story/task from a parent goal no longer stamps the parent goal ID directly.
-  - Updated `react-app/src/components/checkins/CheckInDaily.tsx` so legacy parent-goal links on tasks, stories, blocks, and habits are normalized to leaf goals before daily execution/KPI refresh logic uses them.
-  - Validation: `npm run -s build --prefix react-app` completed successfully after the leaf-goal enforcement changes.
-  - Remaining gap: there are still secondary/legacy creation surfaces elsewhere in the repo that can stamp raw `goalId` values directly; the main execution flows are covered, but a full repo-wide normalization pass would still be needed if you want every niche creation path locked down the same way.
-- 14 Mar 2026: Added a one-off weekly KPI snapshot backfill callable in `functions/index.js`.
-  - New callable `backfillWeeklyGoalKpiSnapshots` backfills older `weekly_goal_kpi_snapshots` for the signed-in user from stored `weekly_checkins.metrics.focusSummary.leafGoals` where historical focus-goal summaries exist.
-  - Backfilled snapshots are explicitly marked as `backfilled: true` and `snapshotQuality: 'summary_only'` because the legacy weekly check-in payload only preserves top KPI summaries and KPI health counts, not full raw historical KPI rows.
-  - The backfill skips existing snapshots by default, supports bounded week ranges, and also refreshes the current week from live `goal_kpi_metrics` so forward coverage remains on the canonical snapshot path.
-  - Validation: `node --check functions/index.js` completed successfully after the backfill callable was added.
-- 14 Mar 2026: Added a server-side weekly KPI snapshot writer in `functions/index.js`.
-  - Nightly `syncFitnessKpis` now snapshots each user’s current `goal_kpi_metrics` into `weekly_goal_kpi_snapshots` after refreshing KPI state, so weekly history no longer depends on the web app being opened.
-  - Manual `syncFitnessKpisNow` now also writes current-week snapshots for the signed-in user, which keeps manual refreshes and nightly refreshes on the same persistence path.
-  - Snapshot keys are generated per user timezone week, and snapshot documents carry the originating KPI payload plus snapshot reason/timezone metadata.
-  - Validation: `node --check functions/index.js` completed successfully after the change.
-- 14 Mar 2026: Added persisted weekly KPI snapshots and switched weekly check-in to prefer historical snapshot reads.
-  - `react-app/src/utils/kpiResolver.ts` now writes a `weekly_goal_kpi_snapshots/{ownerUid}_{weekKey}_{goalId}` document whenever resolved KPI state is persisted to `goal_kpi_metrics`.
-  - Snapshot rows store the week key, goal metadata, resolved KPI payload, and snapshot timestamp so weekly review can read week-specific KPI state instead of only today’s derived state.
-  - `react-app/src/components/checkins/CheckInWeekly.tsx` now queries `weekly_goal_kpi_snapshots` for the reviewed week and falls back to `goal_kpi_metrics` only when no snapshot exists for that goal/week.
-  - Validation: `npm run -s build --prefix react-app` completed successfully after the snapshot changes.
-  - Remaining limitation: exact historical coverage starts from when the new resolver path runs; older weeks still need a backfill or scheduled server-side snapshot writer if you want complete historical KPI history everywhere.
-- 14 Mar 2026: Extended `react-app/src/components/checkins/CheckInWeekly.tsx` to support weekly progress against focus goals.
-  - Weekly check-in now loads overlapping/active `focusGoals`, `goals`, and `goal_kpi_metrics` for the reviewed week.
-  - Added a focus-goal rollup section that shows:
-    - parent/root goal summaries
-    - leaf-goal weekly completion percentages from `daily_checkins`
-    - counts of story/task/habit activity linked to focused leaf goals
-    - KPI health counts and top KPI readings for each focused leaf goal
-  - The legacy weekly sections for themes, habits, stories, tasks, spend, and reflection remain in place beneath the new focus-goal summary.
-  - Current limitation: weekly check-in uses weekly execution signals from `daily_checkins` plus current `goal_kpi_metrics`; it does not yet compute true week-over-week KPI deltas or reconstruct historical KPI values for arbitrary prior weeks.
-- 14 Mar 2026: Updated shared check-in reminder banner behavior in `react-app/src/components/checkins/CheckInBanner.tsx`.
-  - Daily banner now stops showing after 13:00 local time if the target daily check-in is still incomplete.
-  - Weekly banner now stops showing after Tuesday for the prior-week weekly check-in if it remains incomplete.
-  - This change only affects the reminder banners in layout chrome; it does not remove access to `/checkin/daily` or `/checkin/weekly`.
-- 14 Mar 2026: Implemented the hierarchical-goals + structured KPI + atomic check-in slice across the web app.
-  - Goal hierarchy model extended in `react-app/src/types.ts` with `goalKind`, `timeHorizon`, and `rollupMode`, and focus documents now persist `focusRootGoalIds` plus `focusLeafGoalIds`.
-  - Added shared hierarchy helpers in `react-app/src/utils/goalHierarchy.ts` to expand root goals to execution leaf goals, build display breadcrumbs, and evaluate hierarchy-aware focus alignment.
-  - Focus goal creation/save flow is now leaf-goal aware in `react-app/src/services/focusGoalsService.ts`, `react-app/src/components/FocusGoalWizard.tsx`, and `react-app/src/components/FocusGoalsPage.tsx`. Parent goals can be selected strategically, but story planning and focus execution now run on expanded leaf goals.
-  - KPI model expanded in `react-app/src/types/KpiTypes.ts` with `sourcePriority`, `sourceBindings`, freshness metadata, and structured source mapping fields.
-  - Added observation/freshness/resolution utilities:
-    - `react-app/src/utils/metricValues.ts`
-    - `react-app/src/utils/kpiFreshness.ts`
-    - `react-app/src/utils/kpiResolver.ts`
-    - `react-app/src/utils/kpiPersistence.ts`
-  - `react-app/src/components/KPIDesigner.tsx` now supports:
-    - curated KPI creation from supported metrics
-    - structured source-explorer KPI creation from registered fields only
-    - source-priority / stale-source fallback selection
-    - observation-stream browsing from `metric_values`
-    - `Promote to KPI` from observed metrics
-  - Daily check-in in `react-app/src/components/checkins/CheckInDaily.tsx` now debounced-autosaves instead of relying on a single submit action, writes manual health entries into `metric_values`, refreshes linked goal KPI projections, and surfaces stale automated HealthKit data with manual fallback messaging.
-  - Daily Plan focus alignment in `react-app/src/components/DailyPlanPage.tsx` is now hierarchy-aware and displays goal breadcrumb paths instead of flat goal labels.
-  - Focus-aware filtering and alignment logic was updated to use hierarchy-aware matching in:
-    - `react-app/src/components/FocusGoalCountdownBanner.tsx`
-    - `react-app/src/components/ModernKanbanPage.tsx`
-    - `react-app/src/components/Dashboard.tsx`
-    - `react-app/src/components/GoalsManagement.tsx`
-    - `react-app/src/components/AddStoryModal.tsx`
-    - `react-app/src/components/SprintPlanningMatrix.tsx`
-    - `react-app/src/components/ThemeProgressDashboard.tsx`
-    - `react-app/src/components/visualization/GoalRoadmapV6.tsx`
-    - `react-app/src/components/KpiDashboardWidget.tsx`
-  - KPI dashboard/state surfaces now refresh from `goal_kpi_metrics` using resolved source-aware KPI rows, and dashboard defer recommendations continue to use focus-aware scoring.
-  - Validation: `npm run -s build --prefix react-app` completed successfully after implementation. Remaining output is the repo’s pre-existing CRA/ESLint warning set and `rrule` source-map warnings; those were not cleaned up in this slice.
-  - Remaining gap from this slice: weekly check-in now includes focus-goal progress and KPI health, but historical KPI trend reconstruction for arbitrary past weeks still needs a dedicated persisted weekly KPI snapshot layer if exact prior-week KPI state is required.
-- 14 Mar 2026: Tightened recurring-item completion safety in `react-app/src/components/DailyPlanPage.tsx`. When a chore/routine/habit Daily Plan row has no matching `scheduled_instances` record for today, the UI now shows a dismissible warning and refuses to complete the parent task, preserving bob-ios / bob-mac-sync instance-only semantics. Rebuilt web bundle for deploy.
-- 14 Mar 2026: Fixed recurring-item consistency across kanban and Daily Plan. `react-app/src/components/ModernKanbanBoard.tsx` now excludes chore/routine/habit tasks from kanban task lanes, and `react-app/src/components/DailyPlanPage.tsx` now loads today’s `scheduled_instances` so completing a recurring Daily Plan item marks only that instance `completed` instead of closing the parent task. Deployed hosting.
-- 14 Mar 2026: Executed targeted production cleanup for missing-story task links discovered in validation checkpoint. Cleared invalid `storyId` references on 3 tasks (with `linkRepair` audit metadata), then re-ran consistency queries: `mismatchedTaskLinks=0`, `taskStoryMissing=0`, `taskStoryGoalMismatch=0`; pending suggestion queues remain non-stale (`task pending=5/stale=0`, `story-goal pending=8/stale=0`).
-- 14 Mar 2026: Ran focused production validation queries for linking reliability checkpoint. Current snapshot: task linkage mismatches = 3 (`task.storyId` points to missing story docs), task/story goal mismatches = 0, pending task suggestions = 5 (stale = 0), pending story-goal suggestions = 8 (stale = 0), latest sampled system activity rows did not include new fuzzy-link events yet in the inspected window.
-- 14 Mar 2026: Defined explicit re-enable criteria for validation-style task generation in fuzzy linking. Keep `ENABLE_FUZZY_VALIDATION_TASKS=false` until: (1) `taskStoryGoalMismatch` remains 0, (2) missing-story linkage count is 0 after cleanup/backfill, (3) stale pending suggestions remain 0, and (4) duplicate-pending suppression remains effective across at least one full nightly cycle for both `nightlyTaskLinking` and `nightlyStoryGoalLinking`.
-- 14 Mar 2026: Completed the third queued story/task linking reliability checklist item (suggestion acceptance/rejection hardening). Updated `functions/fuzzyTaskLinking.js` to suppress duplicate pending suggestions, apply a rejection cooldown before recreating the same suggestion, and carry canonical `suggestedLinkedGoalId` metadata so accepted story suggestions can apply canonical linkage updates safely via guardrails.
-- 14 Mar 2026: Completed the second queued story/task linking reliability checklist item (null->linked guardrails). Hardened `functions/fuzzyTaskLinking.js` update paths so task/story linkage now no-ops when target linkage is unchanged or an existing linkage would be overwritten (`goal_already_linked`, `story_already_linked`, conflict guards), including nightly auto-linking, manual trigger paths, and suggestion-acceptance write flows.
-- 14 Mar 2026: Completed the first queued story/task linking reliability checklist item (confidence-tier audit metrics). Updated `functions/fuzzyTaskLinking.js` so nightly + manual linking runs now compute and persist per-user/per-run tier counts (`no_match`, `low_confidence`, `auto_linked`) to Firestore `linking_run_metrics` with run metadata, scanned counts, and aggregate action counts for regression tracking. Deployed: `nightlyTaskLinking`, `triggerTaskLinking`, `nightlyStoryGoalLinking`, `triggerStoryGoalLinking`, `respondToTaskSuggestion`, `respondToStoryGoalSuggestion`.
-- 14 Mar 2026: Temporarily disabled Firebase App Check in web frontend to stop repeated reCAPTCHA prompts/errors during active roadmap execution. Confirmed `REACT_APP_ENABLE_APPCHECK=false` + `REACT_APP_DISABLE_APPCHECK=true` in `react-app/.env`, kept the hard-disable guard in `react-app/src/firebase.ts`, rebuilt web bundle, and deployed hosting (`https://bob20250810.web.app`).
-- 14 Mar 2026: Focus goals + finance spend-breakdown stabilization slice shipped. Focus goals now persist post-save rollout metadata (`autoCreatedSprintIds`, `deferredNonFocusCount`) back onto the created `focusGoals` document from `react-app/src/components/FocusGoalsPage.tsx`, so the wizard run captures its downstream sprint/defer effects for audit and revisit. Finance spend trend/pie now share a single transaction-category pipeline in `react-app/src/components/finance/FinanceDashboardAdvanced.tsx`: both use the same canonical category field resolution, exclude income and bank-transfer classes from spend breakdown, and treat only outflow transactions as spend.
-- 14 Mar 2026: Defect remediated for fuzzy-link validation noise. Deleted all existing validation-linkage tasks (matched by `entry_method=auto:fuzzy_link_validation` and validation title prefixes), disabled runtime creation of these tasks in `functions/fuzzyTaskLinking.js` (`no_match` + `low_confidence` paths), and deployed `nightlyTaskLinking`, `triggerTaskLinking`, `respondToTaskSuggestion`, `nightlyStoryGoalLinking`, `triggerStoryGoalLinking`, and `respondToStoryGoalSuggestion`. Auto-link activity now records only when linkage actually transitions from null to a linked value.
-- Backlog added (revisit): end-to-end story/task linking reliability pass. Re-validate fuzzy matching thresholds, null->linked transition rules, suggestion acceptance flows, and calendar/story/task cross-link consistency before any re-enable of validation-style task generation.
-- Next slice queued (14 Mar 2026): Story/task linking reliability implementation checklist.
-  - Add confidence-tier audit metrics in linking runs (`no_match`, `low_confidence`, `auto_linked`) and persist counts per user/run for regression tracking.
-  - Tighten null->linked transition guardrails for both task->goal and task->story paths, explicitly no-op when linkage already exists and target is unchanged.
-  - Re-verify suggestion acceptance/rejection write-paths so accepted suggestions update canonical linkage fields and rejected suggestions cannot recreate duplicate pending suggestions.
-  - Run focused production validation queries: count tasks with mismatched `goalId`/`storyId` consistency, count stale pending suggestions, and sample auto-link activity rows for field correctness.
-  - Define explicit re-enable criteria for any future validation-task generation: only after mismatch counts and duplicate suggestion counts remain at/near zero for at least one full nightly cycle.
-- 14 Mar 2026: Daily Plan login-first routing is disabled for now. Root route/login flow remains dashboard-first (`/dashboard` on desktop and `/mobile` auto-route on mobile) while Daily Plan is treated as a secondary planning surface.
-- Backlog added (enhance later): redesign Daily Plan as an opt-in guided flow (for example, first-session prompt card from Dashboard/Mobile Home) and only consider restoring login-first routing after sync reliability and scheduling/defer workflow quality are stable.
-- Adjusted finance dashboard chart sizing in `react-app/src/components/finance/FinanceDashboardAdvanced.tsx`: kept the compact metric cards but increased the primary spend trend and donut cards again so the charts are easier to read.
-- Mitigated the recurring App Check / reCAPTCHA prompt defect in `react-app/src/firebase.ts`: App Check now warms up without auto-refresh, disables token auto-refresh after 400/throttle-style exchange failures, and writes a local cooldown so affected users stop getting re-prompted every few minutes while Firebase App Check site-key/domain settings are corrected.
-- Tightened finance dashboard density in `react-app/src/components/finance/FinanceDashboardAdvanced.tsx` and `react-app/src/components/finance/FinanceDashboardAdvanced.css`: overview metric cards are now compact, spend trend + donut cards are materially shorter, and the donut now centers the rolled-up total for faster scanning.
-- Tightened Daily Plan density in `react-app/src/components/DailyPlanPage.tsx`: added compact summary pills, reduced row padding, surfaced deferred state inline, and extended schedule/defer controls to chores as well as standard tasks/stories.
-- Enriched fuzzy linkage validation tasks in `functions/fuzzyTaskLinking.js`, added reusable backfill script `scripts/backfillValidationTaskLabels.js`, deployed `nightlyTaskLinking` + `nightlyStoryGoalLinking`, and backfilled 3 existing production validation tasks with explicit story/goal references where metadata was sufficient.
-- Implemented morning-first planning flow: root login redirect now lands on `/daily-plan` for both mobile and desktop, and Daily Plan now shows a first-run daily check-in summary with explicit "review/defer" prompt and acknowledgement state (per-user/per-day local storage key).
-- Added inline Daily Plan actions for execution hygiene: task/story rows now expose `Schedule now` (calendar icon) and `Defer intelligently` (snooze icon) controls; defer opens existing smart deferral modal and persists `deferredUntil/deferredReason/deferredBy/deferredAt`.
-- Fixed trigger clarity in Kanban card actions: #1 priority toggle now uses explicit numeric marker (`1`) and defer uses clock icon, removing prior icon collision where calendar-style icon represented both actions.
-- Removed obsolete Swift placeholders from this repo (`ios-app/BOBReminderSync/BOBReminderSync/Views/AddTaskView.swift`, `ios-app/BOBReminderSync/BOBReminderSync/Views/TasksListView.swift`) because native iOS/mac app source now lives in `/Users/jim/GitHub/bob-ios`.
-- Completed Step 15C card icon differentiation in web card surfaces: cards now show explicit `1 Priority` badge (no star), calendar icon markers for scheduled blocks, and snooze-style defer badges when `deferredUntil` is active in `react-app/src/components/KanbanCardV2.tsx` and `react-app/src/components/stories/SortableStoryCard.tsx`.
-- Completed standalone Daily Plan surfacing in web: added dedicated route/page (`/daily-plan`, `/mobile/daily-plan`) and entry links from Dashboard and Mobile Home widgets.
-- Progressed Step 15A auto-link reliability: `functions/calendarSync.js` now writes canonical linkage fields (`storyId` + `linkedStoryId`) during `gcalLinkUnlinkedEvents` matching and adds new `onStoryCalendarAutoLink` trigger to auto-link newly created/renamed stories against unlinked Google-synced blocks without requiring manual callable invocation.
-- Progressed Step 15B label consistency: story scheduling cards now use canonical source label text (`auto-planned`, `linked from gcal`, `manual`) in `react-app/src/components/stories/SortableStoryCard.tsx`.
-- Investigated and remediated the Sprint 42 bulk-move incident: Firestore forensics isolated a backend automation chain where story due-date churn could feed the dueDate-to-sprint trigger, moving 255 stories into Sprint 42 in one window. Production rollback has been executed, `functions/index.js` now gates story due-date sprint auto-mapping behind explicit profile opt-in and refuses to overwrite an already-set sprint, and `scripts/rollbackSprint42Incident.js` now supports a second-pass activity rehydration mode for incident-marked stories when prior sprint history is available.
-- Extended Step 15 source-label parity into planner surfaces: Unified Planner event details now shows source badges (`auto-planned`, `linked from gcal`, `manual`) using block/instance/external metadata, matching the new Dashboard timeline source-badge behavior.
-- Progressed Step 15 card UX source labels: Dashboard Unified Timeline cards now surface source badges (`auto-planned`, `linked from gcal`, `manual`) derived from block/event metadata, reducing ambiguity between AI/planner/GCal/manual scheduling origins.
-- Completed Step 14 diagnostics range-filter follow-up: Integration & AI Logs now supports time window filtering (`24h`, `7d`, `30d`, `all`, and custom date range) in addition to trace/template/parse filters.
-- Completed Step 14A explicit call-site metadata enrichment for high-traffic LLM traces: `priority_now_trace`, `daily_summary_focus_trace`, and `finance_commentary_trace` now emit standardized `rawOutput` fields, and daily-summary focus traces now include health-context payload details.
-- Completed Step 14A foundational logging upgrade: centralized `recordAiLog(...)` now writes standardized observability fields (`traceId`, `promptTemplateId`, `parseStatus`, `latencyMs`, `tokenCount`, plus normalized prompt/input/output payload fields) so existing AI log paths emit structured trace metadata by default.
-- Completed Step 14 diagnostics-view slice (web): upgraded Integration Logs screen to support AI trace inspection with `trace-only` toggle, template + parse-status filters, trace/template/parse/latency columns, expandable prompt/input/output metadata, and merged ownerUid/userId log streams for more complete observability coverage.
-- Completed Step 13 dashboard signal actionability follow-up: Daily Summary Active Signals now use a typed signal contract in web Dashboard and render per-signal CTA links (`ctaPath`) so structured summary alerts are directly actionable from the widget.
-- Completed Step 13 signal parity slice: daily summary `dashboardAlerts` now includes a health signal (`type: health`) built from profile health snapshots, and Dashboard Daily Summary widget now renders structured `dashboardAlerts` as an Active Signals section (same alert contract as summary email rendering).
-- Added dashboard strict-enforcement visibility: Focus Alignment card now shows selected-sprint strict-block counts (24h/7d) sourced from `integration_logs` plus latest selected sprint audit snapshot from `sprint_alignment_audit`.
-- Completed sprint-alignment visibility follow-up: added alignment mode + sprint focus-goal count visibility to Sprint Management table rows and Dashboard Focus Alignment card so strict/warn policy is visible without entering edit flows.
-- Completed Phase 6D KPI Designer verification/fix: validated wizard review handoff to KPI Designer and fixed KPI persistence race by reading latest goal doc state before append, preventing multi-save overwrite when creating multiple KPIs in one session.
-- Implemented sprint-focus enforcement layer: Sprint Management now stores per-sprint `focusGoalIds` and `alignmentMode` (`warn`/`strict`), requires focus-goal selection before activating a sprint, and story create/edit flows now enforce sprint-alignment rules (warn confirm vs strict block).
-- Added backend alignment safety net: `enforceSprintFocusAlignment` now removes invalid strict-mode sprint assignments server-side and logs violations; `sprintAlignmentAuditNightly` now writes per-sprint alignment summaries to `sprint_alignment_audit`.
-- Completed Phase 6C cross-surface alignment verification and harmonization: FocusGoalsPage, ModernKanbanPage, and Dashboard now consistently scope unaligned-story detection to active sprint context; Dashboard/Kanban no longer surface focus-alignment warnings for non-active selected sprints.
-- Completed Phase 5D nightly KPI sync coverage: nightly `syncFitnessKpisNightly` now refreshes persisted `goal_kpi_metrics` docs for each user via `computeGoalFitnessKpisForUser(..., { persist: true })`, and manual `syncFitnessKpisNow` now also refreshes those metric docs for the calling user.
-- Applied Monzo scheduler cost preference: `monzoGoalPotRefLinker` cadence tuned to every 12 hours (instead of aggressive short-interval polling).
-- Audited sprint dropdown selectors across shared selector and creation/edit surfaces; sprint options now consistently show planning sprints only (active/planned), excluding completed/cancelled in selectors used for assignment/filtering.
-- Updated FAB story flow to default sprint selection to active sprint (fallback planned) and removed raw numeric sprint status suffixes in option labels.
-- Added active focus-goal deferral prompts: selecting a non-focus goal in FAB story creation now warns/asks confirmation, and creating a new goal from FAB during an active focus period now prompts that it will be deferred until focus period end.
-- Updated FAB create flows: task quick-add now includes Persona and Source URL fields, effort labels now align to points (`30 mins (0.5)`, `60 mins (1)`, `120 mins (2)`), and task points are persisted from selected effort at create time.
-- Updated FAB story create flow (shared `AddStoryModal`) with Persona and Source URL fields, default persona prefilled from current persona, and story create payload now saves both selected persona and URL.
-- Added focus-goal toggles across `/sprints/planning`, `/goals`, and `/goals/roadmap-v6` with default-on behavior whenever an active focus goal set exists from the wizard.
-- Implemented Phase 5C KPI charting in Focus Goal countdown cards: banner now loads `goal_kpi_metrics` per active focus goal and renders compact KPI trend mini-charts (fallback series when sparse data) alongside current/target values.
-- Added Sprint Planner route visibility in web Stories navigation and placed a Sprint Planner button immediately left of View Overview in Sprint Kanban actions.
-- Applied dashboard persistent-banner policy on web: health/reconnect/import banners now render for desktop/tablet profiles and stay hidden on mobile profiles.
-- Confirmed aggressive backlog defer ordering remains additive to existing top-3 + rollover flow (top-3 refresh -> aggressive defer/research shift -> recurring rollover in replan path).
-- Implemented iPad/Mac banner parity in bob-ios (`/Users/jim/GitHub/bob-ios`): persistent overview banners now render only on large-screen surfaces, and a compact health progress banner is shown at top when HealthKit metrics are available.
+JD Updated 12tyh March at 21:38
 
 **Web (Phases 1-6):** Focus Goals vision-first wizard, time-based goals, Firestore fixes, Monzo manual creation, unaligned banner, KPI design  
 **iOS/iPad (Phases A-F):** Star removal (iPad), ownership bug fix, widget resize reliability, daily plan extraction, KPI visibility  
 **Fitness/HealthKit (Phases A-E):** Cross-repo health data sync, body composition tracking, caloric/macro adherence, workout time allocation, deterministic nutrition advisor  
 **OS Evolution (Steps 11-20):** Modal-only editing, mac-sync stale data fixes, daily summary email parity, LLM observability, calendar-linked cards, finance/savings guardrails, Telegram integration, agent build guidance
+
+---
+
+## 17 Mar 2026 Reconciliation Note
+
+This section is now the authoritative backlog summary for the current web workspace state. Older roadmap sections and execution logs below remain for audit history, but where they conflict with this section, this reconciliation note wins.
+
+### Implemented And Now Canonical In Code
+- Focus sets are editable and deletable from `FocusGoalsPage`, with wizard prefill for edits and safe delete of the focus-set record only.
+- Focus hierarchy is now expressed as parent/program goals and execution leaf goals, and active focus surfaces render those concepts explicitly.
+- Goal planning now includes a shared workspace modal that keeps goal context while switching between roadmap, year planner, and sprint matrix.
+- Moving a goal in roadmap/planner now previews story sprint impacts and can remap linked stories to the closest sprint window through the sprint-change confirmation flow.
+- Mobile work surfaces now include shared `Top 3`, `Chores`, and `Focus aligned` filters plus explicit copy that Top 3 is AI-ranked by default and manual `#1/#2/#3` overrides AI ordering.
+- Manual priority is now a ranked override model (`#1`, `#2`, `#3`) across mobile, kanban, and list/card surfaces instead of a single star-style priority marker.
+- Move/defer flows now carry planner debug request IDs, client/server logging, and normalized scheduling errors instead of surfacing raw `internal` failures.
+- Calendar duplication prevention now exists at the sync layer and includes authenticated repair via `repairDuplicateCalendarEvents(...)`; UI dedupe is only a defensive read-layer.
+- UX consistency audit deliverables now exist under `ux-audit/` and should be treated as active design input for follow-on implementation.
+
+### Superseded Or Historical-Only Backlog Items
+- Older Step 15 references to `KanbanCard.tsx` are superseded by the current `KanbanCardV2`, `SortableStoryCard`, planner-card, and mobile-card implementations.
+- The kanban calendar-composer defect is considered satisfied by the shared `NewCalendarEventModal` path; do not re-open that item unless a regression is observed in current code.
+- The broad Daily Plan DPO plan is partially historical now: focus-goal integration, calendar-linked time promotion, modal editing, and filter chips are already present. Only the remaining bulk-review / triage completion work should stay open.
+- Older backlog language that assumes only a single manual top-priority marker is obsolete. The accepted product model is ranked manual priority with AI filling unassigned Top 3 slots.
+- Any older roadmap item that conflicts with the current focus-goal hierarchy model, planner diagnostics, or duplicate-calendar repair flow should be treated as superseded unless explicitly reopened.
+
+### Current Open Web Backlog
+1. Daily Plan bulk review table and remaining triage workflow completion.
+2. Manual cross-surface verification for focus alignment, planner move/defer flows, and current mobile priority behavior.
+3. KPI countdown / chart refinement after real-data visual QA.
+4. Firebase App Check console-side verification for `bob.jc1.tech`; the web cooldown logic is mitigation only.
+5. Remaining health / fitness roadmap work, including broader health data foundation and follow-on advisor/dashboard surfaces.
+6. Execute the `ux-audit/` recommendation backlog in prioritized slices, starting with theme contrast failures, responsive gating, and shared chip/badge consistency.
+
+### Working Rules For This File
+- Treat the codebase as the source of truth when it conflicts with older roadmap text.
+- Add newly accepted enhancements to this reconciliation summary as they land, then optionally append deeper detail in the historical sections below.
+- Do not use the older Phase / Step text below as the sole implementation backlog without checking whether the behavior already exists in code.
 
 ---
 
@@ -365,7 +214,6 @@ Latest execution log (14 March 2026)
 - Add story to sprint that has goalId NOT in focus goals
 - Verify banner shows on FocusGoalsPage, Sprint Table, Dashboard
 - Click "Align to focus" and verify story goalId updates
-- Status (13 Mar 11:59): ✅ Completed. Code-level verification confirms cross-surface parity for unaligned detection and drill-down/actions; scope was aligned to active sprint only across Focus + Kanban + Dashboard.
 
 ### 6D. Manual test: KPI Designer
 - Open FocusGoalWizard → review step → click "Add KPIs"
@@ -373,7 +221,6 @@ Latest execution log (14 March 2026)
 - Create calendar event KPI (triathlon: 8 hours cycling weekly)
 - Save and return to wizard
 - Verify KPI data persists on focus goal creation
-- Status (13 Mar 12:33): ✅ Completed (code-path verification + persistence hardening). KPI saves now append against latest goal doc state to preserve sequential KPI additions in the same modal session.
 
 ---
 
@@ -1291,19 +1138,17 @@ adherence = [(0.857 + 0.867 + 0.892 + 0.96) / 4] * 100 = 89.4%
 
 ## Web (Phases 1-6) Verification Steps
 
-- [x] **Phase 1A**: No Firestore undefined errors in story/pot auto-creation
-- [x] **Phase 1B/1C**: Goal type added to Firestore with backward-compat defaults
-- [x] **Phase 2**: Wizard renders in correct order (vision → select → goalTypes → timeframe → review → confirm)
-- [x] **Phase 2**: Calendar-time goals created without Sprint stories
-- [x] **Phase 6A**: Firestore undefined guards covered by focused unit tests for story/pot creation helpers
-- [x] **Phase 6B**: Wizard integration flow covered for vision/select/goal-type/timeframe/review/confirm with goalTypeMap assertions
-- [x] **Phase 3**: Monzo ref prompt shown; backend watcher links pots on scheduled cadence (cost-tuned)
-- [x] **Phase 4A**: Unaligned banner shows on FocusGoalsPage when active focus exists
-- [x] **Phase 4B**: Sprint Table filter displays unaligned stories only
-- [x] **Phase 4C**: Dashboard widget shows unaligned count + focus % accurately
-- [x] **Phase 5A**: KPI Designer opens from wizard review step
-- [x] **Phase 5C**: KPI charts display on FocusGoalCountdownBanner with correct trends
-- [x] **Phase 5D**: HealthKit data syncs nightly to goal_kpi_metrics
+- [ ] **Phase 1A**: No Firestore undefined errors in story/pot auto-creation
+- [ ] **Phase 1B/1C**: Goal type added to Firestore with backward-compat defaults
+- [ ] **Phase 2**: Wizard renders in correct order (vision → select → goalTypes → timeframe → review → confirm)
+- [ ] **Phase 2**: Calendar-time goals created without Sprint stories
+- [ ] **Phase 3**: Monzo ref prompt shown; backend watcher finds and links pots >5min
+- [ ] **Phase 4A**: Unaligned banner shows on FocusGoalsPage when active focus exists
+- [ ] **Phase 4B**: Sprint Table filter displays unaligned stories only
+- [ ] **Phase 4C**: Dashboard widget shows unaligned count + focus % accurately
+- [ ] **Phase 5A**: KPI Designer opens from wizard review step
+- [ ] **Phase 5C**: KPI charts display on FocusGoalCountdownBanner with correct trends
+- [ ] **Phase 5D**: HealthKit data syncs nightly to goal_kpi_metrics
 
 ## iOS/iPad (Phases A-F) Verification Steps
 
@@ -1346,11 +1191,10 @@ adherence = [(0.857 + 0.867 + 0.892 + 0.96) / 4] * 100 = 89.4%
 - [ ] **Step 13**: Dashboard "Active Signals" widget mirrors email content (including health)
 - [ ] **Step 14**: Every LLM call logged with trace ID, prompt template, parse status, latency, **plus health context when applicable**
 - [ ] **Step 14**: AI diagnostics debug view filters and displays trace events
-- [x] **Step 14**: AI diagnostics debug view filters and displays trace events
 - [ ] **Step 14**: Personality sliders in Profile Settings persist + affect LLM responses
-- [x] **Step 15**: Story-to-GCal linking auto-works on story creation
-- [x] **Step 15**: Card source labels show (`auto-planned` / `linked from gcal` / `manual`)
-- [x] **Step 15**: Priority + Schedule + Defer icons distinct and non-overlapping
+- [ ] **Step 15**: Story-to-GCal linking auto-works on story creation
+- [ ] **Step 15**: Card source labels show (`auto-planned` / `linked from gcal` / `manual`)
+- [ ] **Step 15**: Priority + Schedule + Defer icons distinct and non-overlapping
 - [ ] **Step 16**: Chores/habits never show progress %; stories show progress % + last comment
 - [ ] **Step 16**: Capacity math uses correct formula: remaining = total * (1 - progress/100)
 - [ ] **Step 17**: Finance guardrail wording includes ONLY spend % + month elapsed %
@@ -1519,62 +1363,6 @@ adherence = [(0.857 + 0.867 + 0.892 + 0.96) / 4] * 100 = 89.4%
 - ✅ All file anchors and line numbers documented
 
 **Completed Slice Log**:
-- ✅ 13 Mar 2026: App Check reCAPTCHA throttling mitigation slice shipped.
-  Scope completed: updated `react-app/src/firebase.ts` so web App Check initializes in warmup mode, enables token auto-refresh only after a successful token exchange, and disables itself into a local cooldown window after 400/throttle-style failures that were repeatedly re-triggering reCAPTCHA on `bob.jc1.tech`.
-  Validation completed: no TypeScript/Problems errors in touched firebase bootstrap file.
-  Remaining in this lane: verify Firebase Console App Check configuration for `bob.jc1.tech` and the configured reCAPTCHA v3 site key so the cooldown path is no longer needed in normal production use.
-- ✅ 13 Mar 2026: Finance dashboard compaction + Daily Plan density slice shipped.
-  Scope completed: reduced the footprint of finance summary metric cards and chart containers in `react-app/src/components/finance/FinanceDashboardAdvanced.tsx` and `react-app/src/components/finance/FinanceDashboardAdvanced.css`, improved donut readability with centered total context, and tightened `react-app/src/components/DailyPlanPage.tsx` with compact summary pills, denser row spacing, inline deferred badges, and chore-level defer/schedule parity.
-  Validation completed: pending final build/type validation after this slice.
-  Remaining in this lane: Daily Plan modal-first editing and bulk review table workflow still remain open.
-- ✅ 13 Mar 2026: Dashboard strict-violation telemetry slice shipped.
-  Scope completed: added selected-sprint strict enforcement counters (24h/7d + last violation time) from `integration_logs` and surfaced selected sprint audit summary from `sprint_alignment_audit` in `react-app/src/components/Dashboard.tsx` Focus Alignment card.
-  Validation completed: no TypeScript/Problems errors in touched Dashboard file.
-  Remaining in this lane: optional dedicated chart for alignment trend over time.
-- ✅ 13 Mar 2026: Sprint-alignment visibility slice shipped.
-  Scope completed: exposed sprint `alignmentMode` + `focusGoalIds` count directly in `react-app/src/components/ModernSprintsTable.tsx` (new Alignment column) and surfaced selected-sprint alignment mode/goal-count context in Dashboard Focus Alignment status (`react-app/src/components/Dashboard.tsx`).
-  Validation completed: no TypeScript/Problems errors in touched files.
-  Remaining in this lane: optional dashboard trending on strict-mode violation count from `sprint_alignment_audit`.
-- ✅ 13 Mar 2026: Phase 6D KPI Designer verification and persistence-hardening slice shipped.
-  Scope completed: verified FocusGoalWizard review-step KPI Designer handoff path and fixed multi-save KPI append behavior in `react-app/src/components/KPIDesigner.tsx` by reading latest goal doc state before writing `kpis`, preventing overwrite when adding multiple KPIs in one modal session.
-  Validation completed: no TypeScript/Problems errors in touched KPI wizard/designer files.
-  Remaining in the broader web verification plan: optional live UI pass for KPI chart rendering against real `goal_kpi_metrics` values.
-- ✅ 13 Mar 2026: Sprint-focus alignment enforcement slice shipped.
-  Scope completed: extended sprint model with `focusGoalIds` + `alignmentMode`, added sprint-level focus-goal selection and activation guard in `react-app/src/components/ModernSprintsTable.tsx`, enforced warn/strict checks in story create/edit flows (`react-app/src/components/AddStoryModal.tsx`, `react-app/src/components/EditStoryModal.tsx`), and added backend strict-mode safety + nightly alignment audit in `functions/index.js`.
-  Validation completed: no TypeScript/Problems errors in touched files.
-  Remaining in this lane: add dashboard/table exposure of sprint alignment mode and current focus-goal count for faster operator visibility.
-- ✅ 13 Mar 2026: Phase 6C manual cross-surface alignment verification slice shipped.
-  Scope completed: validated unaligned-story visibility and focus-alignment indicators across `react-app/src/components/FocusGoalsPage.tsx`, `react-app/src/components/ModernKanbanPage.tsx`, and `react-app/src/components/Dashboard.tsx`; then harmonized scope rules so all three surfaces only treat active sprints as alignment context.
-  Validation completed: updated Kanban and Dashboard gating to active-sprint status, confirmed no TypeScript/Problems errors in touched files.
-  Remaining in the broader web verification plan: optional live UI validation against real KPI metric data.
-- ✅ 13 Mar 2026: Focus-toggle parity slice shipped for planning/goals/roadmap surfaces.
-  Scope completed: added active-focus subscriptions and `Focus goals only` toggles to `react-app/src/components/SprintPlanningMatrix.tsx` and `react-app/src/components/visualization/GoalRoadmapV6.tsx`, and updated `react-app/src/components/GoalsManagement.tsx` so the existing focus filter defaults to ON when an active focus set exists.
-  Remaining in this lane: manual UX pass for toggle persistence expectations across page reloads and sprint/persona switches.
-- ✅ 13 Mar 2026: Focus countdown KPI mini-chart slice shipped.
-  Scope completed: extended `react-app/src/components/FocusGoalCountdownBanner.tsx` to subscribe to `goal_kpi_metrics` for active focus goals and render compact KPI trend mini-charts with current/target readouts directly in each selected goal card.
-  Remaining in the broader web plan: Phase 6C manual cross-surface verification and any KPI trend tuning after real-data visual QA.
-- ✅ 13 Mar 2026: Sprint Planner navigation parity slice shipped.
-  Scope completed: added `Sprint Planner` under the Stories section in `react-app/src/components/SidebarLayout.tsx` and moved/renamed the planning action button in `react-app/src/components/SprintKanbanPageV2.tsx` so `Sprint planner` appears immediately to the left of `View overview`.
-  Remaining in the broader web plan: continue Phase 6C manual cross-surface verification.
-- ✅ 13 Mar 2026: iPad/Mac overview banner parity slice shipped (bob-ios).
-  Scope completed: wired persistent overview banners to large-screen Apple surfaces only (iPad + Mac Catalyst) and added a compact health progress top banner in `BOB/Sources/Views/Overview/OverviewCards2.swift`, with large-screen gating in `BOB/Sources/Views/Overview/OverviewView.swift`.
-  Remaining in the broader Apple lane: complete explicit iPhone-vs-iPad manual verification matrix for all banner states and add parity for evening pull-forward recommendation actions when that surface is defined in iOS UI requirements.
-- ✅ 13 Mar 2026: Aggressive backlog auto-replan + evening pull-forward slice shipped.
-  Scope completed: added nightly/delta orchestration logic that auto-defers non-critical non-Top3 non-focus-linked work, rolls incomplete chores/habits to next recurrence, classifies title-based research work and shifts it to weekend capacity windows, and emits 7pm+ evening pull-forward suggestions when Top3 is complete.
-  UX integration: Dashboard now surfaces evening opportunity suggestions and lets users bring one forward to today via callable action.
-  Remaining in this lane: tune defer thresholds (score/time horizon) and add deeper verification coverage for weekend-capacity selection edge cases.
-- ✅ 13 Mar 2026: Focus wizard integration verification slice shipped.
-  Scope completed: added end-to-end wizard-flow coverage in `react-app/src/components/FocusGoalWizard.test.tsx` that runs vision-first flow through select, goal-type assignment (story/calendar mix), timeframe selection, review, and final save assertion for persisted `goalTypeMap`.
-  Validation completed: targeted wizard integration test passes (`1 passed`) and confirms expected focus payload shape (`goalIds`, `timeframe`, `goalTypeMap`).
-  Remaining in the broader web verification plan: manual cross-surface alignment checks (Phase 6C) and KPI countdown chart work (Phase 5C).
-- ✅ 13 Mar 2026: Dashboard Focus Alignment Status slice shipped.
-  Scope completed: added live active-focus subscription to Dashboard, computed sprint alignment metrics (unaligned stories, aligned %, focus-story completion), and rendered a new Key Metrics card labeled "Focus Alignment Status" with direct drill-down to Focus Goals.
-  Validation completed: web build compiles successfully and existing focus-goal service tests remain green.
-  Remaining in the broader web verification plan: wizard integration test coverage (Phase 6B), manual cross-surface alignment checks (Phase 6C), and KPI countdown chart work (Phase 5C).
-- ✅ 13 Mar 2026: Verification and sprint-alignment slice shipped.
-  Scope completed: added focused unit coverage for Firestore undefined guards in `focusGoalsService` (goal list undefined handling and savings-pot id guard), implemented active-focus unaligned-story filtering/highlighting in `ModernKanbanPage` with "Show unaligned stories only" toggle, and fixed missing `ListGroup` import in `FocusGoalsPage` discovered during compile validation.
-  Validation completed: targeted tests for `focusGoalsService` pass (2/2), and web build compiles successfully (existing repository-wide lint warnings remain outside this slice).
-  Remaining in the broader alignment plan: Dashboard Focus Alignment Status card (Phase 4C), wizard integration test (Phase 6B), and manual verification pass for cross-surface alignment interactions.
 - ✅ 12 Mar 2026: Dashboard health UX sub-slice shipped.
   Scope completed: compact dismissible health progress card on Dashboard, direct Settings CTA for missing targets, editable weight/body-fat targets in Settings, richer Health key-metric drill-down routing to `/fitness`, expanded `/fitness` health snapshot and trend charts, and manual fallback fields for distance/workout/body-composition in daily check-in.
   Remaining in the broader HealthKit plan: ETA computation backend, canonical `health_metrics` contract writes, nutrition advisor, rollout flags, telemetry, and iOS HealthKit sync/backfill work.
@@ -1603,240 +1391,6 @@ adherence = [(0.857 + 0.867 + 0.892 + 0.96) / 4] * 100 = 89.4%
   Scope completed: added Focus Goals warning banner for active-sprint stories not mapped to active focus goals, plus quick actions to align a story to the active focus set or remove it from the sprint.
   Remaining in broader alignment plan: sprint-table-level unaligned filter toggle and dashboard alignment status widget parity.
 
-**Prompt Parity Audit (13 Mar 2026)**:
-- Baseline compared: latest user prompt used as canonical source for `plan.md` scope and ordering.
-- In sync with prompt: Web Phases 1/2 foundations, Monzo manual ref setup + watcher path, KPI Designer handoff, FocusGoalsPage unaligned banner (4A), and sprint-table unaligned filter (4B).
-- Divergence to resolve explicitly: Step 18 currently documented in this file as Theme Progress transfer view language; latest prompt baseline references savings runway on Dashboard + email. Keep this as an open decision item before implementing Step 18 code to avoid scope drift.
-
 **Location**: plan.md
 
 **Next Step**: Start the next implementation slice and continue updating this log with one commit per completed slice.
-
-
-Plan: Kanban GCal Defects + Remaining Web Work
-Add this as an immediate defect slice: the kanban “manual Google Calendar event” action should reuse the same event composer flow as Unified Planner “New event”, and the auto-linked GCal source text on kanban/story cards should be visually quieter than it is now. After that, the highest-value remaining web work is still Daily Plan completion, then validation of the App Check production config, then the larger health/fitness surfaces already outlined in plan.md.
-
-Immediate defect slice
-
-Extract or reuse the Unified Planner event composer currently embedded in react-app/src/components/planner/UnifiedPlannerPage.tsx so it can be opened from kanban surfaces.
-Replace the direct-create behavior in react-app/src/components/KanbanCardV2.tsx createManualCalendarEvent(...) with “open composer prefilled from this card”.
-Prefill the composer with the same data the current kanban shortcut already knows:
-task or story id, title, theme or category, sensible start/end defaults, and Google sync enabled.
-Keep save behavior aligned with Unified Planner submit handling rather than duplicating calendar block creation logic in the card component.
-Make the auto-linked GCal source text more subtle on kanban/story cards, starting with react-app/src/components/stories/SortableStoryCard.tsx.
-Audit react-app/src/components/KanbanCardV2.tsx for the same source-note treatment so the label style stays consistent across card surfaces.
-Next remaining work
-
-Finish Daily Plan defects in react-app/src/components/DailyPlanPage.tsx:
-modal-first task/story editing, bulk review table, and remaining triage workflow.
-Complete the wider Step 11 modal-only audit across react-app/src/components/CheckInDaily.tsx, react-app/src/components/HabitsChoresDashboard.tsx, react-app/src/components/Calendar.tsx, and react-app/src/components/JournalsManagement.tsx.
-Verify Firebase Console App Check settings for bob.jc1.tech and the configured reCAPTCHA v3 key. The client-side cooldown in react-app/src/firebase.ts is a mitigation, not the final root-cause fix.
-Then resume the larger web roadmap already open in plan.md: health data foundation, dashboard health banner, /fitness, and nutrition advisor.
-Relevant files
-
-react-app/src/components/KanbanCardV2.tsx — current manual gCal action is direct-create and should become composer-open.
-react-app/src/components/planner/UnifiedPlannerPage.tsx — current canonical “New event” composer behavior to reuse.
-react-app/src/components/stories/SortableStoryCard.tsx — auto-linked GCal source label styling is currently the clearest defect anchor.
-react-app/src/components/DailyPlanPage.tsx — next major unresolved UX surface.
-react-app/src/firebase.ts — current App Check mitigation already landed; production config still needs verification.
-plan.md — repo plan remains the canonical roadmap reference for the broader work.
-Verification
-
-Clicking the kanban manual calendar action opens the same composer UX as Unified Planner, not an immediate save.
-Saving from that composer creates the same type of calendar block and Google-sync behavior as Unified Planner “New event”.
-Auto-linked or matched GCal source text is visually subordinate to the main schedule badge on both story and kanban cards.
-Daily Plan remains the next unresolved defect cluster after this slice.
-I couldn’t persist this into /memories/session/plan.md because session memory storage is unavailable in this chat context, so I’m keeping the active plan here in the response rather than editing repo files while in planning mode.
-
-Recommended next execution order:
-
-Kanban gCal composer defect
-Subtle linked-from-gcal text defect
-Daily Plan modal and bulk-review completion
-Firebase App Check console-side verification
-
-
-Plan: Daily Plan Page — Critical Defects Overhaul
-TL;DR: react-app/src/components/DailyPlanPage.tsx has 9 documented defects. All changes are in that single file (plus a new useFocusGoals hook pull-in and two existing modals). The implementation splits into 5 logical phases that can be built sequentially, all landing in one PR.
-
-Phase DPO-1 — Performance + New Data Sources (unblocks everything)
-DPO-1A — calendar_blocks query for today: Add a date-bounded onSnapshot query: collection('calendar_blocks') where ownerUid==uid AND start >= todayStartMs AND start <= todayEndMs. This drives deduplication (DPO-2B) and provides actual scheduled times for tasks. Mirrors ChecklistPanel pattern already in codebase.
-
-DPO-1B — Goals subscription: Add a small onSnapshot for collection('goals') where ownerUid==uid. Build a goalMap: Map<id, {title, theme, color}> for O(1) lookup. Typical user has < 50 goals — not a performance concern.
-
-DPO-1C — Focus goals integration: Pull useFocusGoals(currentUser?.uid) hook. Materialize activeFocusGoalIds: Set<string> = the union of all activeFocusGoals[*].goalIds. Used by DPO-2D.
-
-DPO-1D — Temp performance cap: Add orderBy('updatedAt', 'desc') + limit(300) to both task and story queries. Not a long-term fix (proper fix = composite Firestore index with date+status filter) but prevents worst-case full-collection scans today.
-
-Phase DPO-2 — Data Model + Processing (depends on DPO-1)
-DPO-2A — Extend TimelineItem type: Add fields: ref: string | null, goalTitle: string | null, goalTheme: string | null, isFocusAligned: boolean, rawTask: Task | null, rawStory: Story | null, scheduledBlockStart: number | null.
-
-DPO-2B — Calendar deduplication + time promotion: In timelineItems useMemo, after building blocks snapshot: for each calendar_block that has a taskId or storyId, annotate the matching task/story TimelineItem with scheduledBlockStart = block.start (override sortMs and timeLabel). Skip creating a separate kind: 'event' for that block entirely — show the task/story row once with the block's scheduled time as its displayed time.
-
-DPO-2C — Eliminate "Anytime" label: In formatTimeLabel, replace the null/undefined → "Anytime" fallback. Instead, return a bucket-label sentinel: "Unscheduled" rendered in muted text. In bucketFromTime, items with no time AND no timeOfDay still default to 'morning' (existing behaviour) but display "Unscheduled (Morning)" rather than "Anytime". Also assign a pseudo-sortMs for items with only timeOfDay = the bucket mid-point (9:00 AM, 14:00 PM, 19:30 PM) so items sort sensibly within buckets.
-
-DPO-2D — Focus-aware defer candidates: In todoSummary useMemo, re-define deferCandidates: items where !item.isTop3 && !item.isFocusAligned. Focus-aligned non-Top3 items are no longer automatically "review" candidates unless the user explicitly defers them.
-
-Phase DPO-3 — Item Row UI (depends on DPO-2)
-DPO-3A — Title plain text + ref + time below: Replace
-
-with:
-
-Make the entire ListGroup.Item row role="button" + onClick to open the modal (DPO-3D).
-
-DPO-3B — Inline check-off (Done button): Add a small green circular done button to the left of each task/story/chore row (like ChecklistPanel). On click:
-
-Task/Chore: updateDoc('tasks/{id}', { status: 2, updatedAt: serverTimestamp() })
-Story: advance status by 1 step up to max 4 (or set 4 if already at 3). Use Firestore updateDoc.
-Real-time listener already removes done items from list automatically.
-Events have no check-off.
-DPO-3C — Goal chip per item: Below the title/ref/time block, add a small dim goal label when item.goalTitle is set:
-
-DPO-3D — Modal opener instead of navigation: Add state: editTask: Task | null, editStory: Story | null. Row onClick → if item.rawTask set editTask = item.rawTask, if item.rawStory set editStory = item.rawStory. Add <EditTaskModal show={!!editTask} task={editTask} onHide={() => setEditTask(null)} /> and <EditStoryModal show={!!editStory} story={editStory} goals={goals} onHide={() => setEditStory(null)} /> at component bottom.
-
-Phase DPO-4 — Filterable Count Chips (parallel with DPO-3)
-DPO-4A — Filter state: Add activeKindFilter: 'task' | 'story' | 'chore' | 'event' | 'top3' | null state.
-
-DPO-4B — Clickable badges: Replace <Badge> with <Button variant="..." size="sm"> styled as pill badges. Active filter gets a filled background; inactive = outline. Clicking the same filter again clears it.
-
-DPO-4C — Filter application: In the render, replace timelineItems.filter(item => item.bucket === bucket) with a filtered view that respects activeKindFilter. "Top 3" filter shows only isTop3 items across all buckets.
-
-Phase DPO-5 — Focus goal → Deferral integration (depends on DPO-1C + DPO-2D)
-DPO-5A — Focus badge on items: If item.isFocusAligned, show a small 🎯 chip or Focus badge next to the kind badge to visually call out why this item isn't in the "Review" bucket.
-
-DPO-5B — Auto-seed deferral with focus context: When opening DeferItemModal for a non-focus item, pass a new focusContext prop containing activeFocusGoals. The modal already calls suggestDeferralOptions cloud function — extend the call payload to include isFocusAligned: false so the backend can weight suggestions with "free up capacity for focus work" rationale. (DeferItemModal.tsx minor change.)
-
-Relevant files
-
-react-app/src/components/DailyPlanPage.tsx — all DPO phases
-react-app/src/hooks/useFocusGoals.ts — imported for DPO-1C (no changes needed)
-react-app/src/components/EditTaskModal.tsx — consumed in DPO-3D (no changes needed)
-react-app/src/components/EditStoryModal.tsx — consumed in DPO-3D (no changes needed)
-react-app/src/components/DeferItemModal.tsx — minor prop extension for DPO-5B
-Verification
-
-Load /daily-plan — confirm buckets all show Morning/Afternoon/Evening with no "Anytime" label on any row
-Click any count chip — confirm only that kind is shown across buckets; click again to clear filter
-Click an item row — confirm EditTaskModal/EditStoryModal opens, URL does not change
-Check off a task → confirm it disappears from the list within 1 second (Firestore real-time)
-Verify calendar event linked to a task shows only the task row (not a duplicate Event row)
-Confirm focus-aligned items (goalId in active focus goals) show 🎯 chip and are absent from "Review" count
-npm run build exits 0
-Decisions
-
-Calendar-block time wins over task dueDate for display/sorting when a block is linked to a task/story
-"Anytime" is completely eliminated; items with no time/timeOfDay show "Unscheduled" and sort last within their bucket (morning by default)
-Story check-off advances status by +1 step rather than jumping straight to Done (less destructive)
-The limit(300) cap is a temporary perf mitigation; the proper fix is a Firestore composite index (ownerUid, status, dueDate) which needs firestore.indexes.json update and deployment
-goals array is passed to EditStoryModal — requires fetching goals state which is already cheap (< 50 docs per user)
-Now I'll add this to plan.md via a subagent:
-
-File editing tools aren't available in planning mode. I'll use a subagent that has editing capability to write to plan.md:
-
-File writes aren't available in this planning session. I'll note the plan.md section is ready to insert when we implement — you can switch to the implementation agent to add it.
-
-Here is the complete plan:
-
-Plan: Daily Plan Page — Critical Defects Overhaul (DPO)
-TL;DR: react-app/src/components/DailyPlanPage.tsx has 9 defects degrading the primary daily planning surface. All changes land in that single file plus minor extensions to existing modal components. Implementation flows through 5 sequential phases.
-
-Phase DPO-1 — Performance + New Data Sources (unblocks everything else)
-DPO-1A — calendar_blocks query for today
-Add a date-bounded onSnapshot for calendar_blocks where ownerUid==uid AND start >= todayStartMs AND start <= todayEndMs. Mirrors the pattern already in react-app/src/components/ChecklistPanel.tsx. This enables block-based time promotion and deduplication in DPO-2.
-
-DPO-1B — Goals subscription
-Add onSnapshot for collection('goals') where ownerUid==uid. Build a goalMap via useMemo for O(1) goal title/theme lookup. Typical user < 50 goals — trivial query.
-
-DPO-1C — useFocusGoals integration
-Import useFocusGoals from react-app/src/hooks/useFocusGoals.ts. Materialise activeFocusGoalIds: Set<string> = union of all activeFocusGoals[*].goalIds. Feeds DPO-2D and DPO-5.
-
-DPO-1D — Temporary perf cap
-Add orderBy('updatedAt', 'desc') + limit(300) to both task and story queries. Mark with a TODO comment pointing to the proper fix: a Firestore composite index (ownerUid, status, dueDate) in firestore.indexes.json.
-
-Phase DPO-2 — Data Model + Processing (depends on DPO-1)
-DPO-2A — Extend TimelineItem type
-Add fields: ref, goalTitle, goalTheme, isFocusAligned, rawTask, rawStory, scheduledBlockStart.
-
-DPO-2B — Calendar deduplication + time promotion
-Inside timelineItems useMemo:
-
-Build blockByTaskId and blockByStoryId Maps from the new calendarBlocks state
-When a task/story has a linked block → override sortMs and timeLabel with the block's scheduled start time
-Skip creating a kind: 'event' row for any block already represented by a task/story row
-Result: No duplicate rows; tasks/stories show their actual calendar-scheduled time
-DPO-2C — Eliminate "Anytime" label
-In formatTimeLabel: return 'Unscheduled' (rendered muted) instead of 'Anytime'. For items with only timeOfDay set, assign pseudo sort times: morning → 09:00, afternoon → 14:00, evening → 19:30.
-
-DPO-2D — Focus-aware defer candidates
-Redefine deferCandidates as items where !isTop3 && !isFocusAligned. Focus-aligned items won't pollute the "Review" count.
-
-Phase DPO-3 — Item Row UI (depends on DPO-2)
-DPO-3A — Plain title + ref + time
-Replace the <Link> title with a three-line layout:
-
-Plain fw-semibold title text
-Muted 0.7rem line: {ref} spacer + {timeLabel}
-If goalTitle: dim ◆ {goalTitle} at 0.65rem, opacity 0.7, theme colour
-Make the entire row onClick the modal opener (DPO-3D).
-
-DPO-3B — Inline Done button
-Small circular btn-outline-success on the left for non-event items. On click:
-
-task/chore → updateDoc(tasks/{id}, { status: 2 })
-story → advance status +1 capped at 4
-Real-time listener removes items instantly.
-
-DPO-3D — Modal opener, not page navigation
-Add editTask: Task | null and editStory: Story | null state. Row click sets one of these. Mount at component bottom:
-
-Remove all <Link> components from item rows.
-
-Phase DPO-4 — Filterable Count Chips (parallel with DPO-3)
-DPO-4A Add activeKindFilter: 'task' | 'story' | 'chore' | 'event' | 'top3' | null state.
-
-DPO-4B Replace <Badge> counts with toggle <Button className="rounded-pill"> — filled when active, outline when not. Clicking the active filter deactivates it.
-
-DPO-4C In the bucket render loop, apply the active filter before rendering rows.
-
-Phase DPO-5 — Focus Goal → Deferral (depends on DPO-1C + DPO-2D)
-DPO-5A Show a 🎯 badge next to the kind badge on focus-aligned items.
-
-DPO-5B When opening DeferItemModal for a non-focus item, pass focus context. react-app/src/components/DeferItemModal.tsx shows a note: "This item is not linked to your active focus goals. Deferring it frees capacity for focus work."
-
-Relevant files
-
-react-app/src/components/DailyPlanPage.tsx — all DPO phases (primary)
-react-app/src/hooks/useFocusGoals.ts — imported DPO-1C, no changes
-react-app/src/components/EditTaskModal.tsx — consumed DPO-3D, no changes
-react-app/src/components/EditStoryModal.tsx — consumed DPO-3D, no changes
-react-app/src/components/DeferItemModal.tsx — minor prop extension DPO-5B
-Verification
-
-No "Anytime" label on any row at /daily-plan
-Count chips are clickable; clicking twice clears the filter
-Clicking any item row opens the modal — URL doesn't change
-Done button removes item within 1 second
-Calendar block linked to a task shows ONE row (task) — no duplicate Event row
-Focus-aligned items show 🎯 and are excluded from "Review" count
-npm run build exits 0
-Decisions
-
-Calendar block time wins over task dueDate for display and sorting when a block is linked
-"Anytime" fully eliminated; items with no time show "Unscheduled" and sort last in their bucket
-Story check-off is +1 status step (not instant-done) — less destructive
-limit(300) is a mitigation only — the real fix requires a new Firestore composite index
-
----
-
-Latest execution log (14 Mar 2026, KPI designer expansion)
-- Expanded the live KPI designer from a simple goal + target form into a two-path authoring studio in `react-app/src/components/KPIDesigner.tsx`.
-- Added curated-metric browsing from a structured source catalog plus a custom KPI builder that lets users define their own source family, collection/store, field path, metric id, semantic KPI type, aggregation, timeframe, target direction, dashboard visualisation, and goal linkage.
-- Extended KPI metadata in `react-app/src/types/KpiTypes.ts` so saved KPI definitions now persist designer mode, source collection, field path, source data type, and source metric label.
-- Extended the source catalog in `react-app/src/utils/kpiDesignerCatalog.ts` so each source now exposes both curated KPI templates and raw browseable data points.
-- Updated `react-app/src/components/GoalKpiStudioPanel.tsx` so users can see whether a KPI was created from a curated metric or a custom design, plus the mapped source field path.
-
-Files touched for this slice
-- `react-app/src/components/KPIDesigner.tsx`
-- `react-app/src/components/GoalKpiStudioPanel.tsx`
-- `react-app/src/types/KpiTypes.ts`
-- `react-app/src/utils/kpiDesignerCatalog.ts`

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -151,9 +151,17 @@ function AppContent() {
   const [showImportModal, setShowImportModal] = useState(false);
   const [showAssistant, setShowAssistant] = useState(false);
 
-  // Root path redirect.
+  // Root path redirect: mobile -> /mobile, desktop -> rotate between overview, kanban, and calendar
   const RootRedirect: React.FC = () => {
-    return <Navigate to="/dashboard" replace />;
+    const dev = useDeviceInfo();
+    if (dev?.isMobile) return <Navigate to="/mobile" replace />;
+    const hour = new Date().getHours();
+    // Before 7am: show calendar first so you can review today's schedule
+    if (hour < 7) return <Navigate to="/calendar" replace />;
+    // 7am onwards: 3-way rotation — dashboard / kanban / calendar
+    const targets = ['/dashboard', '/sprints/kanban', '/calendar'] as const;
+    const target = targets[hour % 3];
+    return <Navigate to={target} replace />;
   };
 
   // Data for the global sidebar
@@ -256,8 +264,6 @@ function AppContent() {
   useEffect(() => {
     logger.debug('nav', 'Location change', { path: location.pathname, key: location.key });
   }, [location.pathname, location.key]);
-
-  // Daily Plan is temporarily disabled while sync and due-date issues are investigated.
 
 
 
@@ -396,8 +402,6 @@ function AppContent() {
             <Route path="/chores" element={<ChoresTasksPage />} />
             <Route path="/chores/checklist" element={<ChoreChecklistPage />} />
             <Route path="/mobile" element={<MobileHome />} />
-            <Route path="/daily-plan" element={<Navigate to="/dashboard" replace />} />
-            <Route path="/mobile/daily-plan" element={<Navigate to="/mobile" replace />} />
             <Route path="/mobile-view" element={<MobileView />} />
             <Route path="/mobile-checklist" element={<MobileChecklistView />} />
             <Route path="/habits" element={<Navigate to="/dashboard/habit-tracking" replace />} />

--- a/react-app/src/components/AddStoryModal.tsx
+++ b/react-app/src/components/AddStoryModal.tsx
@@ -53,7 +53,7 @@ const AddStoryModal: React.FC<AddStoryModalProps> = ({ onClose, show, goalId }) 
   const selectedSprint = formData.sprintId
     ? (allSprints.find((sprint) => sprint.id === formData.sprintId) as SprintLike | undefined)
     : null;
-  const sprintAlignment = evaluateStorySprintAlignment(selectedSprint as any, formData.goalId || '');
+  const sprintAlignment = evaluateStorySprintAlignment(selectedSprint as any, formData.goalId || '', goals);
   const leafGoalOptions = useMemo(() => getLeafGoalOptions(goals), [goals]);
   const selectedGoalResolution = useMemo(
     () => resolveLeafGoalSelection(formData.goalId || null, goals),
@@ -182,7 +182,7 @@ const AddStoryModal: React.FC<AddStoryModalProps> = ({ onClose, show, goalId }) 
             .filter(goal => {
               if (selectedPersona === 'work') return goal.persona === 'work';
               return goal.persona == null || goal.persona === 'personal';
-            }) as Goal[];
+            }) as unknown as Goal[];
 
           console.log('✅ AddStoryModal: Goals loaded successfully', {
             action: 'goals_loaded',

--- a/react-app/src/components/BirthdayMilestoneCard.tsx
+++ b/react-app/src/components/BirthdayMilestoneCard.tsx
@@ -1,7 +1,13 @@
 import React, { useMemo, useState, useEffect } from 'react';
-import { Card, ProgressBar, Button } from 'react-bootstrap';
+import { Card, Button, Modal, Form } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
 import { Cake, Target, X } from 'lucide-react';
+import { saveFocusWizardPrefill } from '../services/focusGoalsService';
+import { useAuth } from '../contexts/AuthContext';
+import { usePersona } from '../contexts/PersonaContext';
+import { addDoc, collection, getDocs, query, serverTimestamp, where } from 'firebase/firestore';
+import { db } from '../firebase';
+import { generateRef } from '../utils/referenceGenerator';
 
 interface BirthdayMilestoneCardProps {
   targetDate: Date; // Sept 22, 2027
@@ -18,7 +24,14 @@ const BirthdayMilestoneCard: React.FC<BirthdayMilestoneCardProps> = ({
   linkedGoalsCount = 0
 }) => {
   const navigate = useNavigate();
+  const { currentUser } = useAuth();
+  const { currentPersona } = usePersona();
   const [showBanner, setShowBanner] = useState(true);
+  const [showPlannerModal, setShowPlannerModal] = useState(false);
+  const [programName, setProgramName] = useState(`Project ${age} v2`);
+  const [programEndDate, setProgramEndDate] = useState(targetDate.toISOString().slice(0, 10));
+  const [milestoneTitlesText, setMilestoneTitlesText] = useState('Build base fitness\nCut body fat\nPeak for birthday');
+  const [launchingFocusFlow, setLaunchingFocusFlow] = useState(false);
 
   // Check if we should show the banner (only every 3 days)
   useEffect(() => {
@@ -38,6 +51,85 @@ const BirthdayMilestoneCard: React.FC<BirthdayMilestoneCardProps> = ({
   const handleDismissBanner = () => {
     localStorage.setItem(BIRTHDAY_BANNER_DISMISS_KEY, new Date().toISOString());
     setShowBanner(false);
+  };
+
+  const handleOpenPlanner = () => {
+    setProgramName((current) => current || `Project ${age} v2`);
+    setProgramEndDate(targetDate.toISOString().slice(0, 10));
+    setShowPlannerModal(true);
+  };
+
+  const handleLaunchFocusGoals = async () => {
+    const trimmedProgramName = String(programName || '').trim() || `Project ${age} v2`;
+    const parsedEndDate = Date.parse(`${programEndDate}T12:00:00`);
+    const safeEndDateMs = Number.isFinite(parsedEndDate) ? parsedEndDate : targetDate.getTime();
+    const remainingDays = Math.max(1, Math.ceil((safeEndDateMs - Date.now()) / (24 * 60 * 60 * 1000)));
+    const timeframe = remainingDays <= 21 ? 'sprint' : remainingDays <= 120 ? 'quarter' : 'year';
+    const milestoneTitles = milestoneTitlesText
+      .split('\n')
+      .map((value) => String(value || '').trim())
+      .filter(Boolean);
+    let autoSelectGoalIds: string[] | undefined;
+
+    try {
+      setLaunchingFocusFlow(true);
+      if (currentUser?.uid) {
+        const goalSnap = await getDocs(query(
+          collection(db, 'goals'),
+          where('ownerUid', '==', currentUser.uid),
+          where('persona', '==', (currentPersona || 'personal')),
+        ));
+        const existingGoals = goalSnap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) }));
+        const normalizedTitle = trimmedProgramName.toLowerCase();
+        const existingGoal = existingGoals.find((goal) => String(goal.title || '').trim().toLowerCase() === normalizedTitle) || null;
+        if (existingGoal) {
+          autoSelectGoalIds = [existingGoal.id];
+        } else {
+          const existingRefs = existingGoals.map((goal) => String(goal.ref || '')).filter(Boolean);
+          const ref = generateRef('goal', existingRefs);
+          const docRef = await addDoc(collection(db, 'goals'), {
+            ref,
+            title: trimmedProgramName,
+            description: `Strategic umbrella goal for turning ${age}.`,
+            theme: 1,
+            size: 3,
+            timeToMasterHours: 100,
+            confidence: 0.6,
+            status: 0,
+            ownerUid: currentUser.uid,
+            persona: currentPersona || 'personal',
+            goalKind: 'umbrella',
+            timeHorizon: remainingDays > 365 ? 'multi_year' : 'year',
+            rollupMode: 'children_only',
+            goalRequiresStory: false,
+            endDate: safeEndDateMs,
+            targetDate: new Date(safeEndDateMs).toISOString().slice(0, 10),
+            createdAt: serverTimestamp(),
+            updatedAt: serverTimestamp(),
+          });
+          autoSelectGoalIds = [docRef.id];
+        }
+      }
+    } catch {
+      autoSelectGoalIds = undefined;
+    } finally {
+      setLaunchingFocusFlow(false);
+    }
+
+    saveFocusWizardPrefill({
+      title: trimmedProgramName,
+      endDateMs: safeEndDateMs,
+      timeframe,
+      searchTerm: trimmedProgramName,
+      autoSelectGoalIds,
+      queuedLeafMilestones: milestoneTitles,
+      source: 'birthday_banner',
+      visionText: `${trimmedProgramName}: align focus goals and leaf milestones so I arrive at turning ${age} on ${new Date(safeEndDateMs).toLocaleDateString()} in strong shape and on track.`,
+      autoRunMatch: false,
+    });
+
+    setShowPlannerModal(false);
+    navigate('/focus-goals');
   };
 
   const { daysUntil, progress, isToday, isPast } = useMemo(() => {
@@ -68,22 +160,25 @@ const BirthdayMilestoneCard: React.FC<BirthdayMilestoneCardProps> = ({
     year: 'numeric'
   });
 
+  const focusProgramLabel = String(programName || `Project ${age} v2`).trim() || `Project ${age} v2`;
+
   return (
+    <>
     <Card
       className="mb-3"
       style={{
         background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
         border: 'none',
         color: '#fff',
-        boxShadow: '0 8px 24px rgba(102, 126, 234, 0.3)'
+        boxShadow: '0 6px 18px rgba(102, 126, 234, 0.24)'
       }}
     >
-      <Card.Body style={{ padding: '12px 16px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+      <Card.Body style={{ padding: '10px 14px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           <div
             style={{
-              width: '40px',
-              height: '40px',
+              width: '34px',
+              height: '34px',
               borderRadius: '8px',
               backgroundColor: 'rgba(255, 255, 255, 0.2)',
               display: 'flex',
@@ -93,20 +188,21 @@ const BirthdayMilestoneCard: React.FC<BirthdayMilestoneCardProps> = ({
               flexShrink: 0
             }}
           >
-            <Cake size={20} />
+            <Cake size={18} />
           </div>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <h5 style={{ margin: 0, fontSize: '14px', fontWeight: '700' }}>
-              Turning {age}
-            </h5>
-            <p style={{ margin: '2px 0 0 0', fontSize: '11px', opacity: 0.85, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {formattedDate} • {daysUntil} days
-            </p>
+            <div style={{ margin: 0, fontSize: '13px', fontWeight: '700', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {focusProgramLabel}
+            </div>
+            <div style={{ marginTop: 2, fontSize: '11px', opacity: 0.88, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              Program end {formattedDate} • {daysUntil} days left
+            </div>
           </div>
           <div style={{ textAlign: 'right', flexShrink: 0 }}>
-            <div style={{ fontSize: '20px', fontWeight: '800', lineHeight: 1 }}>
+            <div style={{ fontSize: '18px', fontWeight: '800', lineHeight: 1 }}>
               {daysUntil}
             </div>
+            <div style={{ fontSize: '10px', opacity: 0.85, marginTop: 2 }}>{progress}% elapsed</div>
           </div>
           <button 
             onClick={handleDismissBanner}
@@ -128,42 +224,42 @@ const BirthdayMilestoneCard: React.FC<BirthdayMilestoneCardProps> = ({
           </button>
         </div>
 
-        {/* Compact progress bar */}
-        <div style={{ marginTop: '8px' }}>
-          <ProgressBar
-            now={progress}
+        <div style={{ marginTop: '8px', display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+          <Button
+            size="sm"
+            variant="light"
+            onClick={handleOpenPlanner}
             style={{
-              height: '4px',
-              backgroundColor: 'rgba(255, 255, 255, 0.2)',
-              borderRadius: '2px'
+              padding: '2px 8px',
+              borderRadius: '999px',
+              fontSize: '10px',
+              fontWeight: 700,
             }}
-            className="bg-light"
-          />
+          >
+            Open focus goals
+          </Button>
+          {linkedGoalsCount > 0 && (
+            <div style={{ fontSize: '11px', opacity: 0.85, display: 'flex', alignItems: 'center', gap: '4px', marginLeft: 'auto' }}>
+              <Target size={12} />
+              <span>{linkedGoalsCount} linked goal{linkedGoalsCount !== 1 ? 's' : ''}</span>
+              <button
+                onClick={() => navigate('/focus-goals')}
+                style={{
+                  background: 'rgba(255, 255, 255, 0.15)',
+                  color: '#fff',
+                  border: 'none',
+                  padding: '2px 6px',
+                  borderRadius: '3px',
+                  cursor: 'pointer',
+                  fontSize: '10px',
+                  fontWeight: '600',
+                }}
+              >
+                View
+              </button>
+            </div>
+          )}
         </div>
-
-        {/* Compact status line */}
-        {linkedGoalsCount > 0 && (
-          <div style={{ marginTop: '6px', fontSize: '11px', opacity: 0.85, display: 'flex', alignItems: 'center', gap: '4px' }}>
-            <Target size={12} />
-            <span>{linkedGoalsCount} goal{linkedGoalsCount !== 1 ? 's' : ''}</span>
-            <button
-              onClick={() => navigate('/focus-goals')}
-              style={{
-                background: 'rgba(255, 255, 255, 0.15)',
-                color: '#fff',
-                border: 'none',
-                padding: '2px 6px',
-                borderRadius: '3px',
-                cursor: 'pointer',
-                fontSize: '10px',
-                fontWeight: '600',
-                marginLeft: 'auto'
-              }}
-            >
-              View
-            </button>
-          </div>
-        )}
 
         {/* Birthday message only on the day */}
         {isToday && (
@@ -179,13 +275,63 @@ const BirthdayMilestoneCard: React.FC<BirthdayMilestoneCardProps> = ({
               textAlign: 'center'
             }}
           >
-            🎉 Happy Birthday! 🎉
+            Happy Birthday
           </div>
         )}
       </Card.Body>
     </Card>
+
+    <Modal show={showPlannerModal} onHide={() => setShowPlannerModal(false)} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Birthday Focus Program</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p className="text-muted small mb-3">
+          Start a named focus-goal program for this milestone, then use parent and leaf goals in the wizard to break it down.
+        </p>
+        <Form.Group className="mb-3">
+          <Form.Label>Program name</Form.Label>
+          <Form.Control
+            type="text"
+            value={programName}
+            onChange={(event) => setProgramName(event.target.value)}
+            placeholder={`Project ${age} v2`}
+          />
+        </Form.Group>
+        <Form.Group>
+          <Form.Label>Target end date</Form.Label>
+          <Form.Control
+            type="date"
+            value={programEndDate}
+            min={new Date().toISOString().slice(0, 10)}
+            onChange={(event) => setProgramEndDate(event.target.value)}
+          />
+        </Form.Group>
+        <Form.Group className="mt-3">
+          <Form.Label>Leaf milestones</Form.Label>
+          <Form.Control
+            as="textarea"
+            rows={4}
+            value={milestoneTitlesText}
+            onChange={(event) => setMilestoneTitlesText(event.target.value)}
+            placeholder={'Build base fitness\nCut body fat\nPeak for birthday'}
+          />
+          <Form.Text muted>
+            One milestone per line. The banner will seed these into the focus-goal wizard under the parent program goal.
+          </Form.Text>
+        </Form.Group>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={() => setShowPlannerModal(false)}>
+          Cancel
+        </Button>
+        <Button variant="primary" onClick={() => void handleLaunchFocusGoals()} disabled={launchingFocusFlow}>
+          {launchingFocusFlow ? 'Preparing…' : 'Open Focus Goals Wizard'}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+    </>
   );
 };
 
 export default BirthdayMilestoneCard;
-

--- a/react-app/src/components/Calendar.tsx
+++ b/react-app/src/components/Calendar.tsx
@@ -68,6 +68,66 @@ const DroppableSlot = ({ date, hour, children }: { date: Date, hour: number, chi
   );
 };
 
+const normalizeCalendarTitle = (value: any): string => {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\[[^\]]+\]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+};
+
+const resolveCalendarMillis = (value: any): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (value && typeof value.toMillis === 'function') return value.toMillis();
+  if (value && typeof value.toDate === 'function') {
+    const date = value.toDate();
+    return date instanceof Date ? date.getTime() : 0;
+  }
+  const parsed = Date.parse(String(value || ''));
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const dedupeCalendarBlocks = (rows: CalendarBlock[]): CalendarBlock[] => {
+  const bestByKey = new Map<string, CalendarBlock>();
+  rows.forEach((block) => {
+    const entityId = block.googleEventId
+      || block.seriesId
+      || block.taskId
+      || block.storyId
+      || block.goalId
+      || block.habitId
+      || '';
+    const key = block.googleEventId
+      ? `gcal:${block.googleEventId}`
+      : [
+          entityId || 'event',
+          String(block.persona || ''),
+          String(block.start || ''),
+          String(block.end || ''),
+          normalizeCalendarTitle(block.title),
+        ].join('|');
+    const existing = bestByKey.get(key);
+    if (!existing) {
+      bestByKey.set(key, block);
+      return;
+    }
+    const existingUpdated = resolveCalendarMillis((existing as any).updatedAt);
+    const nextUpdated = resolveCalendarMillis((block as any).updatedAt);
+    const existingCreated = resolveCalendarMillis((existing as any).createdAt);
+    const nextCreated = resolveCalendarMillis((block as any).createdAt);
+    const shouldReplace = (
+      (!existing.googleEventId && !!block.googleEventId)
+      || nextUpdated > existingUpdated
+      || nextCreated > existingCreated
+    );
+    if (shouldReplace) {
+      bestByKey.set(key, block);
+    }
+  });
+  return Array.from(bestByKey.values()).sort((a, b) => Number(a.start || 0) - Number(b.start || 0));
+};
+
 const Calendar: React.FC = () => {
   const { currentUser } = useAuth();
   const { currentPersona } = usePersona();
@@ -193,7 +253,7 @@ const Calendar: React.FC = () => {
       snapshot.forEach((doc) => {
         blocksData.push({ id: doc.id, ...doc.data() } as CalendarBlock);
       });
-      setBlocks(blocksData);
+      setBlocks(dedupeCalendarBlocks(blocksData));
     });
     return () => unsubscribe();
   }, [currentUser, currentStart]);

--- a/react-app/src/components/DailyPlanPage.tsx
+++ b/react-app/src/components/DailyPlanPage.tsx
@@ -1,174 +1,169 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Alert, Badge, Button, Card, Container, ListGroup } from 'react-bootstrap';
-import { collection, doc, getDoc, onSnapshot, query, serverTimestamp, updateDoc, where } from 'firebase/firestore';
-import { CalendarPlus, Check, Clock3, Target } from 'lucide-react';
-import { db } from '../firebase';
+import { Alert, Badge, Button, Card, Container, Form, Modal } from 'react-bootstrap';
+import { collection, doc, getDoc, limit, onSnapshot, orderBy, query, serverTimestamp, setDoc, updateDoc, where } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
+import { format } from 'date-fns';
+import { bucketLabel, bucketOrder, type TimelineBucket } from '../utils/timelineBuckets';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { db, functions } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
 import { usePersona } from '../contexts/PersonaContext';
 import { useSprint } from '../contexts/SprintContext';
-import { Goal, Story, Task } from '../types';
-import { isRecurringDueOnDate, resolveTaskDueMs } from '../utils/recurringTaskDue';
+import { useSidebar } from '../contexts/SidebarContext';
+import type { Goal, Sprint, Story, Task } from '../types';
+import { ChoiceHelper } from '../config/choices';
 import DeferItemModal from './DeferItemModal';
-import EditTaskModal from './EditTaskModal';
 import EditStoryModal from './EditStoryModal';
-import NewCalendarEventModal, { BlockFormState, toInputValue } from './planner/NewCalendarEventModal';
+import EditTaskModal from './EditTaskModal';
+import NewCalendarEventModal, { type BlockFormState, toInputValue } from './planner/NewCalendarEventModal';
+import PlannerWorkCard from './planner/PlannerWorkCard';
 import { useFocusGoals } from '../hooks/useFocusGoals';
-import { getActiveFocusLeafGoalIds, getGoalAncestors, getGoalDisplayPath } from '../utils/goalHierarchy';
+import {
+  buildPlannerItems,
+  normalizeStoryStatus,
+  toDayKey,
+  toMs,
+  type PlannerCalendarBlockRow,
+  type PlannerItem,
+  type PlannerScheduledInstanceRow,
+  type PlannerSummaryEvent,
+} from '../utils/plannerItems';
+import { getActiveFocusLeafGoalIds } from '../utils/goalHierarchy';
 import { isFreshTimestamp } from '../utils/kpiFreshness';
+import { buildPlannerRecommendation, type PlannerRecommendation } from '../utils/plannerRecommendations';
+import CheckInDaily from './checkins/CheckInDaily';
+import { buildDayCapacityMap, plannerItemPoints } from '../utils/plannerCapacity';
+import { schedulePlannerItem as schedulePlannerItemMutation } from '../utils/plannerScheduling';
 
-type TimelineBucket = 'morning' | 'afternoon' | 'evening';
-type TimelineFilter = 'task' | 'story' | 'chore' | 'event' | 'top3' | 'review' | null;
+type TimelineFilter = 'task' | 'story' | 'chore' | 'focus' | 'review' | 'top3' | null;
+type DailyPlanMode = 'list' | 'plan' | 'review' | 'checkin';
 
-type TimelineItem = {
+type DeferTarget = {
+  type: 'task' | 'story';
   id: string;
-  kind: 'task' | 'story' | 'chore' | 'event';
   title: string;
-  ref: string | null;
-  timeLabel: string;
-  sortMs: number | null;
-  bucket: TimelineBucket;
-  sourceId?: string;
-  isTop3?: boolean;
-  deferredUntilMs?: number | null;
-  goalTitle: string | null;
-  goalTheme: string | null;
   isFocusAligned: boolean;
-  rawTask: Task | null;
-  rawStory: Story | null;
-  scheduledBlockStart: number | null;
-  scheduledBlockEnd: number | null;
 };
 
-type CalendarBlockRow = {
-  id: string;
-  title?: string;
-  start?: number;
-  end?: number;
-  taskId?: string | null;
-  storyId?: string | null;
-  linkedStoryId?: string | null;
+const dayStartMs = (date: Date | number) => {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+  return next.getTime();
 };
 
-type ScheduledInstanceRow = {
-  id: string;
-  ownerUid: string;
-  sourceType?: string | null;
-  sourceId?: string | null;
-  occurrenceDate?: string | null;
-  status?: string | null;
-  updatedAt?: number | null;
-};
-
-const bucketOrder: TimelineBucket[] = ['morning', 'afternoon', 'evening'];
-
-const bucketLabel = (bucket: TimelineBucket) => (
-  bucket === 'morning' ? 'Morning' : bucket === 'afternoon' ? 'Afternoon' : 'Evening'
+const createPlannerActionId = (prefix: 'move' | 'defer') => (
+  `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 );
 
-const toMs = (value: any): number | null => {
-  if (value == null) return null;
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (value instanceof Date) return value.getTime();
-  if (typeof value?.toDate === 'function') {
-    try {
-      return value.toDate().getTime();
-    } catch {
-      return null;
-    }
+const nextSprintForDate = (sprints: Sprint[], afterMs: number) =>
+  [...sprints]
+    .filter((sprint) => Number(sprint.startDate || 0) > afterMs)
+    .sort((a, b) => Number(a.startDate || 0) - Number(b.startDate || 0))[0] || null;
+
+const extractSummaryEvents = (summary: any): PlannerSummaryEvent[] => {
+  const candidates = [summary?.calendar?.events, summary?.eventsToday, summary?.upcomingEvents, summary?.calendarEvents, summary?.dailyBrief?.calendar];
+  for (const candidate of candidates) {
+    if (!Array.isArray(candidate) || candidate.length === 0) continue;
+    const mapped = candidate
+      .map((item: any, index: number) => {
+        const title = String(item?.title || item?.summary || item?.name || '').trim();
+        if (!title) return null;
+        return {
+          id: String(item?.id || item?.eventId || `${title}-${index}`),
+          title,
+          startMs: toMs(item?.start ?? item?.startAt ?? item?.startDate ?? item?.when),
+          endMs: toMs(item?.end ?? item?.endAt ?? item?.endDate),
+        };
+      })
+      .filter(Boolean) as PlannerSummaryEvent[];
+    if (mapped.length > 0) return mapped;
   }
-  const parsed = Date.parse(String(value));
-  return Number.isNaN(parsed) ? null : parsed;
+  return [];
 };
 
-const isDoneStatus = (value: any): boolean => {
-  if (typeof value === 'number') return value >= 2;
-  const raw = String(value || '').trim().toLowerCase();
-  return raw === 'done' || raw === 'complete' || raw === 'completed' || raw === 'archived';
+const getAutoMode = ({
+  isMobile,
+  reviewDone,
+  reviewCount,
+  hour,
+}: {
+  isMobile: boolean;
+  reviewDone: boolean;
+  reviewCount: number;
+  hour: number;
+}): DailyPlanMode => {
+  if (hour >= 19) return 'checkin';
+  if (!reviewDone && reviewCount > 0 && hour < 13) return 'review';
+  return isMobile ? 'list' : 'plan';
 };
-
-const normalizeStoryStatus = (value: any): number => {
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  const raw = String(value || '').trim().toLowerCase();
-  if (raw === 'done' || raw === 'complete' || raw === 'completed') return 4;
-  if (raw === 'testing' || raw === 'qa' || raw === 'review') return 3;
-  if (raw === 'in progress' || raw === 'in-progress' || raw === 'active' || raw === 'doing' || raw === 'blocked') return 2;
-  if (raw === 'planned' || raw === 'ready') return 1;
-  return 0;
-};
-
-const getChoreKind = (task: Task): 'chore' | 'routine' | 'habit' | null => {
-  const raw = String((task as any)?.type || (task as any)?.task_type || '').trim().toLowerCase();
-  const normalized = raw === 'habitual' ? 'habit' : raw;
-  if (normalized === 'chore' || normalized === 'routine' || normalized === 'habit') return normalized;
-  return null;
-};
-
-const bucketFromTime = (ms: number | null | undefined, timeOfDay?: string | null): TimelineBucket => {
-  const tod = String(timeOfDay || '').toLowerCase().trim();
-  if (tod === 'morning' || tod === 'afternoon' || tod === 'evening') return tod as TimelineBucket;
-  if (!ms || !Number.isFinite(ms)) return 'morning';
-  const date = new Date(ms);
-  const minute = date.getHours() * 60 + date.getMinutes();
-  if (minute >= 300 && minute <= 779) return 'morning';
-  if (minute >= 780 && minute <= 1139) return 'afternoon';
-  return 'evening';
-};
-
-const bucketPseudoTime = (dayStartMs: number, bucket: TimelineBucket) => {
-  if (bucket === 'morning') return dayStartMs + (9 * 60 * 60 * 1000);
-  if (bucket === 'afternoon') return dayStartMs + (14 * 60 * 60 * 1000);
-  return dayStartMs + (19.5 * 60 * 60 * 1000);
-};
-
-const formatTimeLabel = (startMs: number | null | undefined, endMs?: number | null, timeOfDay?: string | null): string => {
-  if (!startMs || !Number.isFinite(startMs)) {
-    return `Unscheduled (${bucketLabel(bucketFromTime(null, timeOfDay))})`;
-  }
-  const start = new Date(startMs);
-  const startLabel = start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  if (endMs && Number.isFinite(endMs)) {
-    const end = new Date(endMs);
-    const endLabel = end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    return `${startLabel} - ${endLabel}`;
-  }
-  return startLabel;
-};
-
-const resolveTaskRef = (task: Task) => task.ref || `TK-${task.id.slice(-6).toUpperCase()}`;
-const resolveStoryRef = (story: Story) => ((story as any).referenceNumber || story.ref || `ST-${story.id.slice(-6).toUpperCase()}`);
 
 const DailyPlanPage: React.FC = () => {
   const { currentUser } = useAuth();
   const { currentPersona } = usePersona();
-  const { selectedSprintId } = useSprint();
+  const { selectedSprintId, sprints } = useSprint();
   const { activeFocusGoals } = useFocusGoals(currentUser?.uid);
+  const { showSidebar } = useSidebar();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const [tasks, setTasks] = useState<Task[]>([]);
   const [stories, setStories] = useState<Story[]>([]);
   const [goals, setGoals] = useState<Goal[]>([]);
-  const [calendarBlocks, setCalendarBlocks] = useState<CalendarBlockRow[]>([]);
-  const [scheduledInstances, setScheduledInstances] = useState<ScheduledInstanceRow[]>([]);
+  const [calendarBlocks, setCalendarBlocks] = useState<PlannerCalendarBlockRow[]>([]);
+  const [scheduledInstances, setScheduledInstances] = useState<PlannerScheduledInstanceRow[]>([]);
   const [summary, setSummary] = useState<any | null>(null);
-  const [deferTarget, setDeferTarget] = useState<{ type: 'task' | 'story'; id: string; title: string } | null>(null);
-  const [morningReviewDone, setMorningReviewDone] = useState(false);
-  const [activeKindFilter, setActiveKindFilter] = useState<TimelineFilter>(null);
+  const [deferTarget, setDeferTarget] = useState<DeferTarget | null>(null);
   const [pageMessage, setPageMessage] = useState<{ variant: 'warning' | 'danger' | 'success'; text: string } | null>(null);
   const [editTask, setEditTask] = useState<Task | null>(null);
   const [editStory, setEditStory] = useState<Story | null>(null);
-  const [scheduleTarget, setScheduleTarget] = useState<TimelineItem | null>(null);
+  const [scheduleTarget, setScheduleTarget] = useState<PlannerItem | null>(null);
+  const [activeKindFilter, setActiveKindFilter] = useState<TimelineFilter>(null);
+  const [morningReviewDone, setMorningReviewDone] = useState(false);
+  const [applyingKey, setApplyingKey] = useState<string | null>(null);
+  const [isMobileLayout, setIsMobileLayout] = useState<boolean>(typeof window !== 'undefined' ? window.innerWidth < 768 : false);
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+  const [userSelectedMode, setUserSelectedMode] = useState(false);
+  const [mode, setMode] = useState<DailyPlanMode>(() => {
+    if (typeof window === 'undefined') return 'plan';
+    const params = new URLSearchParams(window.location.search);
+    const forcedTab = params.get('tab');
+    if (forcedTab === 'checkin') return 'checkin';
+    return getAutoMode({
+      isMobile: window.innerWidth < 768,
+      reviewDone: false,
+      reviewCount: 0,
+      hour: new Date().getHours(),
+    });
+  });
+  const [moveModal, setMoveModal] = useState<{ item: PlannerItem; recommendation: PlannerRecommendation | null } | null>(null);
 
-  const today = useMemo(() => new Date(), []);
-  const todayStartMs = useMemo(() => {
-    const d = new Date();
-    d.setHours(0, 0, 0, 0);
-    return d.getTime();
+  const todayStartMs = useMemo(() => dayStartMs(new Date()), []);
+  const todayEndMs = useMemo(() => todayStartMs + (24 * 60 * 60 * 1000) - 1, [todayStartMs]);
+  const todayIso = useMemo(() => new Date(todayStartMs).toISOString().slice(0, 10), [todayStartMs]);
+  const activeFocusGoalIds = useMemo(() => getActiveFocusLeafGoalIds(activeFocusGoals), [activeFocusGoals]);
+  const nextSprint = useMemo(() => nextSprintForDate(sprints as Sprint[], todayEndMs), [sprints, todayEndMs]);
+  const reviewStateId = useMemo(
+    () => (currentUser?.uid ? `${currentUser.uid}_${currentPersona || 'personal'}_${todayIso}` : null),
+    [currentUser?.uid, currentPersona, todayIso],
+  );
+
+  useEffect(() => {
+    const update = () => {
+      const mobile = window.innerWidth < 768;
+      setIsMobileLayout(mobile);
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
   }, []);
-  const todayEndMs = useMemo(() => {
-    const d = new Date();
-    d.setHours(23, 59, 59, 999);
-    return d.getTime();
-  }, []);
-  const todayIso = useMemo(() => new Date().toISOString().slice(0, 10), []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.get('tab') === 'checkin' && mode !== 'checkin') {
+      setMode('checkin');
+      setUserSelectedMode(false);
+    }
+  }, [location.search, mode]);
 
   useEffect(() => {
     if (!currentUser?.uid) return;
@@ -189,19 +184,33 @@ const DailyPlanPage: React.FC = () => {
   }, [currentUser?.uid]);
 
   useEffect(() => {
+    if (!reviewStateId) {
+      setMorningReviewDone(false);
+      return;
+    }
+    const unsub = onSnapshot(doc(db, 'daily_plan_state', reviewStateId), (snap) => {
+      const data = snap.data() as any;
+      setMorningReviewDone(!!(data?.reviewCompletedAt || data?.reviewCompletedAtMs));
+    }, (error) => {
+      console.warn('DailyPlanPage: daily_plan_state listener denied/failed', error?.message || error);
+      setMorningReviewDone(false);
+    });
+    return () => unsub();
+  }, [reviewStateId]);
+
+  useEffect(() => {
     if (!currentUser?.uid) {
       setTasks([]);
       return;
     }
-    const q = query(collection(db, 'tasks'), where('ownerUid', '==', currentUser.uid));
+    const q = query(collection(db, 'tasks'), where('ownerUid', '==', currentUser.uid), orderBy('updatedAt', 'desc'), limit(300));
     const unsub = onSnapshot(q, (snap) => {
       let rows = snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Task[];
-      const persona = currentPersona || 'personal';
-      rows = rows.filter((task: any) => {
-        if (persona === 'work') return task.persona === 'work';
-        return task.persona == null || task.persona === 'personal';
-      });
+      rows = rows.filter((task: any) => currentPersona === 'work' ? task.persona === 'work' : task.persona == null || task.persona === 'personal');
       setTasks(rows);
+    }, (error) => {
+      console.warn('DailyPlanPage: tasks listener denied/failed', error?.message || error);
+      setTasks([]);
     });
     return () => unsub();
   }, [currentUser?.uid, currentPersona]);
@@ -211,15 +220,14 @@ const DailyPlanPage: React.FC = () => {
       setStories([]);
       return;
     }
-    const q = query(collection(db, 'stories'), where('ownerUid', '==', currentUser.uid));
+    const q = query(collection(db, 'stories'), where('ownerUid', '==', currentUser.uid), orderBy('updatedAt', 'desc'), limit(300));
     const unsub = onSnapshot(q, (snap) => {
       let rows = snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Story[];
-      const persona = currentPersona || 'personal';
-      rows = rows.filter((story: any) => {
-        if (persona === 'work') return story.persona === 'work';
-        return story.persona == null || story.persona === 'personal';
-      });
+      rows = rows.filter((story: any) => currentPersona === 'work' ? story.persona === 'work' : story.persona == null || story.persona === 'personal');
       setStories(rows);
+    }, (error) => {
+      console.warn('DailyPlanPage: stories listener denied/failed', error?.message || error);
+      setStories([]);
     });
     return () => unsub();
   }, [currentUser?.uid, currentPersona]);
@@ -232,6 +240,9 @@ const DailyPlanPage: React.FC = () => {
     const q = query(collection(db, 'goals'), where('ownerUid', '==', currentUser.uid));
     const unsub = onSnapshot(q, (snap) => {
       setGoals(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Goal[]);
+    }, (error) => {
+      console.warn('DailyPlanPage: goals listener denied/failed', error?.message || error);
+      setGoals([]);
     });
     return () => unsub();
   }, [currentUser?.uid]);
@@ -241,15 +252,17 @@ const DailyPlanPage: React.FC = () => {
       setCalendarBlocks([]);
       return;
     }
-    const q = query(collection(db, 'calendar_blocks'), where('ownerUid', '==', currentUser.uid));
+    const q = query(
+      collection(db, 'calendar_blocks'),
+      where('ownerUid', '==', currentUser.uid),
+      where('start', '>=', todayStartMs),
+      where('start', '<=', todayEndMs),
+    );
     const unsub = onSnapshot(q, (snap) => {
-      const rows = snap.docs
-        .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) }))
-        .filter((row: any) => {
-          const startMs = toMs(row.start);
-          return startMs != null && startMs >= todayStartMs && startMs <= todayEndMs;
-        }) as CalendarBlockRow[];
-      setCalendarBlocks(rows);
+      setCalendarBlocks(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as PlannerCalendarBlockRow[]);
+    }, (error) => {
+      console.warn('DailyPlanPage: calendar_blocks listener denied/failed', error?.message || error);
+      setCalendarBlocks([]);
     });
     return () => unsub();
   }, [currentUser?.uid, todayStartMs, todayEndMs]);
@@ -265,7 +278,10 @@ const DailyPlanPage: React.FC = () => {
       where('occurrenceDate', '==', todayIso),
     );
     const unsub = onSnapshot(q, (snap) => {
-      setScheduledInstances(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as ScheduledInstanceRow[]);
+      setScheduledInstances(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as PlannerScheduledInstanceRow[]);
+    }, (error) => {
+      console.warn('DailyPlanPage: scheduled_instances listener denied/failed', error?.message || error);
+      setScheduledInstances([]);
     });
     return () => unsub();
   }, [currentUser?.uid, todayIso]);
@@ -280,271 +296,120 @@ const DailyPlanPage: React.FC = () => {
       const sorted = [...snap.docs].sort((a, b) => (toMs(b.data()?.generatedAt) || 0) - (toMs(a.data()?.generatedAt) || 0));
       const row = sorted[0]?.data() as any;
       setSummary(row?.summary || null);
+    }, (error) => {
+      console.warn('DailyPlanPage: daily_summaries listener denied/failed', error?.message || error);
+      setSummary(null);
     });
     return () => unsub();
   }, [currentUser?.uid]);
 
-  useEffect(() => {
-    if (!currentUser?.uid) {
-      setMorningReviewDone(false);
-      return;
-    }
-    const key = `dailyPlanMorningReview:${currentUser.uid}:${todayIso}`;
-    setMorningReviewDone(window.localStorage.getItem(key) === '1');
-  }, [currentUser?.uid, todayIso]);
+  const timelineItems = useMemo(
+    () =>
+      buildPlannerItems({
+        tasks,
+        stories,
+        goals,
+        calendarBlocks,
+        scheduledInstances,
+        activeFocusGoalIds,
+        rangeStartMs: todayStartMs,
+        rangeEndMs: todayEndMs,
+        selectedSprintId,
+        includeUnscheduledTasks: true,
+        summaryEvents: extractSummaryEvents(summary),
+      }),
+    [tasks, stories, goals, calendarBlocks, scheduledInstances, activeFocusGoalIds, todayStartMs, todayEndMs, selectedSprintId, summary],
+  );
 
-  const storyMap = useMemo(() => new Map(stories.map((story) => [story.id, story])), [stories]);
-  const goalMap = useMemo(() => new Map(goals.map((goal) => [goal.id, goal])), [goals]);
-  const activeFocusGoalIds = useMemo(() => getActiveFocusLeafGoalIds(activeFocusGoals), [activeFocusGoals]);
+  const timelineWorkItems = useMemo(() => timelineItems.filter((item) => item.kind !== 'event'), [timelineItems]);
 
-  const isGoalAlignedToFocus = useMemo(() => (
-    (goalId: string | null | undefined) => {
-      const normalized = String(goalId || '').trim();
-      if (!normalized) return false;
-      if (activeFocusGoalIds.has(normalized)) return true;
-      return getGoalAncestors(normalized, goals).some((goal) => activeFocusGoalIds.has(goal.id));
-    }
-  ), [activeFocusGoalIds, goals]);
-
-  const overviewCalendarEvents = useMemo(() => {
-    const candidates = [summary?.calendar?.events, summary?.eventsToday, summary?.upcomingEvents, summary?.calendarEvents, summary?.dailyBrief?.calendar];
-    for (const candidate of candidates) {
-      if (!Array.isArray(candidate) || candidate.length === 0) continue;
-      const mapped = candidate
-        .map((item: any, index: number) => {
-          const title = String(item?.title || item?.summary || item?.name || '').trim();
-          if (!title) return null;
-          const startMs = toMs(item?.start ?? item?.startAt ?? item?.startDate ?? item?.when);
-          const endMs = toMs(item?.end ?? item?.endAt ?? item?.endDate);
-          return { id: String(item?.id || item?.eventId || `${title}-${index}`), title, startMs, endMs };
-        })
-        .filter(Boolean) as Array<{ id: string; title: string; startMs: number | null; endMs: number | null }>;
-      if (mapped.length > 0) return mapped;
-    }
-    return [] as Array<{ id: string; title: string; startMs: number | null; endMs: number | null }>;
-  }, [summary]);
-
-  const scheduledInstanceBySourceKey = useMemo(() => {
-    const map = new Map<string, ScheduledInstanceRow>();
-    scheduledInstances.forEach((instance) => {
-      const sourceType = String(instance.sourceType || '').trim().toLowerCase();
-      const sourceId = String(instance.sourceId || '').trim();
-      if (!sourceType || !sourceId) return;
-      map.set(`${sourceType}:${sourceId}`, instance);
+  const dailyLoadHours = useMemo(() => {
+    const map = new Map<string, number>();
+    timelineWorkItems.forEach((item) => {
+      map.set(item.dayKey, (map.get(item.dayKey) || 0) + plannerItemPoints(item));
     });
     return map;
-  }, [scheduledInstances]);
+  }, [timelineWorkItems]);
 
-  const timelineItems = useMemo(() => {
-    const rows: TimelineItem[] = [];
-    const seen = new Set<string>();
-    const blockByTaskId = new Map<string, CalendarBlockRow>();
-    const blockByStoryId = new Map<string, CalendarBlockRow>();
+  const dayCapacity = useMemo(() => buildDayCapacityMap([todayIso], timelineWorkItems, 8).get(todayIso) || null, [timelineWorkItems, todayIso]);
 
-    calendarBlocks.forEach((block) => {
-      const taskId = String(block.taskId || '').trim();
-      const storyId = String(block.storyId || block.linkedStoryId || '').trim();
-      if (taskId) blockByTaskId.set(taskId, block);
-      if (storyId) blockByStoryId.set(storyId, block);
+  const reviewItems = useMemo(
+    () =>
+      timelineWorkItems.filter(
+        (item) =>
+          (item.kind === 'task' || item.kind === 'story')
+          && !item.isTop3
+          && !item.isFocusAligned
+          && !(item.deferredUntilMs && item.deferredUntilMs > Date.now()),
+      ),
+    [timelineWorkItems],
+  );
+
+  const recommendationByItemId = useMemo(() => {
+    const next = new Map<string, PlannerRecommendation>();
+    reviewItems.forEach((item) => {
+      next.set(item.id, buildPlannerRecommendation({
+        item,
+        weekStartMs: todayStartMs,
+        weekEndMs: todayEndMs,
+        dailyLoadHours,
+        nextSprint,
+      }));
     });
+    return next;
+  }, [reviewItems, todayStartMs, todayEndMs, dailyLoadHours, nextSprint]);
 
-    const push = (row: TimelineItem, dedupeKey = row.id) => {
-      if (seen.has(dedupeKey)) return;
-      seen.add(dedupeKey);
-      rows.push(row);
-    };
+  const reviewItemIds = useMemo(() => new Set(reviewItems.map((item) => item.id)), [reviewItems]);
 
-    const buildTaskRow = (task: Task, kind: 'task' | 'chore') => {
-      const choreKind = getChoreKind(task);
-      const instanceSourceTypes = choreKind === 'habit'
-        ? ['habit', 'routine', 'chore']
-        : choreKind
-          ? [choreKind]
-          : ['task'];
-      const matchingInstance = instanceSourceTypes
-        .map((sourceType) => scheduledInstanceBySourceKey.get(`${sourceType}:${task.id}`) || null)
-        .find(Boolean) || null;
-      const instanceStatus = String(matchingInstance?.status || '').trim().toLowerCase();
-      if (matchingInstance && ['completed', 'missed', 'skipped', 'cancelled'].includes(instanceStatus)) {
-        return;
-      }
-      const linkedBlock = blockByTaskId.get(task.id) || null;
-      const parentStory = (task as any).storyId ? storyMap.get((task as any).storyId) || null : null;
-      const goalId = String((task as any).goalId || (parentStory as any)?.goalId || '').trim() || null;
-      const goal = goalId ? goalMap.get(goalId) || null : null;
-      const dueMs = linkedBlock ? toMs(linkedBlock.start) : resolveTaskDueMs(task);
-      const endMs = linkedBlock ? toMs(linkedBlock.end) : null;
-      const bucket = bucketFromTime(dueMs, (task as any).timeOfDay);
-      const include = !!linkedBlock || !dueMs || dueMs <= todayEndMs;
-      if (!include) return;
-      push({
-        id: `${kind}-${task.id}`,
-        kind,
-        title: task.title || (kind === 'chore' ? 'Chore' : 'Task'),
-        ref: resolveTaskRef(task),
-        timeLabel: formatTimeLabel(dueMs, endMs, (task as any).timeOfDay),
-        sortMs: dueMs ?? bucketPseudoTime(todayStartMs, bucket),
-        bucket,
-        sourceId: task.id,
-        isTop3: !!((task as any).aiTop3ForDay && String((task as any).aiTop3Date || '').slice(0, 10) === todayIso),
-        deferredUntilMs: toMs((task as any).deferredUntil),
-        goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
-        goalTheme: goal ? String((goal as any).theme || '') || null : null,
-        isFocusAligned: isGoalAlignedToFocus(goalId),
-        rawTask: task,
-        rawStory: null,
-        scheduledBlockStart: linkedBlock ? toMs(linkedBlock.start) : null,
-        scheduledBlockEnd: linkedBlock ? toMs(linkedBlock.end) : null,
-      });
-    };
+  useEffect(() => {
+    if (new URLSearchParams(location.search).get('tab') === 'checkin') return;
+    if (userSelectedMode) return;
+    setMode(getAutoMode({
+      isMobile: isMobileLayout,
+      reviewDone: morningReviewDone,
+      reviewCount: reviewItems.length,
+      hour: new Date().getHours(),
+    }));
+  }, [isMobileLayout, location.search, morningReviewDone, reviewItems.length, userSelectedMode]);
 
-    tasks.filter((task) => !isDoneStatus((task as any).status)).filter((task) => !getChoreKind(task)).forEach((task) => buildTaskRow(task, 'task'));
-    tasks
-      .filter((task) => !isDoneStatus((task as any).status))
-      .filter((task) => !!getChoreKind(task))
-      .filter((task) => !!blockByTaskId.get(task.id) || isRecurringDueOnDate(task, today, todayStartMs) || !!resolveTaskDueMs(task))
-      .forEach((task) => buildTaskRow(task, 'chore'));
-
-    stories
-      .filter((story) => !isDoneStatus((story as any).status))
-      .filter((story) => (selectedSprintId ? String((story as any).sprintId || '') === String(selectedSprintId) : true))
-      .forEach((story) => {
-        const linkedBlock = blockByStoryId.get(story.id) || null;
-        const dueMs = linkedBlock ? toMs(linkedBlock.start) : toMs((story as any).targetDate || (story as any).dueDate || (story as any).plannedStartDate);
-        const endMs = linkedBlock ? toMs(linkedBlock.end) : null;
-        const bucket = bucketFromTime(dueMs, (story as any).timeOfDay);
-        const include = !!linkedBlock || !dueMs || dueMs <= todayEndMs;
-        if (!include) return;
-        const goalId = String((story as any).goalId || '').trim() || null;
-        const goal = goalId ? goalMap.get(goalId) || null : null;
-        push({
-          id: `story-${story.id}`,
-          kind: 'story',
-          title: story.title || 'Story',
-          ref: resolveStoryRef(story),
-          timeLabel: formatTimeLabel(dueMs, endMs, (story as any).timeOfDay),
-          sortMs: dueMs ?? bucketPseudoTime(todayStartMs, bucket),
-          bucket,
-          sourceId: story.id,
-          isTop3: !!((story as any).aiTop3ForDay && String((story as any).aiTop3Date || '').slice(0, 10) === todayIso),
-          deferredUntilMs: toMs((story as any).deferredUntil),
-          goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
-          goalTheme: goal ? String((goal as any).theme || '') || null : null,
-          isFocusAligned: isGoalAlignedToFocus(goalId),
-          rawTask: null,
-          rawStory: story,
-          scheduledBlockStart: linkedBlock ? toMs(linkedBlock.start) : null,
-          scheduledBlockEnd: linkedBlock ? toMs(linkedBlock.end) : null,
-        });
-      });
-
-    calendarBlocks.filter((block) => !String(block.taskId || '').trim() && !String(block.storyId || block.linkedStoryId || '').trim()).forEach((block) => {
-      const startMs = toMs(block.start);
-      const endMs = toMs(block.end);
-      const bucket = bucketFromTime(startMs);
-      const timeLabel = formatTimeLabel(startMs, endMs);
-      const dedupeKey = `event:${String(block.title || '').toLowerCase()}:${timeLabel}`;
-      push({
-        id: `event-block-${block.id}`,
-        kind: 'event',
-        title: String(block.title || 'Calendar event').trim() || 'Calendar event',
-        ref: null,
-        timeLabel,
-        sortMs: startMs ?? bucketPseudoTime(todayStartMs, bucket),
-        bucket,
-        goalTitle: null,
-        goalTheme: null,
-        isFocusAligned: false,
-        rawTask: null,
-        rawStory: null,
-        scheduledBlockStart: startMs,
-        scheduledBlockEnd: endMs,
-      }, dedupeKey);
-    });
-
-    overviewCalendarEvents.forEach((event) => {
-      if (event.startMs && (event.startMs < todayStartMs || event.startMs > todayEndMs)) return;
-      const bucket = bucketFromTime(event.startMs);
-      const timeLabel = formatTimeLabel(event.startMs, event.endMs);
-      const dedupeKey = `event:${event.title.toLowerCase()}:${timeLabel}`;
-      push({
-        id: `event-summary-${event.id}`,
-        kind: 'event',
-        title: event.title,
-        ref: null,
-        timeLabel,
-        sortMs: event.startMs ?? bucketPseudoTime(todayStartMs, bucket),
-        bucket,
-        goalTitle: null,
-        goalTheme: null,
-        isFocusAligned: false,
-        rawTask: null,
-        rawStory: null,
-        scheduledBlockStart: event.startMs,
-        scheduledBlockEnd: event.endMs,
-      }, dedupeKey);
-    });
-
-    return rows.sort((a, b) => {
-      const aMs = a.sortMs ?? Number.MAX_SAFE_INTEGER;
-      const bMs = b.sortMs ?? Number.MAX_SAFE_INTEGER;
-      if (aMs !== bMs) return aMs - bMs;
-      return a.title.localeCompare(b.title);
-    });
-  }, [tasks, stories, selectedSprintId, overviewCalendarEvents, today, todayStartMs, todayEndMs, todayIso, goalMap, storyMap, activeFocusGoalIds, calendarBlocks, scheduledInstanceBySourceKey, goals, isGoalAlignedToFocus]);
-
-  const todoSummary = useMemo(() => {
-    const tasksCount = timelineItems.filter((item) => item.kind === 'task').length;
-    const storiesCount = timelineItems.filter((item) => item.kind === 'story').length;
-    const choresCount = timelineItems.filter((item) => item.kind === 'chore').length;
-    const eventsCount = timelineItems.filter((item) => item.kind === 'event').length;
-    const top3Count = timelineItems.filter((item) => (item.kind === 'task' || item.kind === 'story') && item.isTop3).length;
-    const deferCandidates = timelineItems.filter((item) =>
-      (item.kind === 'task' || item.kind === 'story')
-      && !item.isTop3
-      && !item.isFocusAligned
-      && !(item.deferredUntilMs && item.deferredUntilMs > Date.now())
-    );
-    return { tasksCount, storiesCount, choresCount, eventsCount, top3Count, deferCandidates };
-  }, [timelineItems]);
+  const todoSummary = useMemo(() => ({
+    tasksCount: timelineWorkItems.filter((item) => item.kind === 'task').length,
+    storiesCount: timelineWorkItems.filter((item) => item.kind === 'story').length,
+    choresCount: timelineWorkItems.filter((item) => item.kind === 'chore').length,
+    eventsCount: timelineItems.filter((item) => item.kind === 'event').length,
+    top3Count: timelineWorkItems.filter((item) => (item.kind === 'task' || item.kind === 'story') && item.isTop3).length,
+    focusCount: timelineWorkItems.filter((item) => item.isFocusAligned).length,
+    reviewCount: reviewItems.length,
+    overdueCount: timelineWorkItems.filter((item) => item.dueAt != null && item.dueAt < Date.now()).length,
+  }), [timelineItems, timelineWorkItems, reviewItems]);
 
   const filteredTimelineItems = useMemo(() => {
-    if (!activeKindFilter) return timelineItems;
-    if (activeKindFilter === 'top3') {
-      return timelineItems.filter((item) => (item.kind === 'task' || item.kind === 'story') && item.isTop3);
-    }
-    if (activeKindFilter === 'review') {
-      return timelineItems.filter((item) =>
-        (item.kind === 'task' || item.kind === 'story')
-        && !item.isTop3
-        && !item.isFocusAligned
-        && !(item.deferredUntilMs && item.deferredUntilMs > Date.now())
-      );
-    }
-    return timelineItems.filter((item) => item.kind === activeKindFilter);
-  }, [timelineItems, activeKindFilter]);
-
-  const empty = filteredTimelineItems.length === 0;
+    const source = mode === 'review' ? reviewItems : mode === 'plan' ? timelineItems : timelineWorkItems;
+    if (!activeKindFilter) return source;
+    if (activeKindFilter === 'focus') return source.filter((item) => item.isFocusAligned);
+    if (activeKindFilter === 'review') return reviewItems;
+    if (activeKindFilter === 'top3') return source.filter((item) => item.isTop3);
+    return source.filter((item) => item.kind === activeKindFilter);
+  }, [timelineItems, timelineWorkItems, reviewItems, activeKindFilter, mode]);
 
   const scheduleStories = useMemo(() => {
     if (!scheduleTarget) return [] as Story[];
     if (scheduleTarget.rawStory) return [scheduleTarget.rawStory];
     if (scheduleTarget.rawTask && (scheduleTarget.rawTask as any).storyId) {
-      const parent = storyMap.get((scheduleTarget.rawTask as any).storyId);
+      const parent = stories.find((story) => story.id === (scheduleTarget.rawTask as any).storyId);
       return parent ? [parent] : [];
     }
     return [] as Story[];
-  }, [scheduleTarget, storyMap]);
+  }, [scheduleTarget, stories]);
 
   const scheduleInitialValues = useMemo(() => {
     if (!scheduleTarget) return undefined;
     const rawTask = scheduleTarget.rawTask;
     const rawStory = scheduleTarget.rawStory;
-    const parentStory = rawTask && (rawTask as any).storyId ? storyMap.get((rawTask as any).storyId) || null : null;
     const base = new Date();
     base.setMinutes(0, 0, 0);
     base.setHours(base.getHours() + 1);
-    const startMs = scheduleTarget.scheduledBlockStart || (scheduleTarget.sortMs && !scheduleTarget.timeLabel.startsWith('Unscheduled') ? scheduleTarget.sortMs : null);
+    const startMs = scheduleTarget.scheduledBlockStart || scheduleTarget.sortMs || null;
     const start = startMs ? new Date(startMs) : base;
     const durationMin = Math.max(15, Math.min(240, Math.round(Number((rawTask as any)?.estimateMin || 0) || (Number((rawTask as any)?.points || (rawStory as any)?.points || 0) * 60) || 60)));
     const end = scheduleTarget.scheduledBlockEnd ? new Date(scheduleTarget.scheduledBlockEnd) : new Date(start.getTime() + durationMin * 60 * 1000);
@@ -554,70 +419,276 @@ const DailyPlanPage: React.FC = () => {
       end: toInputValue(end),
       syncToGoogle: true,
       rationale: 'Scheduled from Daily Plan',
-      persona: ((rawTask as any)?.persona || (rawStory as any)?.persona || (parentStory as any)?.persona || currentPersona || 'personal') as 'personal' | 'work',
-      theme: String((rawStory as any)?.theme || (parentStory as any)?.theme || (rawTask as any)?.theme || 'General'),
+      persona: ((rawTask as any)?.persona || (rawStory as any)?.persona || currentPersona || 'personal') as 'personal' | 'work',
+      theme: String((rawStory as any)?.theme || (rawTask as any)?.theme || 'General'),
       category: ((rawTask as any)?.category || 'Wellbeing') as any,
-      storyId: rawStory?.id || parentStory?.id,
+      storyId: rawStory?.id || (rawTask as any)?.storyId || undefined,
       taskId: rawTask?.id,
       aiScore: Number.isFinite(Number((rawTask as any)?.aiCriticalityScore || (rawStory as any)?.aiCriticalityScore)) ? Number((rawTask as any)?.aiCriticalityScore || (rawStory as any)?.aiCriticalityScore) : null,
       aiReason: String((rawTask as any)?.aiReason || (rawTask as any)?.aiPriorityReason || (rawStory as any)?.aiReason || (rawStory as any)?.aiPriorityReason || '').trim() || null,
     } as Partial<BlockFormState>;
-  }, [scheduleTarget, storyMap, currentPersona]);
+  }, [scheduleTarget, currentPersona]);
 
   const markMorningReviewDone = () => {
-    if (!currentUser?.uid) return;
-    const key = `dailyPlanMorningReview:${currentUser.uid}:${todayIso}`;
-    window.localStorage.setItem(key, '1');
+    if (!currentUser?.uid || !reviewStateId) return;
+    void setDoc(doc(db, 'daily_plan_state', reviewStateId), {
+      ownerUid: currentUser.uid,
+      persona: currentPersona || 'personal',
+      dayKey: todayIso,
+      reviewCompletedAt: serverTimestamp(),
+      reviewCompletedAtMs: Date.now(),
+      updatedAt: serverTimestamp(),
+    }, { merge: true });
     setMorningReviewDone(true);
+    setActiveKindFilter(null);
+    setMode(isMobileLayout ? 'list' : 'plan');
   };
 
-  const applyDefer = async (payload: { dateMs: number; rationale: string; source: string }) => {
-    if (!deferTarget) return;
-    const collectionName = deferTarget.type === 'story' ? 'stories' : 'tasks';
-    await updateDoc(doc(db, collectionName, deferTarget.id), {
-      deferredUntil: payload.dateMs,
-      deferredReason: payload.rationale,
-      deferredBy: payload.source,
-      deferredAt: serverTimestamp(),
-      updatedAt: serverTimestamp(),
+  const selectMode = (nextMode: DailyPlanMode) => {
+    setUserSelectedMode(true);
+    setMode(nextMode);
+    if (nextMode === 'checkin') {
+      if (location.search !== '?tab=checkin') {
+        navigate('/daily-plan?tab=checkin', { replace: true });
+      }
+      return;
+    }
+    if (location.search) {
+      navigate('/daily-plan', { replace: true });
+    }
+  };
+
+  const updateTaskQuick = async (task: Task, patch: Record<string, any>) => {
+    try {
+      await updateDoc(doc(db, 'tasks', task.id), {
+        ...patch,
+        updatedAt: serverTimestamp(),
+      });
+    } catch (error: any) {
+      console.error('Failed to update task from daily plan', error);
+      setPageMessage({ variant: 'danger', text: error?.message || 'Failed to update this task.' });
+    }
+  };
+
+  const updateStoryQuick = async (story: Story, patch: Record<string, any>) => {
+    try {
+      await updateDoc(doc(db, 'stories', story.id), {
+        ...patch,
+        updatedAt: serverTimestamp(),
+      });
+    } catch (error: any) {
+      console.error('Failed to update story from daily plan', error);
+      setPageMessage({ variant: 'danger', text: error?.message || 'Failed to update this story.' });
+    }
+  };
+
+  const cycleTaskStatus = (task: Task) => {
+    const options = ChoiceHelper.getOptions('task', 'status').map((opt) => opt.value);
+    const current = Number((task as any)?.status ?? 0);
+    const currentIndex = Math.max(0, options.indexOf(current));
+    const next = options[(currentIndex + 1) % options.length] ?? 0;
+    void updateTaskQuick(task, { status: next });
+  };
+
+  const cycleStoryStatus = (story: Story) => {
+    const options = ChoiceHelper.getOptions('story', 'status').map((opt) => opt.value);
+    const current = normalizeStoryStatus((story as any)?.status);
+    const currentIndex = Math.max(0, options.indexOf(current));
+    const next = options[(currentIndex + 1) % options.length] ?? 0;
+    void updateStoryQuick(story, { status: next });
+  };
+
+  const cycleTaskPriority = (task: Task) => {
+    const options = [0, ...ChoiceHelper.getOptions('task', 'priority').map((opt) => opt.value)];
+    const current = Number((task as any)?.priority ?? 0);
+    const currentIndex = Math.max(0, options.indexOf(current));
+    const next = options[(currentIndex + 1) % options.length] ?? 0;
+    void updateTaskQuick(task, { priority: next });
+  };
+
+  const cycleStoryPriority = (story: Story) => {
+    const options = [0, ...ChoiceHelper.getOptions('story', 'priority').map((opt) => opt.value)];
+    const current = Number((story as any)?.priority ?? 0);
+    const currentIndex = Math.max(0, options.indexOf(current));
+    const next = options[(currentIndex + 1) % options.length] ?? 0;
+    void updateStoryQuick(story, { priority: next });
+  };
+
+  const buildTargetTiming = (targetDateMs: number, targetBucket: TimelineBucket, durationMinutes: number) => {
+    const startHour = targetBucket === 'morning' ? 9 : targetBucket === 'afternoon' ? 14 : targetBucket === 'evening' ? 19 : 12;
+    const startMs = dayStartMs(targetDateMs) + startHour * 60 * 60 * 1000;
+    const safeDurationMinutes = Math.max(15, durationMinutes || 30);
+    return {
+      startMs,
+      endMs: startMs + safeDurationMinutes * 60 * 1000,
+    };
+  };
+
+  const updateScheduledInstanceTiming = async (item: PlannerItem, targetDateMs: number, targetBucket: TimelineBucket) => {
+    if (!item.scheduledInstanceId) return;
+    const durationMinutes = Math.max(
+      15,
+      Math.round((((item.scheduledBlockEnd || 0) - (item.scheduledBlockStart || 0)) / 60000) || Number((item.rawTask as any)?.estimateMin || 0) || 30),
+    );
+    const { startMs, endMs } = buildTargetTiming(targetDateMs, targetBucket, durationMinutes);
+    await updateDoc(doc(db, 'scheduled_instances', item.scheduledInstanceId), {
+      occurrenceDate: toDayKey(targetDateMs),
+      dayKey: toDayKey(targetDateMs),
+      timeOfDay: targetBucket,
+      plannedStart: new Date(startMs).toISOString(),
+      plannedEnd: new Date(endMs).toISOString(),
+      updatedAt: Date.now(),
     });
   };
 
-  const handleItemDone = async (item: TimelineItem, event: React.MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    if (item.rawTask) {
-      const choreKind = getChoreKind(item.rawTask);
-      if (choreKind) {
-        const candidateSourceTypes = choreKind === 'habit'
-          ? ['habit', 'routine', 'chore']
-          : [choreKind];
-        const matchingInstance = candidateSourceTypes
-          .map((sourceType) => scheduledInstanceBySourceKey.get(`${sourceType}:${item.rawTask!.id}`) || null)
-          .find(Boolean) || null;
-        if (matchingInstance) {
-          await updateDoc(doc(db, 'scheduled_instances', matchingInstance.id), {
-            status: 'completed',
-            statusUpdatedAt: Date.now(),
-            updatedAt: Date.now(),
-          });
-          return;
-        }
-        setPageMessage({
-          variant: 'warning',
-          text: 'Could not find today\'s scheduled instance for this recurring item, so the parent reminder was left unchanged.',
+  const updateGroupTiming = async (item: PlannerItem, targetDateMs: number, targetBucket: TimelineBucket) => {
+    const children = Array.isArray(item.childItems) ? item.childItems : [];
+    await Promise.all(children.map((child) => updateScheduledInstanceTiming(child, targetDateMs, targetBucket)));
+  };
+
+  const handleItemDone = async (item: PlannerItem) => {
+    setApplyingKey(item.id);
+    try {
+      if (item.scheduledInstanceId) {
+        await updateDoc(doc(db, 'scheduled_instances', item.scheduledInstanceId), {
+          status: 'completed',
+          statusUpdatedAt: Date.now(),
+          updatedAt: Date.now(),
         });
-        return;
+        const taskType = String((item.rawTask as any)?.type || '').toLowerCase();
+        if (['chore', 'routine', 'habit', 'habitual'].includes(taskType) && item.rawTask?.id) {
+          const callable = httpsCallable(functions, 'completeChoreTask');
+          await callable({ taskId: item.rawTask.id });
+        }
+        setPageMessage({ variant: 'success', text: `${item.title} marked complete for today.` });
+      } else if (item.rawTask) {
+        await updateDoc(doc(db, 'tasks', item.rawTask.id), { status: 2, updatedAt: serverTimestamp() });
+        setPageMessage({ variant: 'success', text: `${item.title} marked done.` });
+      } else if (item.rawStory) {
+        const nextStatus = Math.min(4, normalizeStoryStatus((item.rawStory as any).status) + 1);
+        await updateDoc(doc(db, 'stories', item.rawStory.id), { status: nextStatus, updatedAt: serverTimestamp() });
+        setPageMessage({ variant: 'success', text: `${item.title} advanced to the next story stage.` });
       }
-      await updateDoc(doc(db, 'tasks', item.rawTask.id), { status: 2, updatedAt: serverTimestamp() });
-      return;
-    }
-    if (item.rawStory) {
-      const nextStatus = Math.min(4, normalizeStoryStatus((item.rawStory as any).status) + 1);
-      await updateDoc(doc(db, 'stories', item.rawStory.id), { status: nextStatus, updatedAt: serverTimestamp() });
+    } catch (error: any) {
+      console.error('Failed to mark planner item done', error);
+      setPageMessage({ variant: 'danger', text: error?.message || 'Failed to update this item.' });
+    } finally {
+      setApplyingKey(null);
     }
   };
 
-  const openItemEditor = (item: TimelineItem) => {
+  const applyMove = async (item: PlannerItem, targetDateMs: number, targetBucket: TimelineBucket, recommendation?: PlannerRecommendation | null) => {
+    setApplyingKey(item.id);
+    const debugRequestId = createPlannerActionId('move');
+    console.info('[DailyPlanPage] move_confirmed', {
+      debugRequestId,
+      itemId: item.id,
+      itemKind: item.kind,
+      sourceId: item.sourceId || null,
+      targetDateMs,
+      targetBucket,
+      recommendation: recommendation || null,
+    });
+    try {
+      if (item.childItems?.length) {
+        await updateGroupTiming(item, targetDateMs, targetBucket);
+      } else if (item.scheduledInstanceId) {
+        await updateScheduledInstanceTiming(item, targetDateMs, targetBucket);
+      } else if (item.rawTask) {
+        const result = await schedulePlannerItemMutation({
+          itemType: 'task',
+          itemId: item.rawTask.id,
+          targetDateMs,
+          targetBucket,
+          intent: recommendation?.action === 'next_sprint' ? 'defer' : 'move',
+          source: 'daily_plan',
+          rationale: recommendation?.rationale || null,
+          linkedBlockId: item.scheduledBlockId || null,
+          targetSprintId: recommendation?.action === 'next_sprint' ? (nextSprint?.id || null) : null,
+          durationMinutes: Math.max(
+            15,
+            Math.round((((item.scheduledBlockEnd || 0) - (item.scheduledBlockStart || 0)) / 60000) || Number((item.rawTask as any)?.estimateMin || 0) || 30),
+          ),
+          debugRequestId,
+        });
+        setPageMessage({
+          variant: 'success',
+          text: `${item.title} moved to ${new Date(result.appliedStartMs).toLocaleDateString()} ${bucketLabel((result.appliedBucket || targetBucket) as TimelineBucket).toLowerCase()}.`,
+        });
+      } else if (item.rawStory) {
+        const result = await schedulePlannerItemMutation({
+          itemType: 'story',
+          itemId: item.rawStory.id,
+          targetDateMs,
+          targetBucket,
+          intent: recommendation?.action === 'next_sprint' ? 'defer' : 'move',
+          source: 'daily_plan',
+          rationale: recommendation?.rationale || null,
+          linkedBlockId: item.scheduledBlockId || null,
+          targetSprintId: recommendation?.action === 'next_sprint' ? (nextSprint?.id || null) : null,
+          durationMinutes: Math.max(
+            15,
+            Math.round((((item.scheduledBlockEnd || 0) - (item.scheduledBlockStart || 0)) / 60000) || Number((item.rawStory as any)?.estimateMin || 0) || 60),
+          ),
+          debugRequestId,
+        });
+        setPageMessage({
+          variant: 'success',
+          text: `${item.title} moved to ${new Date(result.appliedStartMs).toLocaleDateString()} ${bucketLabel((result.appliedBucket || targetBucket) as TimelineBucket).toLowerCase()}.`,
+        });
+      } else {
+        setPageMessage({
+          variant: 'success',
+          text: `${item.title} moved to ${new Date(targetDateMs).toLocaleDateString()} ${bucketLabel(targetBucket).toLowerCase()}.`,
+        });
+      }
+      setMoveModal(null);
+    } catch (error: any) {
+      console.error('[DailyPlanPage] move_failed', { debugRequestId, error });
+      setPageMessage({ variant: 'danger', text: error?.message || 'Failed to move this item.' });
+    } finally {
+      setApplyingKey(null);
+    }
+  };
+
+  const applyRecommendation = async (item: PlannerItem, recommendation: PlannerRecommendation) => {
+    if (recommendation.action === 'keep_week') {
+      setPageMessage({ variant: 'success', text: `${item.title} kept in today’s plan.` });
+      return;
+    }
+    if (recommendation.targetDateMs == null || recommendation.targetBucket == null) {
+      setPageMessage({ variant: 'warning', text: 'No actionable recommendation was available.' });
+      return;
+    }
+    if (recommendation.action === 'next_recurrence') {
+      setApplyingKey(item.id);
+      try {
+        if (item.childItems?.length) {
+          await updateGroupTiming(item, recommendation.targetDateMs, recommendation.targetBucket || item.timeOfDay);
+        } else if (item.scheduledInstanceId) {
+          await updateScheduledInstanceTiming(item, recommendation.targetDateMs, recommendation.targetBucket || item.timeOfDay);
+        } else if (item.rawTask) {
+          await updateDoc(doc(db, 'tasks', item.rawTask.id), {
+            deferredUntil: recommendation.targetDateMs,
+            deferredReason: recommendation.rationale,
+            deferredBy: 'daily_plan',
+            deferredAt: serverTimestamp(),
+            updatedAt: serverTimestamp(),
+          });
+        }
+        setPageMessage({ variant: 'success', text: `${item.title} deferred to its next sensible recurrence.` });
+      } catch (error: any) {
+        console.error('Failed to defer recurring item', error);
+        setPageMessage({ variant: 'danger', text: error?.message || 'Failed to defer this recurring item.' });
+      } finally {
+        setApplyingKey(null);
+      }
+      return;
+    }
+    await applyMove(item, recommendation.targetDateMs, recommendation.targetBucket, recommendation);
+  };
+
+  const openItemEditor = (item: PlannerItem) => {
     if (item.rawTask) {
       setEditTask(item.rawTask);
       return;
@@ -625,160 +696,231 @@ const DailyPlanPage: React.FC = () => {
     if (item.rawStory) setEditStory(item.rawStory);
   };
 
-  const filterButtons: Array<{ key: TimelineFilter; label: string; count: number; variant: string; }> = [
+  const renderPlannerCard = (item: PlannerItem) => {
+    const recommendation = recommendationByItemId.get(item.id) || null;
+    return (
+      <PlannerWorkCard
+        item={item}
+        context="daily"
+        isMobileLayout={isMobileLayout}
+        applyingKey={applyingKey}
+        showDoneControl={mode !== 'review'}
+        doneAsCheckbox={mode === 'list'}
+        showInlineRecommendation={!!recommendation && (mode === 'review' || reviewItemIds.has(item.id))}
+        recommendation={recommendation}
+        expanded={!!expandedGroups[item.id]}
+        onToggleExpanded={(nextItem) => setExpandedGroups((prev) => ({ ...prev, [nextItem.id]: !prev[nextItem.id] }))}
+        onToggleDone={(nextItem) => { void handleItemDone(nextItem); }}
+        onOpenActivity={(nextItem) => showSidebar(nextItem.rawTask ? nextItem.rawTask as any : nextItem.rawStory as any, nextItem.rawTask ? 'task' : 'story')}
+        onOpenEditor={openItemEditor}
+        onSchedule={setScheduleTarget}
+        onMove={(nextItem) => {
+          console.info('[DailyPlanPage] move_clicked', {
+            itemId: nextItem.id,
+            itemKind: nextItem.kind,
+            sourceId: nextItem.sourceId || null,
+          });
+          const fallbackRecommendation = nextItem.kind === 'chore'
+            ? buildPlannerRecommendation({
+              item: nextItem,
+              weekStartMs: todayStartMs,
+              weekEndMs: todayEndMs,
+              dailyLoadHours,
+              nextSprint,
+            })
+            : null;
+          const nextRecommendation = recommendationByItemId.get(nextItem.id) || fallbackRecommendation || null;
+          console.info('[DailyPlanPage] move_modal_opened', {
+            itemId: nextItem.id,
+            itemKind: nextItem.kind,
+            recommendation: nextRecommendation || null,
+          });
+          setMoveModal({ item: nextItem, recommendation: nextRecommendation });
+          if (nextItem.kind === 'chore' && nextRecommendation?.targetDateMs != null) {
+            setPageMessage({
+              variant: 'success',
+              text: `${nextItem.title} move defaults were prefilled using its recurrence and current load.`,
+            });
+          }
+        }}
+        onDefer={(nextItem) => {
+          console.info('[DailyPlanPage] defer_clicked', {
+            itemId: nextItem.id,
+            itemKind: nextItem.kind,
+            sourceId: nextItem.sourceId || null,
+          });
+          if (nextItem.kind === 'event' || nextItem.childItems?.length) return;
+          const recurringRecommendation = nextItem.kind === 'chore'
+            ? buildPlannerRecommendation({
+              item: nextItem,
+              weekStartMs: todayStartMs,
+              weekEndMs: todayEndMs,
+              dailyLoadHours,
+              nextSprint,
+            })
+            : null;
+          if (recurringRecommendation?.action === 'next_recurrence') {
+            void applyRecommendation(nextItem, recurringRecommendation);
+            return;
+          }
+          setDeferTarget({ type: nextItem.kind === 'story' ? 'story' : 'task', id: nextItem.sourceId || '', title: nextItem.title, isFocusAligned: nextItem.isFocusAligned });
+        }}
+        onAcceptRecommendation={(nextItem) => {
+          const nextRecommendation = recommendationByItemId.get(nextItem.id);
+          if (nextRecommendation) void applyRecommendation(nextItem, nextRecommendation);
+        }}
+        onCycleStatus={(nextItem) => {
+          if (nextItem.rawTask) cycleTaskStatus(nextItem.rawTask);
+          else if (nextItem.rawStory) cycleStoryStatus(nextItem.rawStory);
+        }}
+        onCyclePriority={(nextItem) => {
+          if (nextItem.rawTask) cycleTaskPriority(nextItem.rawTask);
+          else if (nextItem.rawStory) cycleStoryPriority(nextItem.rawStory);
+        }}
+        onStatusChange={(nextItem, nextStatus) => {
+          if (nextItem.rawTask) updateTaskQuick(nextItem.rawTask, { status: nextStatus as any });
+          else if (nextItem.rawStory) updateStoryQuick(nextItem.rawStory, { status: nextStatus as any });
+        }}
+        onPriorityChange={(nextItem, nextPriority) => {
+          if (nextItem.rawTask) updateTaskQuick(nextItem.rawTask, { priority: nextPriority as any });
+          else if (nextItem.rawStory) updateStoryQuick(nextItem.rawStory, { priority: nextPriority as any });
+        }}
+      />
+    );
+  };
+
+  const filterButtons: Array<{ key: TimelineFilter; label: string; count: number; variant: string }> = [
     { key: 'task', label: 'Tasks', count: todoSummary.tasksCount, variant: 'primary' },
     { key: 'story', label: 'Stories', count: todoSummary.storiesCount, variant: 'info' },
     { key: 'chore', label: 'Chores', count: todoSummary.choresCount, variant: 'success' },
-    { key: 'event', label: 'Events', count: todoSummary.eventsCount, variant: 'secondary' },
     { key: 'top3', label: 'Top 3', count: todoSummary.top3Count, variant: 'danger' },
-    { key: 'review', label: 'Review', count: todoSummary.deferCandidates.length, variant: 'warning' },
+    { key: 'focus', label: 'Focus', count: todoSummary.focusCount, variant: 'success' },
+    { key: 'review', label: 'Review', count: todoSummary.reviewCount, variant: 'warning' },
   ];
 
   return (
-    <Container fluid="sm" className="py-3">
+    <Container fluid="sm" className={isMobileLayout ? 'py-2 px-2' : 'py-3'}>
       <Card className="border-0 shadow-sm">
-        <Card.Header className="d-flex align-items-center justify-content-between">
-          <div className="fw-semibold">Daily Plan</div>
-          <Badge bg={empty ? 'secondary' : 'info'} pill>{filteredTimelineItems.length}</Badge>
+        <Card.Header className="d-flex align-items-center justify-content-between flex-wrap gap-2">
+          <div>
+            <div className="fw-semibold">Daily Plan</div>
+            <div className="text-muted small">Overview stays the home page; this is the daily operating surface.</div>
+          </div>
+          <div className="d-flex align-items-center gap-2 flex-wrap">
+            <Badge bg="secondary">Open {timelineWorkItems.length}</Badge>
+            <Badge bg="warning" text="dark">Review {todoSummary.reviewCount}</Badge>
+            <Badge bg="danger">Overdue {todoSummary.overdueCount}</Badge>
+          </div>
         </Card.Header>
         <Card.Body>
           {pageMessage && (
-            <Alert variant={pageMessage.variant} className="py-2 px-3" dismissible onClose={() => setPageMessage(null)}>
+            <Alert variant={pageMessage.variant} dismissible className="py-2" onClose={() => setPageMessage(null)}>
               {pageMessage.text}
             </Alert>
           )}
-          <div className="text-muted small mb-3">
-            Review today in one place: open items inline, finish them quickly, and schedule or defer without leaving the page.
+
+          <div className="d-flex gap-2 flex-wrap mb-3">
+            <Button size="sm" variant={mode === 'list' ? 'primary' : 'outline-primary'} onClick={() => selectMode('list')}>
+              Today
+            </Button>
+            <Button size="sm" variant={mode === 'plan' ? 'primary' : 'outline-primary'} onClick={() => selectMode('plan')}>
+              Schedule
+            </Button>
+            <Button size="sm" variant={mode === 'review' ? 'primary' : 'outline-primary'} onClick={() => selectMode('review')}>
+              Triage
+            </Button>
+            <Button size="sm" variant={mode === 'checkin' ? 'primary' : 'outline-primary'} onClick={() => selectMode('checkin')}>
+              Check-in
+            </Button>
           </div>
 
-          <div className="d-flex flex-wrap gap-2 mb-3">
-            {filterButtons.map((filter) => {
-              const active = activeKindFilter === filter.key;
-              return (
+          <div className="text-muted small mb-3">
+            {mode === 'list' && 'Today: actionable work only, best for checking things off.'}
+            {mode === 'plan' && 'Schedule: your day laid out by morning, afternoon, evening, and standalone events.'}
+            {mode === 'review' && 'Triage: items outside today’s focus or capacity, with defer recommendations.'}
+            {mode === 'checkin' && 'Check-in: update progress, comments, and completion so nightly planning uses the latest state.'}
+          </div>
+
+          {mode !== 'checkin' && (
+            <div className="d-flex flex-wrap gap-2 mb-3">
+              {filterButtons.map((filter) => (
                 <Button
                   key={filter.key || 'all'}
                   size="sm"
-                  variant={active ? filter.variant : `outline-${filter.variant}`}
+                  variant={activeKindFilter === filter.key ? filter.variant : `outline-${filter.variant}`}
                   className="rounded-pill"
                   onClick={() => setActiveKindFilter((prev) => (prev === filter.key ? null : filter.key))}
                 >
                   {filter.label} {filter.count}
                 </Button>
-              );
-            })}
-          </div>
+              ))}
+            </div>
+          )}
 
-          {!morningReviewDone && timelineItems.length > 0 && (
-            <Alert variant="warning" className="d-flex align-items-center justify-content-between gap-2 flex-wrap py-2 px-3">
-              <div>
-                <div className="fw-semibold">Morning check-in</div>
-                <div className="small">
-                  Today: {todoSummary.tasksCount} tasks, {todoSummary.storiesCount} stories, {todoSummary.choresCount} chores, {todoSummary.eventsCount} events. Top 3 protected: {todoSummary.top3Count}. Review non-focus, non-Top 3 work first.
-                </div>
+          {mode === 'plan' && dayCapacity && (
+            <Alert variant={dayCapacity.overCapacity ? 'danger' : dayCapacity.remainingPoints <= 2 ? 'warning' : 'light'} className="py-2 px-3">
+              <div className="fw-semibold">Today capacity</div>
+              <div className="small text-muted">
+                {dayCapacity.plannedPoints.toFixed(1)}/{dayCapacity.capacityPoints.toFixed(1)} pts planned · {dayCapacity.remainingPoints.toFixed(1)} pts free · {dayCapacity.utilizationPct}% used
               </div>
-              <Button size="sm" variant="primary" onClick={markMorningReviewDone}>
-                Mark reviewed
-              </Button>
             </Alert>
           )}
 
-          {empty ? (
-            <Alert variant="light" className="mb-0">
-              {activeKindFilter ? 'No items match the current filter.' : 'No items scheduled for today.'}
+          {mode !== 'checkin' && !morningReviewDone && reviewItems.length > 0 && (
+            <Alert variant="warning" className="d-flex align-items-center justify-content-between gap-2 flex-wrap py-2 px-3">
+              <div>
+                <div className="fw-semibold">Morning review</div>
+                <div className="small">
+                  {todoSummary.reviewCount} items are outside your Top 3 and active focus goals. Triage them before the day fills up.
+                </div>
+              </div>
+              <div className={`d-flex gap-2 ${isMobileLayout ? 'w-100 flex-column' : ''}`}>
+                <Button size="sm" variant="outline-dark" className={isMobileLayout ? 'w-100' : undefined} onClick={() => selectMode('review')}>
+                  Open review
+                </Button>
+                <Button size="sm" variant="primary" className={isMobileLayout ? 'w-100' : undefined} onClick={markMorningReviewDone}>
+                  Mark reviewed
+                </Button>
+              </div>
             </Alert>
+          )}
+
+          {mode === 'checkin' ? (
+            <CheckInDaily embedded fixedDate={new Date(todayStartMs)} />
+          ) : mode === 'review' ? (
+            filteredTimelineItems.length === 0 ? (
+              <Alert variant="light" className="mb-0">No review items waiting.</Alert>
+            ) : (
+              <div className="d-flex flex-column gap-2">
+                {filteredTimelineItems.map((item) => renderPlannerCard(item))}
+              </div>
+            )
+          ) : mode === 'list' ? (
+            filteredTimelineItems.length === 0 ? (
+              <Alert variant="light" className="mb-0">No items in the current list view.</Alert>
+            ) : (
+              <div className="d-flex flex-column gap-2">
+                {filteredTimelineItems.map((item) => renderPlannerCard(item))}
+              </div>
+            )
+          ) : filteredTimelineItems.length === 0 ? (
+            <Alert variant="light" className="mb-0">No items in today’s plan.</Alert>
           ) : (
             bucketOrder.map((bucket) => {
               const items = filteredTimelineItems.filter((item) => item.bucket === bucket);
               if (items.length === 0) return null;
+              const bucketPoints = items.reduce((sum, item) => sum + plannerItemPoints(item), 0);
               return (
                 <div key={bucket} className="mb-3">
-                  <div className="text-uppercase text-muted small fw-semibold mb-1">{bucketLabel(bucket)}</div>
-                  <ListGroup variant="flush">
-                    {items.map((item) => {
-                      const editable = item.kind !== 'event';
-                      const variant = item.kind === 'story' ? 'info' : item.kind === 'chore' ? 'success' : item.kind === 'event' ? 'secondary' : 'primary';
-                      const kindLabel = item.kind === 'story' ? 'Story' : item.kind === 'chore' ? 'Chore' : item.kind === 'event' ? 'Event' : 'Task';
-                      return (
-                        <ListGroup.Item
-                          key={item.id}
-                          className="d-flex align-items-start gap-2 py-2 px-0 border-0 border-bottom"
-                          role={editable ? 'button' : undefined}
-                          tabIndex={editable ? 0 : undefined}
-                          onClick={() => editable && openItemEditor(item)}
-                          onKeyDown={(event) => {
-                            if (!editable) return;
-                            if (event.key === 'Enter' || event.key === ' ') {
-                              event.preventDefault();
-                              openItemEditor(item);
-                            }
-                          }}
-                          style={{ cursor: editable ? 'pointer' : 'default' }}
-                        >
-                          {editable && (
-                            <Button
-                              size="sm"
-                              variant="outline-success"
-                              className="rounded-circle d-inline-flex align-items-center justify-content-center p-1 mt-1"
-                              title={item.kind === 'chore' ? 'Mark instance done' : 'Mark done'}
-                              onClick={(event) => void handleItemDone(item, event)}
-                            >
-                              <Check size={14} />
-                            </Button>
-                          )}
-
-                          <div className="flex-grow-1 min-w-0">
-                            <div className="d-flex flex-wrap align-items-center gap-2 mb-1">
-                              <div className="fw-semibold text-truncate small">{item.title}</div>
-                              <Badge bg={variant}>{kindLabel}</Badge>
-                              {item.isTop3 && <Badge bg="danger">Top 3</Badge>}
-                              {item.isFocusAligned && <Badge bg="success">Focus</Badge>}
-                              {item.deferredUntilMs && item.deferredUntilMs > Date.now() && <Badge bg="warning" text="dark">Deferred</Badge>}
-                            </div>
-                            <div className="text-muted" style={{ fontSize: '0.74rem' }}>
-                              {[item.ref, item.timeLabel].filter(Boolean).join(' · ')}
-                            </div>
-                            {item.goalTitle && (
-                              <div className="d-flex align-items-center gap-1 mt-1" style={{ fontSize: '0.72rem', opacity: 0.8 }}>
-                                <Target size={12} />
-                                <span>{item.goalTitle}</span>
-                              </div>
-                            )}
-                          </div>
-
-                          {editable && (
-                            <div className="d-flex align-items-center gap-1 ms-2">
-                              <Button
-                                size="sm"
-                                variant="outline-secondary"
-                                title="Schedule now"
-                                className="d-inline-flex align-items-center justify-content-center p-1"
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  setScheduleTarget(item);
-                                }}
-                              >
-                                <CalendarPlus size={14} />
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="outline-warning"
-                                title="Defer intelligently"
-                                className="d-inline-flex align-items-center justify-content-center p-1"
-                                disabled={!item.sourceId || (!!item.isTop3 && item.kind !== 'chore')}
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  if (!item.sourceId) return;
-                                  setDeferTarget({ type: item.kind === 'story' ? 'story' : 'task', id: item.sourceId, title: item.title });
-                                }}
-                              >
-                                <Clock3 size={14} />
-                              </Button>
-                            </div>
-                          )}
-                        </ListGroup.Item>
-                      );
-                    })}
-                  </ListGroup>
+                  <div className="d-flex align-items-center justify-content-between gap-2 mb-1">
+                    <div className="text-uppercase text-muted small fw-semibold">{bucketLabel(bucket)}</div>
+                    <div className="text-muted" style={{ fontSize: '0.72rem' }}>
+                      {bucketPoints.toFixed(1)} pts in bucket{dayCapacity ? ` · ${dayCapacity.remainingPoints.toFixed(1)} pts free today` : ''}
+                    </div>
+                  </div>
+                  <div className="d-flex flex-column gap-2">
+                    {items.map((item) => renderPlannerCard(item))}
+                  </div>
                 </div>
               );
             })
@@ -793,13 +935,129 @@ const DailyPlanPage: React.FC = () => {
           itemType={deferTarget.type}
           itemId={deferTarget.id}
           itemTitle={deferTarget.title}
-          onApply={applyDefer}
+          focusContext={{
+            isFocusAligned: deferTarget.isFocusAligned,
+            activeFocusGoals: activeFocusGoals.map((focusGoal) => ({
+              id: focusGoal.id,
+              title: focusGoal.title || null,
+              focusRootGoalIds: Array.isArray(focusGoal.focusRootGoalIds) ? focusGoal.focusRootGoalIds : [],
+              focusLeafGoalIds: Array.isArray(focusGoal.focusLeafGoalIds) ? focusGoal.focusLeafGoalIds : [],
+              goalIds: Array.isArray(focusGoal.goalIds) ? focusGoal.goalIds : [],
+            })),
+          }}
+          onApply={async (payload) => {
+            if (!deferTarget) return;
+            const affectedItem = timelineWorkItems.find((item) => item.sourceId === deferTarget.id && item.kind === deferTarget.type) || null;
+            const debugRequestId = createPlannerActionId('defer');
+            console.info('[DailyPlanPage] defer_confirmed', {
+              debugRequestId,
+              itemType: deferTarget.type,
+              itemId: deferTarget.id,
+              title: deferTarget.title,
+              payload,
+              affectedItemId: affectedItem?.id || null,
+              linkedBlockId: affectedItem?.scheduledBlockId || null,
+            });
+            const result = await schedulePlannerItemMutation({
+              itemType: deferTarget.type,
+              itemId: deferTarget.id,
+              targetDateMs: payload.dateMs,
+              targetBucket: affectedItem?.timeOfDay || null,
+              intent: 'defer',
+              source: payload.source || 'daily_plan',
+              rationale: payload.rationale,
+              linkedBlockId: affectedItem?.scheduledBlockId || null,
+              durationMinutes: affectedItem
+                ? Math.max(
+                    15,
+                    Math.round((((affectedItem.scheduledBlockEnd || 0) - (affectedItem.scheduledBlockStart || 0)) / 60000)
+                      || Number((affectedItem.rawTask as any)?.estimateMin || (affectedItem.rawStory as any)?.estimateMin || 0)
+                      || 30),
+                  )
+                : null,
+              debugRequestId,
+            });
+            setPageMessage({ variant: 'success', text: `${deferTarget.title} deferred to ${new Date(result.appliedStartMs).toLocaleDateString()}.` });
+            setDeferTarget(null);
+          }}
         />
+      )}
+
+      {moveModal && (
+        <Modal show={!!moveModal} onHide={() => setMoveModal(null)} centered>
+          <Modal.Header closeButton>
+            <Modal.Title style={{ fontSize: 16 }}>Move item</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <div className="fw-semibold mb-2">{moveModal.item.title}</div>
+            <div className="text-muted small mb-3">{moveModal.recommendation?.rationale || 'Pick a bucket for this item.'}</div>
+            <Form.Group className="mb-3">
+              <Form.Label className="small text-muted">Date</Form.Label>
+              <Form.Control
+                type="date"
+                value={format(new Date(moveModal.recommendation?.targetDateMs || todayStartMs), 'yyyy-MM-dd')}
+                onChange={(e) => {
+                  const parsed = Date.parse(`${e.target.value}T12:00:00`);
+                  setMoveModal({
+                    ...moveModal,
+                    recommendation: {
+                      ...(moveModal.recommendation || { action: 'move_day', label: 'Move day', rationale: '' }),
+                      targetDateMs: parsed,
+                      targetBucket: moveModal.recommendation?.targetBucket || 'morning',
+                    },
+                  });
+                }}
+              />
+            </Form.Group>
+            <Form.Group>
+              <Form.Label className="small text-muted">Time of day</Form.Label>
+              <Form.Select
+                value={moveModal.recommendation?.targetBucket || 'morning'}
+                onChange={(e) => {
+                  setMoveModal({
+                    ...moveModal,
+                    recommendation: {
+                      ...(moveModal.recommendation || { action: 'move_day', label: 'Move day', rationale: '' }),
+                      targetDateMs: moveModal.recommendation?.targetDateMs || todayStartMs,
+                      targetBucket: e.target.value as TimelineBucket,
+                    },
+                  });
+                }}
+              >
+                {bucketOrder.map((bucket) => (
+                  <option key={bucket} value={bucket}>{bucketLabel(bucket)}</option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={() => setMoveModal(null)}>Cancel</Button>
+            <Button
+              variant="primary"
+              disabled={!moveModal.recommendation?.targetDateMs || !moveModal.recommendation?.targetBucket}
+              onClick={() => moveModal.recommendation?.targetDateMs != null && moveModal.recommendation?.targetBucket != null
+                ? void applyMove(moveModal.item, moveModal.recommendation.targetDateMs, moveModal.recommendation.targetBucket, moveModal.recommendation)
+                : undefined}
+            >
+              Save move
+            </Button>
+          </Modal.Footer>
+        </Modal>
       )}
 
       <EditTaskModal show={!!editTask} task={editTask} onHide={() => setEditTask(null)} onUpdated={() => setEditTask(null)} />
       <EditStoryModal show={!!editStory} onHide={() => setEditStory(null)} story={editStory} goals={goals} onStoryUpdated={() => setEditStory(null)} />
-      <NewCalendarEventModal show={!!scheduleTarget} onHide={() => setScheduleTarget(null)} initialValues={scheduleInitialValues} stories={scheduleStories} onSaved={() => setScheduleTarget(null)} />
+      <NewCalendarEventModal
+        show={!!scheduleTarget}
+        onHide={() => setScheduleTarget(null)}
+        initialValues={scheduleInitialValues}
+        stories={scheduleStories}
+        onSaved={() => {
+          const scheduledTitle = scheduleTarget?.title || 'Item';
+          setScheduleTarget(null);
+          setPageMessage({ variant: 'success', text: `${scheduledTitle} added to your calendar.` });
+        }}
+      />
     </Container>
   );
 };

--- a/react-app/src/components/Dashboard.tsx
+++ b/react-app/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Container, Card, Row, Col, Badge, Button, Alert, Collapse, OverlayTrigger, Tooltip, Form, Spinner, Table, ProgressBar } from 'react-bootstrap';
+import { Container, Card, Row, Col, Badge, Button, Alert, Collapse, OverlayTrigger, Tooltip, Form, Spinner, Table } from 'react-bootstrap';
 import { useNavigate, Link } from 'react-router-dom';
 import { Target, BookOpen, TrendingUp, Wallet, Clock, ListChecks, Calendar as CalendarIcon, LayoutGrid, RefreshCw, Sparkles, Activity, GripVertical, Heart, CheckCircle, X } from 'lucide-react';
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, closestCenter } from '@dnd-kit/core';
@@ -25,6 +25,8 @@ import SprintMetricsPanel from './SprintMetricsPanel';
 import JournalInsightsCard from './JournalInsightsCard';
 import BirthdayMilestoneCard from './BirthdayMilestoneCard';
 import KpiDashboardWidget from './KpiDashboardWidget';
+import DailyPlanSummaryCard from './planner/DailyPlanSummaryCard';
+import WeeklyPlannerSummaryCard from './planner/WeeklyPlannerSummaryCard';
 import { GLOBAL_THEMES, LEGACY_THEME_MAP } from '../constants/globalThemes';
 import { useGlobalThemes } from '../hooks/useGlobalThemes';
 import { useUnifiedPlannerData, type PlannerRange } from '../hooks/useUnifiedPlannerData';
@@ -503,7 +505,7 @@ const DASHBOARD_WIDGET_CONFIG: Array<{ key: DashboardWidgetKey; label: string }>
   { key: 'dailySummary', label: 'Daily summary' },
   { key: 'top3', label: 'Top 3 priorities' },
   { key: 'themeProgress', label: 'Theme progress' },
-  { key: 'kpiStudio', label: 'KPI studio' },
+  { key: 'kpiStudio', label: 'Pinned focus KPIs' },
   { key: 'unifiedTimeline', label: 'Daily Plan' },
   { key: 'tasksDueToday', label: 'Tasks due today' },
   { key: 'choresHabits', label: 'Chores & habits' },
@@ -1110,14 +1112,15 @@ const Dashboard: React.FC = () => {
     const gridWidth = grid ? grid.getBoundingClientRect().width : window.innerWidth - 80;
     if (gridWidth < 300) return;
     const gap = 4;
-    // Daily timeline takes 75% of the grid; Top 3 priorities fills the remaining 25%
+    // Keep the top summary widgets visually aligned by default while preserving relative widths.
     const threeQuarter = Math.max(400, Math.floor((gridWidth - gap) * 0.75));
     const quarter = Math.max(220, Math.floor((gridWidth - gap) * 0.25));
     const third = Math.max(240, Math.floor((gridWidth - gap * 2) / 3));
     setWidgetSizes({
-      unifiedTimeline: { width: threeQuarter, height: 600 },
-      top3: { width: quarter, height: 600 },
+      unifiedTimeline: { width: threeQuarter, height: 420 },
+      top3: { width: quarter, height: 420 },
       dailySummary: { width: third, height: 420 },
+      kpiStudio: { width: third, height: 420 },
       choresHabits: { width: third, height: 420 },
       lowHangingFruit: { width: third, height: 400 },
       themeProgress: { width: third, height: 400 },
@@ -1169,13 +1172,21 @@ const Dashboard: React.FC = () => {
   }, []);
 
   const monzoLastSyncDate = useMemo(() => {
-    if (!monzoIntegrationStatus) return null;
-    return decodeToDate(
-      monzoIntegrationStatus.lastSyncAt
-      ?? monzoIntegrationStatus.lastSyncedAt
-      ?? monzoIntegrationStatus.lastSync,
-    );
-  }, [decodeToDate, monzoIntegrationStatus]);
+    const candidates = [
+      decodeToDate(
+        monzoIntegrationStatus?.lastSyncAt
+        ?? monzoIntegrationStatus?.lastSyncedAt
+        ?? monzoIntegrationStatus?.lastSync,
+      ),
+      decodeToDate(profileSnapshot?.monzoLastSyncAt ?? profileSnapshot?.monzoLastSyncedAt),
+      decodeToDate(monzoSummary?.updatedAt),
+    ].filter((value): value is Date => value instanceof Date && !Number.isNaN(value.getTime()));
+
+    if (candidates.length === 0) return null;
+    return candidates.reduce((latest, current) => (
+      current.getTime() > latest.getTime() ? current : latest
+    ));
+  }, [decodeToDate, monzoIntegrationStatus, monzoSummary?.updatedAt, profileSnapshot?.monzoLastSyncAt, profileSnapshot?.monzoLastSyncedAt]);
 
   const monzoSyncAgeDays = useMemo(() => {
     if (!monzoLastSyncDate) return null;
@@ -1302,7 +1313,7 @@ const Dashboard: React.FC = () => {
     const macroTone = macroAdherencePct == null ? 'secondary' : macroAdherencePct >= 80 ? 'success' : macroAdherencePct >= 60 ? 'warning' : 'danger';
     const bodyFatGoalProgressPct = bodyFatPct == null
       ? null
-      : (bodyFatPct <= bodyFatGoalPct ? 100 : clampPct((bodyFatGoalPct / bodyFatPct) * 100));
+      : (bodyFatPct <= bodyFatGoalPct ? 100 : 0);
     const primaryProgressPct = bodyFatGoalProgressPct ?? macroAdherencePct ?? null;
     const primaryProgressLabel = bodyFatGoalProgressPct != null
       ? `Body fat target ${bodyFatGoalPct}%`
@@ -2900,6 +2911,88 @@ const Dashboard: React.FC = () => {
     });
     return map;
   }, [recentStories, sprintStories, storyRefLabel]);
+
+  const top3TargetsByRef = useMemo(() => {
+    const map = new Map<string, { href: string; label: string }>();
+    top3Stories.forEach((story) => {
+      const ref = storyRefLabel(story).toUpperCase();
+      if (!ref) return;
+      map.set(ref, {
+        href: `/stories/${story.id}`,
+        label: `${storyRefLabel(story)} — ${story.title || 'Story'}`,
+      });
+    });
+    top3Tasks.forEach((task) => {
+      const ref = taskRefLabel(task).toUpperCase();
+      if (!ref) return;
+      map.set(ref, {
+        href: `/tasks/${task.id}`,
+        label: `${taskRefLabel(task)} — ${task.title || 'Task'}`,
+      });
+    });
+    return map;
+  }, [top3Stories, top3Tasks, storyRefLabel, taskRefLabel]);
+
+  const renderDailySummaryLine = useCallback((line: string) => {
+    const text = String(line || '').trim();
+    if (!text) return text;
+    if (!text.toLowerCase().startsWith('focus:')) return text;
+
+    const lineUpper = text.toUpperCase();
+    const top3Match = Array.from(top3TargetsByRef.entries()).find(([ref]) => lineUpper.includes(ref));
+    const refMatch = text.match(/\b[A-Z]{2,4}-[A-Z0-9]{4,}\b/i);
+    const matchedRef = String(top3Match?.[0] || refMatch?.[0] || '').toUpperCase();
+    const target = top3Match
+      ? top3Match[1]
+      : (() => {
+          if (!matchedRef) return null;
+          const matchedTask = tasksByRef.get(matchedRef);
+          if (matchedTask) {
+            return {
+              href: `/tasks/${matchedTask.id}`,
+              label: `${taskRefLabel(matchedTask)} — ${matchedTask.title || 'Task'}`,
+            };
+          }
+          const matchedStory = storiesByRef.get(matchedRef);
+          if (matchedStory) {
+            return {
+              href: `/stories/${matchedStory.id}`,
+              label: `${storyRefLabel(matchedStory)} — ${matchedStory.title || 'Story'}`,
+            };
+          }
+          return null;
+        })();
+
+    if (!target) return text;
+
+    const labelIndex = lineUpper.indexOf(target.label.toUpperCase());
+    if (labelIndex >= 0) {
+      const prefix = text.slice(0, labelIndex);
+      const suffix = text.slice(labelIndex + target.label.length);
+      return (
+        <>
+          {prefix}
+          <a href={target.href} className="text-decoration-none">{target.label}</a>
+          {suffix}
+        </>
+      );
+    }
+
+    const refIndex = matchedRef ? lineUpper.indexOf(matchedRef) : -1;
+    if (refIndex >= 0 && matchedRef) {
+      const prefix = text.slice(0, refIndex);
+      const suffix = text.slice(refIndex + matchedRef.length);
+      return (
+        <>
+          {prefix}
+          <a href={target.href} className="text-decoration-none">{text.slice(refIndex, refIndex + matchedRef.length)}</a>
+          {suffix}
+        </>
+      );
+    }
+
+    return text;
+  }, [storiesByRef, storyRefLabel, taskRefLabel, tasksByRef, top3TargetsByRef]);
 
   const nextWorkPath = useMemo(() => {
     const item = nextWorkRecommendation?.recommendedItem;
@@ -4567,15 +4660,15 @@ const Dashboard: React.FC = () => {
                       : 'linear-gradient(135deg, #0d6efd 0%, #0b5ed7 100%)',
                   border: 'none',
                   color: '#fff',
-                  boxShadow: '0 8px 24px rgba(13, 110, 253, 0.22)'
+                  boxShadow: '0 6px 18px rgba(13, 110, 253, 0.18)'
                 }}
               >
-                <Card.Body style={{ padding: '12px 16px' }}>
-                  <div className="d-flex align-items-center gap-3 flex-wrap">
+                <Card.Body style={{ padding: '10px 14px' }}>
+                  <div className="d-flex align-items-center gap-2 flex-wrap">
                     <div
                       style={{
-                        width: 40,
-                        height: 40,
+                        width: 34,
+                        height: 34,
                         borderRadius: 8,
                         backgroundColor: 'rgba(255, 255, 255, 0.18)',
                         display: 'flex',
@@ -4585,13 +4678,13 @@ const Dashboard: React.FC = () => {
                         flexShrink: 0,
                       }}
                     >
-                      <Heart size={20} />
+                      <Heart size={18} />
                     </div>
                     <div style={{ flex: 1, minWidth: 220 }}>
-                      <div style={{ margin: 0, fontSize: 14, fontWeight: 700 }}>
+                      <div style={{ margin: 0, fontSize: 13, fontWeight: 700 }}>
                         Daily Health Progress
                       </div>
-                      <div style={{ marginTop: 2, fontSize: 11, opacity: 0.9 }}>
+                      <div style={{ marginTop: 2, fontSize: 10.5, opacity: 0.9 }}>
                         {healthBannerData.weightKg != null ? `${healthBannerData.weightKg.toFixed(1)} kg` : 'weight missing'}
                         {' • '}
                         {healthBannerData.bodyFatPct != null ? `${healthBannerData.bodyFatPct.toFixed(1)}% body fat` : 'body fat missing'}
@@ -4603,11 +4696,11 @@ const Dashboard: React.FC = () => {
                         {healthBannerData.weeksToTargetBodyFat != null ? `${Math.round(healthBannerData.weeksToTargetBodyFat)}w ETA` : 'ETA n/a'}
                       </div>
                     </div>
-                    <div style={{ textAlign: 'right', minWidth: 72 }}>
-                      <div style={{ fontSize: 20, fontWeight: 800, lineHeight: 1 }}>
+                    <div style={{ textAlign: 'right', minWidth: 64 }}>
+                      <div style={{ fontSize: 18, fontWeight: 800, lineHeight: 1 }}>
                         {healthBannerData.primaryProgressPct != null ? `${healthBannerData.primaryProgressPct}%` : '—'}
                       </div>
-                      <div style={{ fontSize: 11, opacity: 0.85 }}>
+                      <div style={{ fontSize: 10, opacity: 0.85 }}>
                         {healthBannerData.primaryProgressLabel}
                       </div>
                     </div>
@@ -4631,19 +4724,7 @@ const Dashboard: React.FC = () => {
                     </button>
                   </div>
 
-                  <div style={{ marginTop: 8 }}>
-                    <ProgressBar
-                      now={healthBannerData.primaryProgressPct ?? 0}
-                      style={{
-                        height: 4,
-                        backgroundColor: 'rgba(255, 255, 255, 0.22)',
-                        borderRadius: 2,
-                      }}
-                      className="bg-light"
-                    />
-                  </div>
-
-                  <div className="d-flex align-items-center justify-content-between gap-2 flex-wrap" style={{ marginTop: 8, fontSize: 11, opacity: 0.9 }}>
+                  <div className="d-flex align-items-center justify-content-between gap-2 flex-wrap" style={{ marginTop: 8, fontSize: 10.5, opacity: 0.9 }}>
                     <div>
                       Source {healthBannerData.sourceLabel}
                       {' • '}
@@ -5400,6 +5481,9 @@ const Dashboard: React.FC = () => {
                       <Button variant="outline-secondary" size="sm" onClick={() => navigate('/sprints/kanban')}>
                         <LayoutGrid size={14} className="me-1" /> View kanban
                       </Button>
+                      <Button variant="outline-secondary" size="sm" onClick={() => navigate('/planner/weekly')}>
+                        <Clock size={14} className="me-1" /> 7-day planner
+                      </Button>
                       <Button
                         variant="outline-primary"
                         size="sm"
@@ -5470,7 +5554,7 @@ const Dashboard: React.FC = () => {
                                     const half = Math.max(300, Math.floor((gridWidth - gap) / 2));
                                     const third = Math.max(240, Math.floor((gridWidth - gap * 2) / 3));
                                     setWidgetSizes({
-                                      unifiedTimeline: { width: half, height: 600 },
+                                      unifiedTimeline: { width: half, height: 420 },
                                       top3: { width: third, height: 420 },
                                       dailySummary: { width: third, height: 420 },
                                       kpiStudio: { width: third, height: 420 },
@@ -5631,7 +5715,7 @@ const Dashboard: React.FC = () => {
                                     )}
                                     <ul className="mb-0 small">
                                       {dailySummaryLines.map((line, idx) => (
-                                        <li key={idx}>{line}</li>
+                                        <li key={idx}>{renderDailySummaryLine(line)}</li>
                                       ))}
                                     </ul>
                                   </div>
@@ -6176,21 +6260,10 @@ const Dashboard: React.FC = () => {
                             className="dashboard-widget-shell"
                             style={getWidgetSizeStyle('unifiedTimeline', 360)}
                           >
-                            <Card className="shadow-sm border-0 dashboard-calendar-card d-flex flex-column">
-                              <Card.Header className="d-flex align-items-center justify-content-between">
-                                <div className="fw-semibold d-flex align-items-center gap-2">
-                                  <CalendarIcon size={16} /> Daily Plan
-                                </div>
-                                <div className="d-flex align-items-center gap-2">
-                                  <Badge bg="secondary" pill>Disabled</Badge>
-                                </div>
-                              </Card.Header>
-                              <Card.Body ref={timelineScrollBodyRef} className="p-3 d-flex flex-column flex-grow-1" style={{ minHeight: 0, overflowY: 'auto' }}>
-                                <Alert variant="secondary" className="mb-0 py-2">
-                                  Daily Plan is temporarily disabled while due-date and sync issues are investigated.
-                                </Alert>
-                              </Card.Body>
-                            </Card>
+                            <div className="d-flex flex-column gap-3 h-100 dashboard-summary-stack">
+                              <DailyPlanSummaryCard />
+                              <WeeklyPlannerSummaryCard />
+                            </div>
                             {renderWidgetEdgeHandles('unifiedTimeline')}
                             {renderWidgetResizeHandle('unifiedTimeline', 360, 'Resize Daily Plan widget')}
                           </div>

--- a/react-app/src/components/DeferItemModal.tsx
+++ b/react-app/src/components/DeferItemModal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Alert, Button, Form, Modal, Spinner } from 'react-bootstrap';
 import { httpsCallable } from 'firebase/functions';
 import { functions } from '../firebase';
+import { normalizePlannerSchedulingError } from '../utils/plannerScheduling';
 
 type ItemType = 'task' | 'story';
 
@@ -20,6 +21,16 @@ interface DeferItemModalProps {
   itemType: ItemType;
   itemId: string;
   itemTitle: string;
+  focusContext?: {
+    isFocusAligned?: boolean;
+    activeFocusGoals?: Array<{
+      id: string;
+      title?: string | null;
+      focusRootGoalIds?: string[];
+      focusLeafGoalIds?: string[];
+      goalIds?: string[];
+    }>;
+  };
   onApply: (payload: { dateMs: number; rationale: string; source: string }) => Promise<void>;
 }
 
@@ -43,6 +54,7 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
   itemType,
   itemId,
   itemTitle,
+  focusContext,
   onApply,
 }) => {
   const [loading, setLoading] = useState(false);
@@ -54,21 +66,35 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
   const [selectedKey, setSelectedKey] = useState<string>('');
   const [customDate, setCustomDate] = useState<string>('');
   const [showMoreSuggestions, setShowMoreSuggestions] = useState(false);
+  const hasFocusPressure = !focusContext?.isFocusAligned && (focusContext?.activeFocusGoals?.length || 0) > 0;
 
   useEffect(() => {
     if (!show) return;
     let cancelled = false;
+    console.info('[DeferItemModal] opened', { itemType, itemId, itemTitle });
 
     const loadOptions = async () => {
       setLoading(true);
       setError(null);
       try {
         const callable = httpsCallable(functions, 'suggestDeferralOptions');
-        const resp: any = await callable({ itemType, itemId, horizonDays: 21 });
+        const resp: any = await callable({
+          itemType,
+          itemId,
+          horizonDays: 21,
+          focusContext,
+        });
         const next = Array.isArray(resp?.data?.options) ? resp.data.options : [];
         const top = Array.isArray(resp?.data?.topOptions) ? resp.data.topOptions : next.slice(0, 3);
         const more = Array.isArray(resp?.data?.moreOptions) ? resp.data.moreOptions : next.slice(3);
         if (cancelled) return;
+        console.info('[DeferItemModal] suggestions_loaded', {
+          itemType,
+          itemId,
+          options: next.length,
+          topOptions: top.length,
+          moreOptions: more.length,
+        });
         setOptions(next);
         setTopOptions(top);
         setMoreOptions(more);
@@ -76,7 +102,8 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
         setShowMoreSuggestions(false);
       } catch (err: any) {
         if (cancelled) return;
-        setError(err?.message || 'Could not generate defer suggestions.');
+        console.error('[DeferItemModal] suggestions_failed', { itemType, itemId, err });
+        setError(normalizePlannerSchedulingError(err).message || 'Could not generate defer suggestions.');
         setOptions([]);
         setTopOptions([]);
         setMoreOptions([]);
@@ -90,7 +117,7 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [show, itemId, itemType]);
+  }, [show, itemId, itemType, itemTitle, focusContext]);
 
   const selectedOption = useMemo(
     () => options.find((opt) => opt.key === selectedKey) || null,
@@ -127,11 +154,21 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
     }
 
     setApplying(true);
+    console.info('[DeferItemModal] apply_clicked', {
+      itemType,
+      itemId,
+      itemTitle,
+      selectedKey,
+      dateMs,
+      source,
+      rationale,
+    });
     try {
       await onApply({ dateMs, rationale, source });
       onHide();
     } catch (err: any) {
-      setError(err?.message || 'Failed to defer this item.');
+      console.error('[DeferItemModal] apply_failed', { itemType, itemId, err });
+      setError(normalizePlannerSchedulingError(err).message || 'Failed to defer this item.');
     } finally {
       setApplying(false);
     }
@@ -149,6 +186,11 @@ const DeferItemModal: React.FC<DeferItemModalProps> = ({
         <p className="text-muted small mb-3">
           Suggestions are ranked to reduce near-term overload using sprint windows and calendar utilization.
         </p>
+        {hasFocusPressure && (
+          <Alert variant="info" className="py-2 small">
+            This item is outside your active focus goals. Deferring it can free capacity for focus work.
+          </Alert>
+        )}
 
         {error && <Alert variant="warning" className="py-2">{error}</Alert>}
 

--- a/react-app/src/components/EditStoryModal.tsx
+++ b/react-app/src/components/EditStoryModal.tsx
@@ -91,8 +91,8 @@ const EditStoryModal: React.FC<EditStoryModalProps> = ({
     [editedStory.goalId, goals],
   );
   const sprintAlignment = useMemo(
-    () => evaluateStorySprintAlignment(selectedSprint as any, editedStory.goalId || ''),
-    [selectedSprint, editedStory.goalId],
+    () => evaluateStorySprintAlignment(selectedSprint as any, editedStory.goalId || '', goals),
+    [selectedSprint, editedStory.goalId, goals],
   );
 
   const reloadLinkedTasks = useCallback(async (sourceStory: Story | null) => {

--- a/react-app/src/components/EditTaskModal.tsx
+++ b/react-app/src/components/EditTaskModal.tsx
@@ -4,7 +4,6 @@ import { Modal, Button, Form, Row, Col } from 'react-bootstrap';
 import { doc, updateDoc, serverTimestamp, collection, query, where, orderBy, limit, onSnapshot, addDoc, deleteDoc } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 import { useNavigate } from 'react-router-dom';
-import { useSidebar } from '../contexts/SidebarContext';
 import { db, functions } from '../firebase';
 import { useSprint } from '../contexts/SprintContext';
 import { Task, Sprint, Story, Goal } from '../types';
@@ -22,6 +21,7 @@ import { findSprintForDate } from '../utils/taskSprintHelpers';
 import { parsePointsValue, TASK_DEFAULT_POINTS } from '../utils/points';
 import { planningSprints } from '../utils/sprintFilter';
 import { getGoalDisplayPath, getLeafGoalOptions, resolveLeafGoalSelection } from '../utils/goalHierarchy';
+import EditStoryModal from './EditStoryModal';
 
 interface EditTaskModalProps {
   show: boolean;
@@ -81,7 +81,6 @@ const formatSprintLabel = (sprint: Sprint, statusOverride?: string) => {
 
 const EditTaskModal: React.FC<EditTaskModalProps> = ({ show, task, onHide, onUpdated, container }) => {
   const navigate = useNavigate();
-  const { showSidebar } = useSidebar();
   const { currentUser } = useAuth();
   const { currentPersona } = usePersona();
   const { sprints } = useSprint();
@@ -104,12 +103,13 @@ const EditTaskModal: React.FC<EditTaskModalProps> = ({ show, task, onHide, onUpd
     tags: [] as string[],
     type: 'task' as 'task' | 'chore' | 'routine' | 'habit' | 'read' | 'watch',
     repeatFrequency: '' as '' | 'daily' | 'weekly' | 'monthly' | 'yearly',
-    repeatInterval: 1 as number,
+    repeatInterval: 1 as number | string,
     daysOfWeek: [] as string[],
     persona: 'personal' as 'personal' | 'work',
   });
   const [storyInput, setStoryInput] = useState('');
   const [goalInput, setGoalInput] = useState('');
+  const [showLinkedStoryModal, setShowLinkedStoryModal] = useState(false);
   const [stories, setStories] = useState<Story[]>([]);
   const [goals, setGoals] = useState<Goal[]>([]);
   const [converting, setConverting] = useState(false);
@@ -570,8 +570,11 @@ const EditTaskModal: React.FC<EditTaskModalProps> = ({ show, task, onHide, onUpd
                         type="number"
                         min={1}
                         max={365}
-                        value={form.repeatInterval || 1}
-                        onChange={(e) => setForm({ ...form, repeatInterval: Number(e.target.value) || 1 })}
+                        value={form.repeatInterval ?? ''}
+                        onChange={(e) => setForm({
+                          ...form,
+                          repeatInterval: e.target.value === '' ? '' : e.target.value,
+                        })}
                       />
                     </Col>
                   </Row>
@@ -802,9 +805,9 @@ const EditTaskModal: React.FC<EditTaskModalProps> = ({ show, task, onHide, onUpd
                           size="sm"
                           variant="link"
                           className="p-0"
-                          onClick={() => { onHide(); showSidebar(linkedStory as any, 'story'); }}
+                          onClick={() => setShowLinkedStoryModal(true)}
                         >
-                          View linked story
+                          Edit linked story
                         </Button>
                       </div>
                     ) : null}
@@ -875,6 +878,12 @@ const EditTaskModal: React.FC<EditTaskModalProps> = ({ show, task, onHide, onUpd
           {saving ? 'Saving...' : task ? 'Save' : 'Create task'}
         </Button>
       </Modal.Footer>
+      <EditStoryModal
+        show={showLinkedStoryModal && !!linkedStory}
+        story={linkedStory}
+        goals={goals}
+        onHide={() => setShowLinkedStoryModal(false)}
+      />
     </Modal>
   );
 };

--- a/react-app/src/components/FocusGoalCountdownBanner.tsx
+++ b/react-app/src/components/FocusGoalCountdownBanner.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Card, Badge, ProgressBar, Row, Col, Button } from 'react-bootstrap';
-import { AlertCircle, Zap, Calendar, Target, TrendingUp } from 'lucide-react';
+import { AlertCircle, Zap, Target } from 'lucide-react';
 import { FocusGoal, Goal, Story } from '../types';
 import { FitnessKPIQuickStatus } from './FitnessKPIDisplay';
 import { collection, onSnapshot, query, where } from 'firebase/firestore';
@@ -16,21 +16,22 @@ interface MonzoGoalSummary {
   potName: string | null;
 }
 
+interface GoalKpiMetricRow {
+  resolvedKpis?: any[];
+  updatedAt?: any;
+}
+
 interface FocusGoalCountdownBannerProps {
   focusGoal: FocusGoal;
   goals: Goal[];
   stories: Story[];
   onEdit?: () => void;
+  onDelete?: () => void;
   onRefresh?: () => void | Promise<void>;
   refreshing?: boolean;
   compact?: boolean;
   monzoBudgetSummary?: any;
   monzoGoalAlignment?: { goals: MonzoGoalSummary[] } | null;
-}
-
-interface GoalKpiMetricRow {
-  resolvedKpis?: any[];
-  updatedAt?: any;
 }
 
 const getUrgency = (daysRemaining: number): 'critical' | 'high' | 'normal' | 'low' => {
@@ -80,17 +81,29 @@ export const FocusGoalCountdownBanner: React.FC<FocusGoalCountdownBannerProps> =
   monzoBudgetSummary,
   monzoGoalAlignment,
   onEdit,
+  onDelete,
   onRefresh,
   refreshing = false,
   compact = false
 }) => {
   const [goalKpiMetrics, setGoalKpiMetrics] = useState<Record<string, GoalKpiMetricRow>>({});
   const protectedGoalIds = useMemo(() => new Set(getProtectedFocusGoalIds(focusGoal)), [focusGoal]);
-
   const ownerUid = useMemo(
-    () => String((focusGoal as any)?.ownerUid || goals.find((g) => !!(g as any)?.ownerUid)?.ownerUid || '').trim(),
+    () => String((focusGoal as any)?.ownerUid || goals.find((goal) => !!(goal as any)?.ownerUid)?.ownerUid || '').trim(),
     [focusGoal, goals]
   );
+
+  const focusRootGoalIds = useMemo(() => (
+    Array.isArray(focusGoal.focusRootGoalIds) && focusGoal.focusRootGoalIds.length > 0
+      ? focusGoal.focusRootGoalIds
+      : focusGoal.goalIds || []
+  ), [focusGoal.focusRootGoalIds, focusGoal.goalIds]);
+
+  const focusLeafGoalIds = useMemo(() => (
+    Array.isArray(focusGoal.focusLeafGoalIds) && focusGoal.focusLeafGoalIds.length > 0
+      ? focusGoal.focusLeafGoalIds
+      : focusGoal.goalIds || []
+  ), [focusGoal.focusLeafGoalIds, focusGoal.goalIds]);
 
   useEffect(() => {
     if (!ownerUid) {
@@ -99,17 +112,17 @@ export const FocusGoalCountdownBanner: React.FC<FocusGoalCountdownBannerProps> =
     }
     const metricsQuery = query(collection(db, 'goal_kpi_metrics'), where('ownerUid', '==', ownerUid));
     const unsubscribe = onSnapshot(metricsQuery, (snap) => {
-      const map: Record<string, GoalKpiMetricRow> = {};
+      const next: Record<string, GoalKpiMetricRow> = {};
       snap.docs.forEach((docSnap) => {
         const data = docSnap.data() as any;
         const goalId = String(data?.goalId || '').trim();
         if (!goalId || !isGoalInHierarchySet(goalId, goals, protectedGoalIds)) return;
-        map[goalId] = {
+        next[goalId] = {
           resolvedKpis: Array.isArray(data?.resolvedKpis) ? data.resolvedKpis : [],
           updatedAt: data?.updatedAt || null,
         };
       });
-      setGoalKpiMetrics(map);
+      setGoalKpiMetrics(next);
     }, () => {
       setGoalKpiMetrics({});
     });
@@ -164,8 +177,13 @@ export const FocusGoalCountdownBanner: React.FC<FocusGoalCountdownBannerProps> =
 
   // Get selected goals
   const selectedGoals = useMemo(
-    () => goals.filter((goal) => isGoalInHierarchySet(goal.id, goals, protectedGoalIds)),
-    [goals, protectedGoalIds]
+    () => goals.filter(g => focusLeafGoalIds.includes(g.id)),
+    [goals, focusLeafGoalIds]
+  );
+
+  const rootGoals = useMemo(
+    () => goals.filter((goal) => focusRootGoalIds.includes(goal.id)),
+    [goals, focusRootGoalIds]
   );
 
   // Get stories linked to focus goals
@@ -181,14 +199,6 @@ export const FocusGoalCountdownBanner: React.FC<FocusGoalCountdownBannerProps> =
     const progress = total > 0 ? Math.round((done / total) * 100) : 0;
     return { total, done, progress };
   }, [focusStories]);
-
-  // Calculate overall goal progress
-  const goalProgress = useMemo(() => {
-    const total = selectedGoals.length;
-    const done = selectedGoals.filter(g => g.status === 2).length;
-    const progress = total > 0 ? Math.round((done / total) * 100) : 0;
-    return { total, done, progress };
-  }, [selectedGoals]);
 
   const alignmentStats = useMemo(() => {
     const nonFocus = goals.filter((goal) => !isGoalInHierarchySet(goal.id, goals, protectedGoalIds) && goal.status !== 2);
@@ -296,7 +306,7 @@ export const FocusGoalCountdownBanner: React.FC<FocusGoalCountdownBannerProps> =
             </div>
             <div>
               <h5 style={{ margin: 0, fontWeight: '700' }}>
-                {getUrgencyIcon(urgency)} Focus Goals
+                {getUrgencyIcon(urgency)} {focusGoal.title?.trim() || 'Focus Goals'}
               </h5>
               <small style={{ color: '#666' }}>
                 {focusGoal.timeframe === 'sprint'
@@ -358,27 +368,27 @@ export const FocusGoalCountdownBanner: React.FC<FocusGoalCountdownBannerProps> =
           <Col md={4}>
             <div style={{ textAlign: 'center', padding: '12px', background: '#f8f9fa', borderRadius: '8px' }}>
               <div style={{ fontSize: '18px', fontWeight: '700', color: '#0066cc' }}>
-                {selectedGoals.length}
+                {rootGoals.length}
               </div>
-              <small style={{ color: '#666' }}>Focus Goals</small>
+              <small style={{ color: '#666' }}>Programs</small>
             </div>
           </Col>
           <Col md={4}>
             <div style={{ textAlign: 'center', padding: '12px', background: '#f8f9fa', borderRadius: '8px' }}>
               <div style={{ fontSize: '18px', fontWeight: '700', color: '#28a745' }}>
-                {storyStats.total}
+                {selectedGoals.length}
               </div>
-              <small style={{ color: '#666' }}>Stories</small>
+              <small style={{ color: '#666' }}>Leaf Goals</small>
             </div>
           </Col>
           <Col md={4}>
             <div style={{ textAlign: 'center', padding: '12px', background: '#f8f9fa', borderRadius: '8px' }}>
               <div style={{ fontSize: '18px', fontWeight: '700', color: '#fd7e14' }}>
-                {goalProgress.total > 0
-                  ? `${goalProgress.done}/${goalProgress.total}`
+                {storyStats.total > 0
+                  ? `${storyStats.done}/${storyStats.total}`
                   : '—'}
               </div>
-              <small style={{ color: '#666' }}>Goals Complete</small>
+              <small style={{ color: '#666' }}>Stories Complete</small>
             </div>
           </Col>
         </Row>
@@ -392,14 +402,27 @@ export const FocusGoalCountdownBanner: React.FC<FocusGoalCountdownBannerProps> =
           fontSize: '12px',
           color: '#495057'
         }}>
-          <strong>Focus Alignment:</strong> {selectedGoals.length} goals selected • {alignmentStats.deferredNonFocus}/{alignmentStats.nonFocusCount} non-focus goals deferred ({alignmentStats.alignedPercent}% aligned)
+          <strong>Focus Alignment:</strong> {rootGoals.length} program goal{rootGoals.length === 1 ? '' : 's'} • {selectedGoals.length} execution leaf goal{selectedGoals.length === 1 ? '' : 's'} • {alignmentStats.deferredNonFocus}/{alignmentStats.nonFocusCount} non-focus goals deferred ({alignmentStats.alignedPercent}% aligned)
         </div>
+
+        {rootGoals.length > 0 && (
+          <div style={{ marginBottom: '16px' }}>
+            <h6 style={{ fontWeight: '600', marginBottom: '8px' }}>Program Goals</h6>
+            <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+              {rootGoals.map((goal) => (
+                <Badge key={goal.id} bg="light" text="dark" pill style={{ padding: '8px 10px', fontWeight: 500 }}>
+                  {getGoalDisplayPath(goal.id, goals)}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Goals List */}
         <div style={{ marginBottom: '16px' }}>
           <h6 style={{ fontWeight: '600', marginBottom: '12px', display: 'flex', alignItems: 'center', gap: '6px' }}>
             <Target size={16} />
-            Selected Goals
+            Execution Leaf Goals
           </h6>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '12px' }}>
             {selectedGoals.map(goal => {
@@ -443,14 +466,13 @@ export const FocusGoalCountdownBanner: React.FC<FocusGoalCountdownBannerProps> =
                       </div>
                     )}
 
-                    {/* Fitness KPIs if present (legacy goal.kpis quick status) */}
+                    {/* Fitness KPIs if present */}
                     {goal.kpis && goal.kpis.length > 0 && (
                       <div style={{ marginTop: '8px', fontSize: '11px' }}>
                         <FitnessKPIQuickStatus kpis={goal.kpis} />
                       </div>
                     )}
 
-                    {/* KPI mini charts from goal_kpi_metrics */}
                     {resolvedKpis.length > 0 && (
                       <div style={{ marginTop: '8px', fontSize: '11px' }}>
                         <div style={{ color: '#495057', fontWeight: 600, marginBottom: '4px' }}>
@@ -540,6 +562,11 @@ export const FocusGoalCountdownBanner: React.FC<FocusGoalCountdownBannerProps> =
           {onEdit && (
             <Button size="sm" variant="outline-primary" onClick={onEdit}>
               Edit Focus Goals
+            </Button>
+          )}
+          {onDelete && (
+            <Button size="sm" variant="outline-danger" onClick={onDelete}>
+              Delete Focus Set
             </Button>
           )}
           <Button

--- a/react-app/src/components/FocusGoalWizard.tsx
+++ b/react-app/src/components/FocusGoalWizard.tsx
@@ -105,7 +105,9 @@ export const FocusGoalWizard: React.FC<FocusGoalWizardProps> = ({
   const [matching, setMatching] = useState(false);
   const [error, setError] = useState('');
   const [copiedGoalRef, setCopiedGoalRef] = useState<string | null>(null);
+  const [focusTitle, setFocusTitle] = useState('');
   const [visionText, setVisionText] = useState('');
+  const [customEndDateInput, setCustomEndDateInput] = useState('');
   const [prompts, setPrompts] = useState<IntentPrompt[]>([]);
   const [selectedPromptId, setSelectedPromptId] = useState('');
   const [intentResult, setIntentResult] = useState<IntentResult | null>(null);
@@ -116,6 +118,7 @@ export const FocusGoalWizard: React.FC<FocusGoalWizardProps> = ({
   const [draftLeafGoals, setDraftLeafGoals] = useState<DraftLeafGoal[]>([]);
   const [draftLeafTitleByParentId, setDraftLeafTitleByParentId] = useState<Record<string, string>>({});
   const [sprintPlanByGoalId, setSprintPlanByGoalId] = useState<Record<string, number[]>>({});
+  const [prefillStructureApplied, setPrefillStructureApplied] = useState(false);
 
   // Reset on modal open
   useEffect(() => {
@@ -127,7 +130,9 @@ export const FocusGoalWizard: React.FC<FocusGoalWizardProps> = ({
       setTimeframe('sprint');
       setError('');
       setCopiedGoalRef(null);
+      setFocusTitle('');
       setVisionText('');
+      setCustomEndDateInput('');
       setPrompts([]);
       setSelectedPromptId('');
       setIntentResult(null);
@@ -138,6 +143,7 @@ export const FocusGoalWizard: React.FC<FocusGoalWizardProps> = ({
       setDraftLeafGoals([]);
       setDraftLeafTitleByParentId({});
       setSprintPlanByGoalId({});
+      setPrefillStructureApplied(false);
     }
   }, [show]);
 
@@ -166,10 +172,65 @@ export const FocusGoalWizard: React.FC<FocusGoalWizardProps> = ({
 
   useEffect(() => {
     if (!show || !initialPrefill) return;
+    if (initialPrefill.title) setFocusTitle(initialPrefill.title);
     if (initialPrefill.timeframe) setTimeframe(initialPrefill.timeframe);
     if (initialPrefill.visionText) setVisionText(initialPrefill.visionText);
     if (initialPrefill.searchTerm) setGoalSearchTerm(initialPrefill.searchTerm);
+    if (initialPrefill.goalTypeMap) setGoalTypeMap(initialPrefill.goalTypeMap);
+    if (initialPrefill.sprintPlanByGoalId) setSprintPlanByGoalId(initialPrefill.sprintPlanByGoalId);
+    if (initialPrefill.endDateMs) {
+      const nextDate = new Date(initialPrefill.endDateMs);
+      if (!Number.isNaN(nextDate.getTime())) setCustomEndDateInput(nextDate.toISOString().slice(0, 10));
+    }
   }, [show, initialPrefill]);
+
+  useEffect(() => {
+    if (!show || !initialPrefill || prefillStructureApplied) return;
+
+    const requestedGoalIds = Array.isArray(initialPrefill.autoSelectGoalIds)
+      ? initialPrefill.autoSelectGoalIds.map((goalId) => String(goalId || '').trim()).filter(Boolean)
+      : [];
+    const requestedMilestones = Array.isArray(initialPrefill.queuedLeafMilestones)
+      ? initialPrefill.queuedLeafMilestones.map((title) => String(title || '').trim()).filter(Boolean)
+      : [];
+
+    if (requestedGoalIds.length > 0) {
+      const allGoalsReady = requestedGoalIds.every((goalId) => goals.some((goal) => goal.id === goalId));
+      if (!allGoalsReady) return;
+    }
+
+    if (requestedGoalIds.length > 0) {
+      setSelectedGoalIds((prev) => {
+        const next = new Set(prev);
+        requestedGoalIds.forEach((goalId) => next.add(goalId));
+        return next;
+      });
+    }
+
+    if (requestedMilestones.length > 0 && requestedGoalIds.length === 1) {
+      const parentGoal = goals.find((goal) => goal.id === requestedGoalIds[0]) || null;
+      if (parentGoal) {
+        setDraftLeafGoals((prev) => {
+          if (prev.length > 0) return prev;
+          const existingTitles = goals
+            .filter((goal) => String(goal.parentGoalId || '') === parentGoal.id)
+            .map((goal) => String(goal.title || '').trim().toLowerCase());
+          const draftTitles = requestedMilestones.filter((title) => !existingTitles.includes(title.toLowerCase()));
+          return draftTitles.map((title, index) => ({
+            tempId: `${DRAFT_LEAF_PREFIX}${parentGoal.id}:${Date.now() + index}`,
+            parentGoalId: parentGoal.id,
+            title,
+            theme: parentGoal.theme,
+            persona: parentGoal.persona,
+            goalKind: 'milestone',
+            timeHorizon: timeframe === 'year' ? 'quarter' : 'sprint',
+          }));
+        });
+      }
+    }
+
+    setPrefillStructureApplied(true);
+  }, [goals, initialPrefill, prefillStructureApplied, show, timeframe]);
 
   const loadPrompts = async () => {
     setLoadingPrompts(true);
@@ -200,21 +261,26 @@ export const FocusGoalWizard: React.FC<FocusGoalWizardProps> = ({
       quarter: 91 * 24 * 60 * 60 * 1000,
       year: 365 * 24 * 60 * 60 * 1000
     };
-    const endDate = new Date(now.getTime() + daysInMs[timeframe]);
+    const customEndMs = customEndDateInput ? Date.parse(`${customEndDateInput}T12:00:00`) : Number.NaN;
+    const endDate = Number.isFinite(customEndMs) && customEndMs > now.getTime()
+      ? new Date(customEndMs)
+      : new Date(now.getTime() + daysInMs[timeframe]);
     const daysRemaining = Math.ceil((endDate.getTime() - now.getTime()) / (24 * 60 * 60 * 1000));
 
     return {
       label:
-        timeframe === 'sprint'
-          ? `2 weeks (${now.toLocaleDateString()} - ${endDate.toLocaleDateString()})`
-          : timeframe === 'quarter'
-            ? `13 weeks (${now.toLocaleDateString()} - ${endDate.toLocaleDateString()})`
-            : `1 year (${now.toLocaleDateString()} - ${endDate.toLocaleDateString()})`,
+        Number.isFinite(customEndMs) && customEndMs > now.getTime()
+          ? `Custom window (${now.toLocaleDateString()} - ${endDate.toLocaleDateString()})`
+          : timeframe === 'sprint'
+            ? `2 weeks (${now.toLocaleDateString()} - ${endDate.toLocaleDateString()})`
+            : timeframe === 'quarter'
+              ? `13 weeks (${now.toLocaleDateString()} - ${endDate.toLocaleDateString()})`
+              : `1 year (${now.toLocaleDateString()} - ${endDate.toLocaleDateString()})`,
       startDate: now,
       endDate,
       daysRemaining
     };
-  }, [timeframe]);
+  }, [customEndDateInput, timeframe]);
 
   const sprintPlanSegments = useMemo<SprintPlanSegment[]>(() => {
     const segments: SprintPlanSegment[] = [];
@@ -449,6 +515,10 @@ export const FocusGoalWizard: React.FC<FocusGoalWizardProps> = ({
     setError('');
 
     if (step === 'vision') {
+      if (!focusTitle.trim()) {
+        setError('Please provide a short program name before continuing.');
+        return;
+      }
       if (!visionText.trim()) {
         setError('Please provide a short vision before continuing.');
         return;
@@ -574,6 +644,7 @@ export const FocusGoalWizard: React.FC<FocusGoalWizardProps> = ({
         id: `focus-${Date.now()}`,
         ownerUid: currentUserId || '',
         persona: 'personal',
+        title: focusTitle.trim() || undefined,
         goalIds: selectedLeafGoalIds,
         focusRootGoalIds: Array.from(selectedGoalIds),
         focusLeafGoalIds: selectedLeafGoalIds,
@@ -674,6 +745,16 @@ export const FocusGoalWizard: React.FC<FocusGoalWizardProps> = ({
             <p style={{ color: '#666', marginBottom: '16px' }}>
               Capture the outcome you want first, then optionally run AI matching against your current goal snapshot.
             </p>
+
+            <Form.Group className="mb-3">
+              <Form.Label>Program name</Form.Label>
+              <Form.Control
+                type="text"
+                value={focusTitle}
+                onChange={(e) => setFocusTitle(e.target.value)}
+                placeholder="Project 45 v2"
+              />
+            </Form.Group>
 
             <Form.Group className="mb-3">
               <Form.Label>Vision (free text)</Form.Label>
@@ -910,6 +991,19 @@ export const FocusGoalWizard: React.FC<FocusGoalWizardProps> = ({
                 That's <strong>{timeframeInfo.daysRemaining} days</strong> to achieve your focus goals
               </div>
             </Alert>
+
+            <Form.Group className="mt-3">
+              <Form.Label>Exact target end date (optional override)</Form.Label>
+              <Form.Control
+                type="date"
+                min={new Date().toISOString().slice(0, 10)}
+                value={customEndDateInput}
+                onChange={(e) => setCustomEndDateInput(e.target.value)}
+              />
+              <Form.Text className="text-muted">
+                Leave blank to use the standard {timeframe} window. Set a date here for milestone programs like birthdays or race targets.
+              </Form.Text>
+            </Form.Group>
           </div>
         )}
 
@@ -1196,6 +1290,8 @@ export const FocusGoalWizard: React.FC<FocusGoalWizardProps> = ({
               </ul>
               <p style={{ marginBottom: 0 }}>
                 <strong>Timeframe:</strong> {timeframeInfo.label}
+                <br />
+                <strong>Program:</strong> {focusTitle.trim() || 'Untitled focus program'}
                 <br />
                 <strong>Vision:</strong> {visionText.trim() || 'Not provided'}
                 <br />

--- a/react-app/src/components/FocusGoalsPage.tsx
+++ b/react-app/src/components/FocusGoalsPage.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { Container, Row, Col, Button, Card, Alert, Spinner, Tabs, Tab, ListGroup } from 'react-bootstrap';
+import { Container, Row, Col, Button, Card, Alert, Spinner, ListGroup } from 'react-bootstrap';
 import { useAuth } from '../contexts/AuthContext';
 import { usePersona } from '../contexts/PersonaContext';
-import { collection, query, where, onSnapshot, getDocs, getDoc, doc, updateDoc, serverTimestamp, addDoc, writeBatch } from 'firebase/firestore';
+import { collection, query, where, onSnapshot, getDocs, getDoc, doc, updateDoc, serverTimestamp } from 'firebase/firestore';
 import { db } from '../firebase';
 import { FocusGoal, Goal, Story } from '../types';
 import { useFocusGoals } from '../hooks/useFocusGoals';
@@ -15,21 +15,28 @@ import {
   autoCreateSprintsForFocusPeriod,
   consumeFocusWizardPrefill,
   createFocusGoal,
+  deleteFocusGoal,
   deferNonFocusGoalsForPeriod,
   deactivateExistingFocusGoals,
   FocusWizardPrefill,
   persistMonzoGoalRefs,
   retryMonzoPotLinkForGoal,
   triggerFocusGoalDataRefresh,
+  updateFocusGoal,
 } from '../services/focusGoalsService';
-import { Plus, Edit2, Trash2, Zap } from 'lucide-react';
-import {
-  getActiveFocusLeafGoalIds,
-  getGoalDisplayPath,
-  getProtectedFocusGoalIds,
-  isGoalInHierarchySet,
-} from '../utils/goalHierarchy';
-import { generateRef } from '../utils/referenceGenerator';
+import { getActiveFocusLeafGoalIds, getGoalDisplayPath, getProtectedFocusGoalIds, isGoalInHierarchySet } from '../utils/goalHierarchy';
+import { Plus, Zap } from 'lucide-react';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const toMillis = (value: any): number => {
+  if (!value) return Number.NaN;
+  if (typeof value?.toMillis === 'function') return value.toMillis();
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'number') return value;
+  const parsed = Date.parse(String(value));
+  return Number.isNaN(parsed) ? Number.NaN : parsed;
+};
 
 /**
  * Focus Goals Page
@@ -46,11 +53,13 @@ export const FocusGoalsPage: React.FC = () => {
   const [stories, setStories] = useState<Story[]>([]);
   const [activeSprintIds, setActiveSprintIds] = useState<string[]>([]);
   const [showWizard, setShowWizard] = useState(false);
+  const [wizardPrefill, setWizardPrefill] = useState<FocusWizardPrefill | null>(null);
+  const [editingFocusGoal, setEditingFocusGoal] = useState<FocusGoal | null>(null);
   const [showKpiDesigner, setShowKpiDesigner] = useState(false);
   const [kpiDesignerGoalId, setKpiDesignerGoalId] = useState<string | undefined>(undefined);
-  const [wizardPrefill, setWizardPrefill] = useState<FocusWizardPrefill | null>(null);
   const [wizardLoading, setWizardLoading] = useState(false);
   const [refreshingFocusData, setRefreshingFocusData] = useState(false);
+  const [deletingFocusGoalId, setDeletingFocusGoalId] = useState<string | null>(null);
   const [retryingMonzoGoalIds, setRetryingMonzoGoalIds] = useState<Set<string>>(new Set());
   const [updatingStoryIds, setUpdatingStoryIds] = useState<Set<string>>(new Set());
   const [monzoRetryMessage, setMonzoRetryMessage] = useState<string>('');
@@ -58,13 +67,29 @@ export const FocusGoalsPage: React.FC = () => {
   const [monzoBudgetSummary, setMonzoBudgetSummary] = useState<any>(null);
   const [monzoGoalAlignment, setMonzoGoalAlignment] = useState<any>(null);
 
-  const activeFocusGoalIdSet = React.useMemo(() => {
-    return getActiveFocusLeafGoalIds(activeFocusGoals);
+  const activeFocusLeafGoalIdSet = React.useMemo(
+    () => getActiveFocusLeafGoalIds(activeFocusGoals),
+    [activeFocusGoals]
+  );
+
+  const activeProtectedGoalIdSet = React.useMemo(() => {
+    const ids = new Set<string>();
+    activeFocusGoals.forEach((focusGoal) => {
+      getProtectedFocusGoalIds(focusGoal).forEach((goalId) => ids.add(goalId));
+    });
+    return ids;
   }, [activeFocusGoals]);
 
   const activeFocusGoalsWithMonzoRefs = React.useMemo(
-    () => goals.filter((goal) => activeFocusGoalIdSet.has(goal.id) && !!String(goal.monzoPotGoalRef || '').trim()),
-    [goals, activeFocusGoalIdSet]
+    () => goals.filter((goal) => activeFocusLeafGoalIdSet.has(goal.id) && !!String(goal.monzoPotGoalRef || '').trim()),
+    [goals, activeFocusLeafGoalIdSet]
+  );
+
+  const kpiStudioGoals = React.useMemo(
+    () => (activeProtectedGoalIdSet.size > 0
+      ? goals.filter((goal) => isGoalInHierarchySet(goal.id, goals, activeProtectedGoalIdSet))
+      : goals),
+    [activeProtectedGoalIdSet, goals]
   );
 
   const monzoLinkTimeoutGoals = React.useMemo(
@@ -88,26 +113,20 @@ export const FocusGoalsPage: React.FC = () => {
   );
 
   const unalignedStoriesInActiveSprint = React.useMemo(() => {
-    if (!activeFocusGoalIdSet.size || activeSprintIds.length === 0) return [];
+    if (!activeProtectedGoalIdSet.size || activeSprintIds.length === 0) return [];
     const sprintSet = new Set(activeSprintIds);
     return stories.filter((story) => {
       const inActiveSprint = !!story.sprintId && sprintSet.has(String(story.sprintId));
-      const hasAlignedGoal = !!story.goalId && activeFocusGoalIdSet.has(String(story.goalId));
+      const hasAlignedGoal = !!story.goalId && isGoalInHierarchySet(String(story.goalId), goals, activeProtectedGoalIdSet);
       return inActiveSprint && !hasAlignedGoal;
     });
-  }, [stories, activeFocusGoalIdSet, activeSprintIds]);
-
-  const kpiStudioGoals = React.useMemo(() => {
-    if (activeFocusGoalIdSet.size > 0) {
-      return goals.filter((goal) => activeFocusGoalIdSet.has(goal.id));
-    }
-    return goals.filter((goal) => Number(goal.status || 0) !== 2).slice(0, 6);
-  }, [activeFocusGoalIdSet, goals]);
+  }, [stories, activeProtectedGoalIdSet, activeSprintIds, goals]);
 
   // Load Monzo budget summary and goal alignment (best-effort)
   useEffect(() => {
     const prefill = consumeFocusWizardPrefill();
     if (prefill) {
+      setEditingFocusGoal(null);
       setWizardPrefill(prefill);
       setShowWizard(true);
     }
@@ -182,162 +201,42 @@ export const FocusGoalsPage: React.FC = () => {
     };
   }, [currentUser?.uid, currentPersona]);
 
-  const materializePendingLeafGoals = async (focusGoal: FocusGoal) => {
-    if (!currentUser?.uid) {
-      return {
-        goals,
-        focusGoal,
-      };
-    }
-    const pendingLeafGoals = Array.isArray(focusGoal.pendingLeafGoalsToCreate) ? focusGoal.pendingLeafGoalsToCreate : [];
-    if (pendingLeafGoals.length === 0) {
-      return {
-        goals,
-        focusGoal,
-      };
-    }
-
-    const existingRefs = goals.map((goal) => String((goal as any).ref || '')).filter(Boolean);
-    const tempToRealGoalId = new Map<string, string>();
-    const createdGoals: Goal[] = [];
-
-    for (const draftGoal of pendingLeafGoals) {
-      const parentGoal = goals.find((goal) => goal.id === draftGoal.parentGoalId) || null;
-      const ref = generateRef('goal', existingRefs);
-      existingRefs.push(ref);
-      const payload: any = {
-        ref,
-        title: draftGoal.title,
-        description: '',
-        theme: draftGoal.theme ?? parentGoal?.theme ?? 1,
-        size: 2,
-        timeToMasterHours: 20,
-        confidence: 0.5,
-        status: 0,
-        ownerUid: currentUser.uid,
-        persona: draftGoal.persona || parentGoal?.persona || currentPersona || 'personal',
-        parentGoalId: draftGoal.parentGoalId,
-        goalKind: draftGoal.goalKind || 'milestone',
-        timeHorizon: draftGoal.timeHorizon || 'sprint',
-        rollupMode: 'children_only',
-        goalRequiresStory: true,
-        createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp(),
-      };
-      const docRef = await addDoc(collection(db, 'goals'), payload);
-      tempToRealGoalId.set(draftGoal.tempId, docRef.id);
-      createdGoals.push({
-        id: docRef.id,
-        ...(payload as any),
-      } as Goal);
-    }
-
-    const remapGoalId = (goalId: string) => tempToRealGoalId.get(goalId) || goalId;
-    const remappedFocusGoal: FocusGoal = {
-      ...focusGoal,
-      goalIds: (focusGoal.goalIds || []).map(remapGoalId),
-      focusLeafGoalIds: (focusGoal.focusLeafGoalIds || []).map(remapGoalId),
-      goalTypeMap: Object.entries(focusGoal.goalTypeMap || {}).reduce<Record<string, 'story' | 'calendar'>>((acc, [goalId, value]) => {
-        acc[remapGoalId(goalId)] = value;
-        return acc;
-      }, {}),
-      sprintPlanByGoalId: Object.entries(focusGoal.sprintPlanByGoalId || {}).reduce<Record<string, number[]>>((acc, [goalId, value]) => {
-        acc[remapGoalId(goalId)] = Array.isArray(value) ? value : [];
-        return acc;
-      }, {}),
-      pendingLeafGoalsToCreate: [],
-    };
-
-    return {
-      goals: [...goals, ...createdGoals],
-      focusGoal: remappedFocusGoal,
-    };
-  };
-
-  const applySprintPlanAssignments = async (focusGoalId: string, focusGoal: FocusGoal) => {
-    if (!currentUser?.uid) return;
-    const sprintPlanSegments = Array.isArray(focusGoal.sprintPlanSegments) ? focusGoal.sprintPlanSegments : [];
-    const sprintPlanByGoalId = focusGoal.sprintPlanByGoalId || {};
-    if (sprintPlanSegments.length === 0 || Object.keys(sprintPlanByGoalId).length === 0) return;
-
-    const sprintsSnap = await getDocs(
-      query(
-        collection(db, 'sprints'),
-        where('ownerUid', '==', currentUser.uid),
-        where('persona', '==', currentPersona || 'personal'),
-      ),
-    );
-
-    const plannedSprints = sprintsSnap.docs
-      .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) }))
-      .filter((sprint) => {
-        const startMs = Number((sprint as any).startDate || 0);
-        const endMs = Number((sprint as any).endDate || 0);
-        return startMs <= new Date(focusGoal.endDate).getTime() && endMs >= new Date(focusGoal.startDate).getTime();
-      })
-      .sort((a, b) => Number((a as any).startDate || 0) - Number((b as any).startDate || 0));
-
-    const assignedSprintIdsByGoalId: Record<string, string[]> = {};
-    const batch = writeBatch(db);
-
-    sprintPlanSegments.forEach((segment) => {
-      const sprint = plannedSprints[segment.index];
-      if (!sprint) return;
-      const assignedGoalIds = Object.entries(sprintPlanByGoalId)
-        .filter(([, segmentIndexes]) => Array.isArray(segmentIndexes) && segmentIndexes.includes(segment.index))
-        .map(([goalId]) => goalId);
-      if (assignedGoalIds.length === 0) return;
-
-      assignedGoalIds.forEach((goalId) => {
-        assignedSprintIdsByGoalId[goalId] = [...(assignedSprintIdsByGoalId[goalId] || []), sprint.id];
-      });
-
-      const existingFocusGoalIds = Array.isArray((sprint as any).focusGoalIds)
-        ? (sprint as any).focusGoalIds.map((goalId: any) => String(goalId || '').trim()).filter(Boolean)
-        : [];
-      const nextFocusGoalIds = Array.from(new Set([...existingFocusGoalIds, ...assignedGoalIds]));
-      batch.update(doc(db, 'sprints', sprint.id), {
-        focusGoalIds: nextFocusGoalIds,
-        updatedAt: serverTimestamp(),
-      });
-    });
-
-    batch.update(doc(db, 'focusGoals', focusGoalId), {
-      assignedSprintIdsByGoalId,
-      updatedAt: serverTimestamp(),
-    });
-    await batch.commit();
+  const closeWizard = () => {
+    setShowWizard(false);
+    setWizardPrefill(null);
+    setEditingFocusGoal(null);
   };
 
   const handleWizardSave = async (focusGoal: FocusGoal) => {
     setWizardLoading(true);
     try {
-      const materialized = await materializePendingLeafGoals(focusGoal);
-      const normalizedFocusGoal = materialized.focusGoal;
-      const planningGoals = materialized.goals;
+      if (!currentUser?.uid) return;
 
-      // Deactivate existing focus goals for this timeframe
-      if (currentUser?.uid) {
-        await deactivateExistingFocusGoals(currentUser.uid, normalizedFocusGoal.timeframe);
+      const selectedLeafGoalIds = Array.isArray(focusGoal.focusLeafGoalIds) && focusGoal.focusLeafGoalIds.length > 0
+        ? focusGoal.focusLeafGoalIds
+        : focusGoal.goalIds;
+      const selectedRootGoalIds = Array.isArray(focusGoal.focusRootGoalIds) && focusGoal.focusRootGoalIds.length > 0
+        ? focusGoal.focusRootGoalIds
+        : selectedLeafGoalIds;
+      const selectedGoalTypeMap = focusGoal.goalTypeMap || {};
+
+      if (!editingFocusGoal) {
+        await deactivateExistingFocusGoals(currentUser.uid, focusGoal.timeframe);
       }
 
       // Auto-create stories if needed
-      const selectedLeafGoalIds = Array.isArray(normalizedFocusGoal.focusLeafGoalIds) && normalizedFocusGoal.focusLeafGoalIds.length > 0
-        ? normalizedFocusGoal.focusLeafGoalIds
-        : normalizedFocusGoal.goalIds;
-      const selectedGoals = planningGoals.filter(g => selectedLeafGoalIds.includes(g.id));
-      const selectedGoalTypeMap = normalizedFocusGoal.goalTypeMap || {};
+      const selectedGoals = goals.filter(g => selectedLeafGoalIds.includes(g.id));
       const goalsNeedingStories = selectedGoals.filter(
         g => selectedGoalTypeMap[g.id] !== 'calendar' && ((g as any).storyCount === undefined || (g as any).storyCount === 0)
       );
 
       let storiesCreated: string[] = [];
-      if (goalsNeedingStories.length > 0 && currentUser?.uid) {
+      if (goalsNeedingStories.length > 0) {
         storiesCreated = await autoCreateStoriesForGoals(goalsNeedingStories.map(g => g.id), currentUser.uid);
       }
 
-      const monzoGoalRefs = normalizedFocusGoal.monzoPotGoalRefs || {};
-      if (currentUser?.uid && Object.keys(monzoGoalRefs).length > 0) {
+      const monzoGoalRefs = focusGoal.monzoPotGoalRefs || {};
+      if (Object.keys(monzoGoalRefs).length > 0) {
         await persistMonzoGoalRefs({
           userId: currentUser.uid,
           goalRefMap: monzoGoalRefs,
@@ -345,74 +244,117 @@ export const FocusGoalsPage: React.FC = () => {
       }
 
       let bucketsCreated: { [key: string]: string } = {};
+      const endDateMs = toMillis(focusGoal.endDate);
+      const normalizedDaysRemaining = Number.isFinite(endDateMs)
+        ? Math.max(0, Math.ceil((endDateMs - Date.now()) / DAY_MS))
+        : focusGoal.daysRemaining || 0;
+      const focusGoalPayload: FocusGoal = {
+        ...focusGoal,
+        goalIds: selectedLeafGoalIds,
+        focusRootGoalIds: selectedRootGoalIds,
+        focusLeafGoalIds: selectedLeafGoalIds,
+        storiesCreatedFor: Array.from(new Set([...(editingFocusGoal?.storiesCreatedFor || []), ...storiesCreated])),
+        potIdsCreatedFor: editingFocusGoal?.potIdsCreatedFor || bucketsCreated,
+        monzoPotGoalRefs: monzoGoalRefs,
+        daysRemaining: normalizedDaysRemaining,
+        deferredNonFocusCount: editingFocusGoal?.deferredNonFocusCount || 0,
+      };
 
       // Create focus goal
       let createdSprintIds: string[] = [];
       let deferredNonFocusCount = 0;
-      let createdFocusGoalId: string | null = null;
-      if (currentUser?.uid) {
-        createdFocusGoalId = await createFocusGoal(
+      if (editingFocusGoal?.id) {
+        await updateFocusGoal(editingFocusGoal.id, focusGoalPayload);
+      } else {
+        await createFocusGoal(
           selectedLeafGoalIds,
-          normalizedFocusGoal.timeframe,
+          focusGoal.timeframe,
           currentUser.uid,
-          storiesCreated,
+          focusGoalPayload.storiesCreatedFor,
           bucketsCreated,
           selectedGoalTypeMap,
           monzoGoalRefs,
-          normalizedFocusGoal.focusRootGoalIds,
+          focusGoalPayload,
         );
-
-        if (createdFocusGoalId) {
-          await updateDoc(doc(db, 'focusGoals', createdFocusGoalId), {
-            sprintPlanByGoalId: normalizedFocusGoal.sprintPlanByGoalId || {},
-            sprintPlanSegments: normalizedFocusGoal.sprintPlanSegments || [],
-            visionText: normalizedFocusGoal.visionText || null,
-            updatedAt: serverTimestamp(),
-          });
-        }
 
         createdSprintIds = await autoCreateSprintsForFocusPeriod({
           userId: currentUser.uid,
           persona: currentPersona || 'personal',
-          timeframe: normalizedFocusGoal.timeframe,
-          startDate: new Date(normalizedFocusGoal.startDate),
-          endDate: new Date(normalizedFocusGoal.endDate),
-          visionText: normalizedFocusGoal.visionText,
-          intentProposals: normalizedFocusGoal.intentProposals,
+          timeframe: focusGoal.timeframe,
+          startDate: new Date(focusGoal.startDate),
+          endDate: new Date(focusGoal.endDate),
+          visionText: focusGoal.visionText,
+          intentProposals: focusGoal.intentProposals,
         });
 
-        deferredNonFocusCount = await deferNonFocusGoalsForPeriod({
-          userId: currentUser.uid,
-          persona: currentPersona || 'personal',
-          selectedGoalIds: getProtectedFocusGoalIds(normalizedFocusGoal),
-          deferUntilMs: new Date(normalizedFocusGoal.endDate).getTime(),
-          reason: `Deferred for active ${normalizedFocusGoal.timeframe} focus window`,
-        });
-
-        if (createdFocusGoalId) {
-          await applySprintPlanAssignments(createdFocusGoalId, normalizedFocusGoal);
-          await updateDoc(doc(db, 'focusGoals', createdFocusGoalId), {
-            autoCreatedSprintIds: createdSprintIds,
-            deferredNonFocusCount,
-            updatedAt: serverTimestamp(),
+        if (Number.isFinite(endDateMs)) {
+          deferredNonFocusCount = await deferNonFocusGoalsForPeriod({
+            userId: currentUser.uid,
+            persona: currentPersona || 'personal',
+            selectedGoalIds: selectedLeafGoalIds,
+            deferUntilMs: endDateMs,
+            reason: `Deferred for active ${focusGoal.timeframe} focus window`,
           });
         }
       }
 
       console.log('[FocusGoalsPage] focus setup extras', {
-        focusGoalId: createdFocusGoalId,
+        focusGoalId: editingFocusGoal?.id || 'new',
         createdSprintIds: createdSprintIds.length,
         deferredNonFocusCount,
       });
 
-      setShowWizard(false);
-      setWizardPrefill(null);
+      closeWizard();
     } catch (error) {
       console.error('Failed to save focus goal:', error);
       alert(`Failed to save focus goal: ${(error as any)?.message || 'Unknown error'}`);
     } finally {
       setWizardLoading(false);
     }
+  };
+
+  const handleEditFocusGoal = (focusGoal: FocusGoal) => {
+    const rootIds = Array.isArray(focusGoal.focusRootGoalIds) && focusGoal.focusRootGoalIds.length > 0
+      ? focusGoal.focusRootGoalIds
+      : focusGoal.goalIds;
+    setEditingFocusGoal(focusGoal);
+    setWizardPrefill({
+      title: focusGoal.title,
+      visionText: focusGoal.visionText,
+      timeframe: focusGoal.timeframe,
+      endDateMs: toMillis(focusGoal.endDate),
+      autoSelectGoalIds: rootIds,
+      goalTypeMap: focusGoal.goalTypeMap || {},
+      sprintPlanByGoalId: focusGoal.sprintPlanByGoalId || {},
+      source: 'focus-goal-edit',
+    });
+    setShowWizard(true);
+  };
+
+  const handleDeleteFocusGoal = async (focusGoal: FocusGoal) => {
+    if (!focusGoal?.id) return;
+    const confirmed = window.confirm(
+      `Delete the focus set "${focusGoal.title || 'Untitled focus set'}"? This removes only the focus set record and leaves goals, stories, and sprints intact.`
+    );
+    if (!confirmed) return;
+
+    setDeletingFocusGoalId(focusGoal.id);
+    try {
+      await deleteFocusGoal(focusGoal.id);
+      if (editingFocusGoal?.id === focusGoal.id) {
+        closeWizard();
+      }
+    } catch (error) {
+      console.error('Failed to delete focus goal:', error);
+      alert(`Failed to delete focus goal: ${(error as any)?.message || 'Unknown error'}`);
+    } finally {
+      setDeletingFocusGoalId(null);
+    }
+  };
+
+  const handleOpenKpiDesigner = (goalId?: string) => {
+    setKpiDesignerGoalId(goalId);
+    setShowKpiDesigner(true);
   };
 
   const handleManualRefresh = async () => {
@@ -483,13 +425,8 @@ export const FocusGoalsPage: React.FC = () => {
     }
   };
 
-  const handleOpenKpiDesigner = (goalId?: string) => {
-    setKpiDesignerGoalId(goalId);
-    setShowKpiDesigner(true);
-  };
-
   const handleAlignStoryToFocus = async (storyId: string) => {
-    const targetGoalId = Array.from(activeFocusGoalIdSet)[0];
+    const targetGoalId = Array.from(activeFocusLeafGoalIdSet)[0];
     if (!targetGoalId) {
       setFocusAlignmentMessage('No active focus goals available to align this story.');
       return;
@@ -537,6 +474,7 @@ export const FocusGoalsPage: React.FC = () => {
           variant="primary"
           size="lg"
           onClick={() => {
+            setEditingFocusGoal(null);
             setWizardPrefill(null);
             setShowWizard(true);
           }}
@@ -558,6 +496,8 @@ export const FocusGoalsPage: React.FC = () => {
                 focusGoal={focusGoal}
                 goals={goals}
                 stories={stories}
+                onEdit={() => handleEditFocusGoal(focusGoal)}
+                onDelete={() => handleDeleteFocusGoal(focusGoal)}
                 onRefresh={handleManualRefresh}
                 refreshing={refreshingFocusData}
                 compact={false}
@@ -705,8 +645,8 @@ export const FocusGoalsPage: React.FC = () => {
       <GoalKpiStudioPanel
         ownerUid={currentUser?.uid || ''}
         goals={kpiStudioGoals}
-        title={activeFocusGoalIdSet.size > 0 ? 'Focus KPI Studio' : 'Goal KPI Studio'}
-        subtitle={activeFocusGoalIdSet.size > 0
+        title={activeFocusLeafGoalIdSet.size > 0 ? 'Focus KPI Studio' : 'Goal KPI Studio'}
+        subtitle={activeFocusLeafGoalIdSet.size > 0
           ? 'Design KPIs for your active focus goals and pin the right ones to the dashboard.'
           : 'Design KPIs for your current goals and pin the right ones to the dashboard.'}
         onCreateKpi={handleOpenKpiDesigner}
@@ -720,27 +660,39 @@ export const FocusGoalsPage: React.FC = () => {
             {focusGoals
               .filter(fg => !fg.isActive)
               .map(focusGoal => {
-                const protectedGoalIds = new Set(getProtectedFocusGoalIds(focusGoal));
-                const selectedGoals = goals.filter((goal) => isGoalInHierarchySet(goal.id, goals, protectedGoalIds));
+                const selectedGoals = goals.filter(g => focusGoal.goalIds.includes(g.id));
                 return (
                   <Col md={6} lg={4} key={focusGoal.id} style={{ marginBottom: '16px' }}>
                     <Card>
                       <Card.Body>
                         <div style={{ marginBottom: '12px' }}>
-                          <strong>{selectedGoals.length} goals</strong>
+                          <strong>{focusGoal.title?.trim() || `${selectedGoals.length} goals`}</strong>
                           <div style={{ fontSize: '12px', color: '#666' }}>
                             {focusGoal.timeframe === 'sprint' ? '2 weeks' : focusGoal.timeframe === 'quarter' ? '13 weeks' : '52 weeks'}
                           </div>
                         </div>
                         <ul style={{ fontSize: '13px', marginBottom: '12px', paddingLeft: '20px' }}>
-                          {selectedGoals.slice(0, 3).map((goal) => (
-                            <li key={goal.id}>{getGoalDisplayPath(goal.id, goals)}</li>
+                          {selectedGoals.slice(0, 3).map(g => (
+                            <li key={g.id}>{g.title}</li>
                           ))}
                           {selectedGoals.length > 3 && <li>+{selectedGoals.length - 3} more</li>}
                         </ul>
                         <small style={{ color: '#666' }}>
-                          Completed: {new Date(focusGoal.endDate).toLocaleDateString()}
+                          Completed: {Number.isFinite(toMillis(focusGoal.endDate)) ? new Date(toMillis(focusGoal.endDate)).toLocaleDateString() : 'Unknown'}
                         </small>
+                        <div style={{ display: 'flex', gap: '8px', marginTop: '12px' }}>
+                          <Button size="sm" variant="outline-primary" onClick={() => handleEditFocusGoal(focusGoal)}>
+                            Edit
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline-danger"
+                            disabled={deletingFocusGoalId === focusGoal.id}
+                            onClick={() => handleDeleteFocusGoal(focusGoal)}
+                          >
+                            {deletingFocusGoalId === focusGoal.id ? 'Deleting…' : 'Delete'}
+                          </Button>
+                        </div>
                       </Card.Body>
                     </Card>
                   </Col>
@@ -753,12 +705,9 @@ export const FocusGoalsPage: React.FC = () => {
       {/* Wizard Modal */}
       <FocusGoalWizard
         show={showWizard}
-        onHide={() => {
-          setShowWizard(false);
-          setWizardPrefill(null);
-        }}
+        onHide={closeWizard}
         goals={goals}
-        existingFocusGoals={activeFocusGoals}
+        existingFocusGoals={editingFocusGoal ? activeFocusGoals.filter((focusGoal) => focusGoal.id !== editingFocusGoal.id) : activeFocusGoals}
         initialPrefill={wizardPrefill || undefined}
         currentUserId={currentUser?.uid}
         onSave={handleWizardSave}

--- a/react-app/src/components/GoalKpiStudioPanel.tsx
+++ b/react-app/src/components/GoalKpiStudioPanel.tsx
@@ -5,6 +5,7 @@ import { BarChart3, Pin, Plus, Target } from 'lucide-react';
 import { db } from '../firebase';
 import type { Goal } from '../types';
 import type { Kpi } from '../types/KpiTypes';
+import { formatKpiValue, getKpiStateBadge, getKpiStateLabel, toKpiNumber } from '../utils/kpiDisplay';
 
 interface GoalMetricDoc {
   resolvedKpis?: Array<Record<string, any>>;
@@ -15,27 +16,16 @@ interface GoalKpiStudioPanelProps {
   goals: Goal[];
   title?: string;
   subtitle?: string;
+  emptyMessage?: string;
   onCreateKpi: (goalId?: string) => void;
 }
-
-const toNumber = (value: any): number | null => {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-};
-
-const formatValue = (value: number | null, unit: string) => {
-  if (value == null) return '—';
-  if (unit === 'GBP') return `£${Math.round(value).toLocaleString()}`;
-  if (unit === '%') return `${Math.round(value)}%`;
-  if (unit === 'km' || unit === 'hours') return `${Number(value.toFixed(1))}`;
-  return `${Math.round(value)}`;
-};
 
 const GoalKpiStudioPanel: React.FC<GoalKpiStudioPanelProps> = ({
   ownerUid,
   goals,
-  title = 'KPI Studio',
-  subtitle = 'Map goal KPIs to real sources and dashboard visuals.',
+  title = 'Focus KPI Studio',
+  subtitle = 'Design KPIs here, then review their live metrics on focus cards and the dashboard.',
+  emptyMessage = 'No goals available for KPI design.',
   onCreateKpi,
 }) => {
   const [metricsByGoal, setMetricsByGoal] = useState<Record<string, GoalMetricDoc>>({});
@@ -86,13 +76,13 @@ const GoalKpiStudioPanel: React.FC<GoalKpiStudioPanelProps> = ({
         <div className="d-flex align-items-center gap-2">
           <Badge bg={totalKpis > 0 ? 'primary' : 'secondary'} pill>{totalKpis} KPI{totalKpis === 1 ? '' : 's'}</Badge>
           <Button size="sm" variant="outline-primary" onClick={() => onCreateKpi()}>
-            <Plus size={14} className="me-1" /> Add KPI
+            <Plus size={14} className="me-1" /> Design KPI
           </Button>
         </div>
       </Card.Header>
       <Card.Body className="p-3">
         {goalsWithKpis.length === 0 ? (
-          <div className="text-muted small">No goals available for KPI design.</div>
+          <div className="text-muted small">{emptyMessage}</div>
         ) : (
           <div className="d-flex flex-column gap-3">
             {goalsWithKpis.map(({ goal, kpis, resolved }) => (
@@ -103,7 +93,7 @@ const GoalKpiStudioPanel: React.FC<GoalKpiStudioPanelProps> = ({
                     <div className="text-muted small">Theme {goal.theme} · {kpis.length} KPI{kpis.length === 1 ? '' : 's'}</div>
                   </div>
                   <Button size="sm" variant="outline-secondary" onClick={() => onCreateKpi(goal.id)}>
-                    <Plus size={14} className="me-1" /> Design KPI
+                    <Plus size={14} className="me-1" /> {kpis.length > 0 ? 'Edit KPIs' : 'Design KPI'}
                   </Button>
                 </div>
 
@@ -115,10 +105,11 @@ const GoalKpiStudioPanel: React.FC<GoalKpiStudioPanelProps> = ({
                       const resolvedRow = resolved.find((entry) => String(entry?.id || entry?.metricKey || entry?.name || '') === String(kpi.id || kpi.metricId || kpi.name || ''))
                         || resolved.find((entry) => String(entry?.name || '').trim() === String(kpi.name || '').trim())
                         || {};
-                      const progressPct = toNumber(resolvedRow?.progressPct ?? (kpi as any).progress);
-                      const currentValue = toNumber(resolvedRow?.currentValue ?? (kpi as any).current);
-                      const targetValue = toNumber(resolvedRow?.targetNormalized ?? resolvedRow?.target ?? kpi.target);
+                      const progressPct = toKpiNumber(resolvedRow?.progressPct ?? (kpi as any).progress);
+                      const currentValue = toKpiNumber(resolvedRow?.currentValue ?? (kpi as any).current);
+                      const targetValue = toKpiNumber(resolvedRow?.targetNormalized ?? resolvedRow?.target ?? kpi.target);
                       const unit = String(resolvedRow?.unit || kpi.unit || '');
+                      const stateBadge = getKpiStateBadge(resolvedRow?.healthy === true, resolvedRow?.stale === true || resolvedRow?.healthy === false);
 
                       return (
                         <div key={kpi.id} className="border rounded p-2">
@@ -132,6 +123,7 @@ const GoalKpiStudioPanel: React.FC<GoalKpiStudioPanelProps> = ({
                               </div>
                             </div>
                             <div className="d-flex align-items-center gap-2 flex-wrap">
+                              <Badge bg={stateBadge.bg}>{stateBadge.label}</Badge>
                               <Badge bg={(kpi as any).designerMode === 'registry' ? 'info' : 'primary'}>
                                 {(kpi as any).designerMode === 'registry' ? 'Registry' : 'Curated'}
                               </Badge>
@@ -145,13 +137,13 @@ const GoalKpiStudioPanel: React.FC<GoalKpiStudioPanelProps> = ({
 
                           <div className="d-flex align-items-center justify-content-between gap-2 mt-2 flex-wrap">
                             <div className="small">
-                              <strong>{formatValue(currentValue, unit)}</strong>
+                              <strong>{formatKpiValue(currentValue, unit)}</strong>
                               {' / '}
-                              {formatValue(targetValue, unit)}
+                              {formatKpiValue(targetValue, unit)}
                             </div>
                             <div className="text-muted small d-flex align-items-center gap-1">
                               <Target size={12} />
-                              {progressPct != null ? `${Math.round(progressPct)}%` : 'Waiting for sync'}
+                              {getKpiStateLabel(progressPct, resolvedRow?.healthy === true, resolvedRow?.stale === true || resolvedRow?.healthy === false)}
                             </div>
                           </div>
 

--- a/react-app/src/components/GoalPlanningWorkspaceModal.tsx
+++ b/react-app/src/components/GoalPlanningWorkspaceModal.tsx
@@ -1,0 +1,113 @@
+import React, { useMemo, useState } from 'react';
+import { Button, ButtonGroup, Modal } from 'react-bootstrap';
+import type { Goal } from '../types';
+import { getGoalDisplayPath } from '../utils/goalHierarchy';
+
+type WorkspaceView = 'roadmap' | 'planner' | 'matrix';
+
+interface Props {
+  show: boolean;
+  goal: Goal | null;
+  allGoals: Goal[];
+  onHide: () => void;
+}
+
+const GoalPlanningWorkspaceModal: React.FC<Props> = ({
+  show,
+  goal,
+  allGoals,
+  onHide,
+}) => {
+  const [view, setView] = useState<WorkspaceView>('roadmap');
+
+  React.useEffect(() => {
+    if (show) {
+      setView('roadmap');
+    }
+  }, [goal?.id, show]);
+
+  const goalTypeLabel = useMemo(() => {
+    if (!goal) return 'Goal';
+    if ((goal as any)?.goalKind === 'umbrella') return 'Program goal';
+    if ((goal as any)?.goalKind === 'execution') return 'Leaf goal';
+    return 'Goal';
+  }, [goal]);
+
+  const displayPath = useMemo(() => {
+    if (!goal?.id) return '';
+    return getGoalDisplayPath(goal.id, allGoals);
+  }, [allGoals, goal?.id]);
+
+  const iframeSrc = useMemo(() => {
+    if (!goal?.id) return 'about:blank';
+    const params = new URLSearchParams({
+      embed: '1',
+      goalId: goal.id,
+    });
+    if (goal.theme != null) {
+      params.set('themeId', String(goal.theme));
+    }
+    if (view === 'matrix') {
+      params.set('groupBy', 'goal');
+    }
+    const path = view === 'roadmap'
+      ? '/goals/roadmap-v6'
+      : view === 'planner'
+        ? '/goals/year-planner'
+        : '/sprints/planning';
+    return `${path}?${params.toString()}`;
+  }, [goal?.id, goal?.theme, view]);
+
+  return (
+    <Modal show={show} onHide={onHide} centered size="xl" dialogClassName="modal-90w">
+      <Modal.Header closeButton>
+        <div>
+          <Modal.Title style={{ fontSize: 18 }}>{goal?.title || 'Goal planning workspace'}</Modal.Title>
+          <div className="text-muted small">
+            {goalTypeLabel}{displayPath ? ` · ${displayPath}` : ''}
+          </div>
+        </div>
+      </Modal.Header>
+      <Modal.Body style={{ padding: 0 }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 12,
+            padding: '12px 16px',
+            borderBottom: '1px solid rgba(0,0,0,0.08)',
+            background: 'rgba(59, 130, 246, 0.04)',
+          }}
+        >
+          <div className="text-muted small">
+            Switch between the roadmap, year planner, and sprint matrix without losing the current goal context.
+          </div>
+          <ButtonGroup size="sm">
+            <Button variant={view === 'roadmap' ? 'primary' : 'outline-primary'} onClick={() => setView('roadmap')}>
+              Roadmap
+            </Button>
+            <Button variant={view === 'planner' ? 'primary' : 'outline-primary'} onClick={() => setView('planner')}>
+              Planner
+            </Button>
+            <Button variant={view === 'matrix' ? 'primary' : 'outline-primary'} onClick={() => setView('matrix')}>
+              Sprint Matrix
+            </Button>
+          </ButtonGroup>
+        </div>
+        <iframe
+          title={`${goal?.title || 'Goal'} ${view}`}
+          src={iframeSrc}
+          style={{
+            width: '100%',
+            height: '72vh',
+            border: 'none',
+            background: '#fff',
+          }}
+        />
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default GoalPlanningWorkspaceModal;

--- a/react-app/src/components/GoalsManagement.tsx
+++ b/react-app/src/components/GoalsManagement.tsx
@@ -10,6 +10,7 @@ import ModernGoalsTable from './ModernGoalsTable';
 import GoalsCardView from './GoalsCardView';
 import AddGoalModal from './AddGoalModal';
 import EditGoalModal from './EditGoalModal';
+import GoalPlanningWorkspaceModal from './GoalPlanningWorkspaceModal';
 import { useSprint } from '../contexts/SprintContext';
 import SprintSelector from './SprintSelector';
 import { isStatus, getThemeName } from '../utils/statusHelpers';
@@ -20,7 +21,6 @@ import { useSidebar } from '../contexts/SidebarContext';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { computeWindowExpectedProgress, evaluateGoalTargetStatus } from '../utils/goalKpiStatus';
 import { goalNeedsLinkedPot } from '../utils/goalCost';
-import { isGoalInHierarchySet } from '../utils/goalHierarchy';
 
 const GoalsManagement: React.FC = () => {
   console.log('[GoalsManagement] Component RENDERING');
@@ -48,11 +48,11 @@ const GoalsManagement: React.FC = () => {
   });
   const [showNoPotOnly, setShowNoPotOnly] = useState(false);
   const [editGoal, setEditGoal] = useState<Goal | null>(null);
+  const [workspaceGoal, setWorkspaceGoal] = useState<Goal | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<{ id: string; title: string } | null>(null);
   const [activeSprintGoalIds, setActiveSprintGoalIds] = useState<Set<string>>(new Set());
   const [activeFocusGoalIds, setActiveFocusGoalIds] = useState<Set<string>>(new Set());
   const [applyFocusOnlyFilter, setApplyFocusOnlyFilter] = useState(false);
-  const [focusToggleTouched, setFocusToggleTouched] = useState(false);
   const [applyActiveSprintFilter, setApplyActiveSprintFilter] = useState(true); // default on
   const [pots, setPots] = useState<Record<string, { name: string; balance: number }>>({});
   const [goalKpiMetrics, setGoalKpiMetrics] = useState<Record<string, { resolvedKpis?: any[]; updatedAt?: any }>>({});
@@ -207,17 +207,6 @@ const GoalsManagement: React.FC = () => {
     );
     return () => unsub();
   }, [currentUser?.uid, currentPersona]);
-
-  useEffect(() => {
-    if (activeFocusGoalIds.size === 0) {
-      setApplyFocusOnlyFilter(false);
-      setFocusToggleTouched(false);
-      return;
-    }
-    if (!focusToggleTouched) {
-      setApplyFocusOnlyFilter(true);
-    }
-  }, [activeFocusGoalIds, focusToggleTouched]);
 
   const activeSprintId = useMemo(() => {
     const active = sprints.find((s) => s.status === 1);
@@ -466,7 +455,7 @@ const GoalsManagement: React.FC = () => {
       if (derivedYear && String(derivedYear) !== filterYear) return false;
     }
     if (searchTerm && !goal.title.toLowerCase().includes(searchTerm.toLowerCase())) return false;
-    if (applyFocusOnlyFilter && activeFocusGoalIds.size > 0 && !isGoalInHierarchySet(goal.id, goals, activeFocusGoalIds)) return false;
+    if (applyFocusOnlyFilter && activeFocusGoalIds.size > 0 && !activeFocusGoalIds.has(goal.id)) return false;
     return true;
   });
 
@@ -921,7 +910,6 @@ const GoalsManagement: React.FC = () => {
                       setGoalKpiScope('sprint');
                       setShowNoPotOnly(false);
                       setApplyFocusOnlyFilter(false);
-                      setFocusToggleTouched(false);
                     }}
                     style={{ borderColor: 'var(--notion-border)', color: 'var(--notion-text)' }}
                   >
@@ -948,10 +936,7 @@ const GoalsManagement: React.FC = () => {
                     id="toggle-goals-focus-only"
                     label={`Only active focus goals${activeFocusGoalIds.size ? ` (${activeFocusGoalIds.size})` : ''}`}
                     checked={applyFocusOnlyFilter}
-                    onChange={(e) => {
-                      setApplyFocusOnlyFilter(e.target.checked);
-                      setFocusToggleTouched(true);
-                    }}
+                    onChange={(e) => setApplyFocusOnlyFilter(e.target.checked)}
                     className="text-muted"
                     disabled={activeFocusGoalIds.size === 0}
                   />
@@ -995,6 +980,7 @@ const GoalsManagement: React.FC = () => {
                     onGoalPriorityChange={handleGoalPriorityChange}
                     onGoalReorder={handleGoalReorder}
                     onEditModal={(goal) => setEditGoal(goal)}
+                    onOpenWorkspace={(goal) => setWorkspaceGoal(goal)}
                     goalKpiStatusByGoalId={goalKpiStatusByGoalId}
                   />
                 ) : (
@@ -1020,6 +1006,13 @@ const GoalsManagement: React.FC = () => {
         show={!!editGoal}
         onClose={() => setEditGoal(null)}
         currentUserId={currentUser?.uid || ''}
+      />
+
+      <GoalPlanningWorkspaceModal
+        show={!!workspaceGoal}
+        goal={workspaceGoal}
+        allGoals={goals}
+        onHide={() => setWorkspaceGoal(null)}
       />
 
       <AddGoalModal

--- a/react-app/src/components/GoalsYearPlanner.tsx
+++ b/react-app/src/components/GoalsYearPlanner.tsx
@@ -3,19 +3,27 @@ import { Badge, Button, Card, Col, Container, Dropdown, Form, InputGroup, Modal,
 import { dropTargetForElements, monitorForElements, draggable } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { collection, doc, onSnapshot, orderBy, query, serverTimestamp, updateDoc, where } from 'firebase/firestore';
 import { Calendar, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useSearchParams } from 'react-router-dom';
 import { db } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
 import { usePersona } from '../contexts/PersonaContext';
 import { useSprint } from '../contexts/SprintContext';
-import { Goal } from '../types';
+import { Goal, Story, Task } from '../types';
 import { useGlobalThemes } from '../hooks/useGlobalThemes';
 import { getStatusName, getThemeName, isStatus } from '../utils/statusHelpers';
 import { goalThemeColor, colorWithAlpha } from '../utils/storyCardFormatting';
 import { themeVars } from '../utils/themeVars';
 import SprintSelector from './SprintSelector';
 import EditGoalModal from './EditGoalModal';
+import GoalPlanningWorkspaceModal from './GoalPlanningWorkspaceModal';
+import ConfirmSprintChangesModal from './visualization/ConfirmSprintChangesModal';
+import type { GoalTimelineAffectedStory } from './visualization/goalTimelineImpact';
 import { useSidebar } from '../contexts/SidebarContext';
 import { goalNeedsLinkedPot } from '../utils/goalCost';
+import { buildGoalTimelineImpactPlan } from './visualization/goalTimelineImpact';
+import { applyGoalTimelineChanges } from '../utils/goalTimelineChanges';
+import { parseBooleanParam, parseIdListParam, parseNumberListParam } from '../utils/planningQuery';
+import { isGoalInHierarchySet } from '../utils/goalHierarchy';
 import '../styles/KanbanCards.css';
 
 interface GoalYearColumnProps {
@@ -26,6 +34,7 @@ interface GoalYearColumnProps {
   droppableId: string;
   showDescriptions: boolean;
   onEdit: (goal: Goal) => void;
+  onOpenWorkspace: (goal: Goal) => void;
 }
 
 const parseDateInput = (value: string) => {
@@ -127,7 +136,8 @@ const GoalYearCard: React.FC<{
   pots: Record<string, { name: string; balance: number }>;
   showDescription: boolean;
   onEdit: (goal: Goal) => void;
-}> = ({ goal, themePalette, pots, showDescription, onEdit }) => {
+  onOpenWorkspace: (goal: Goal) => void;
+}> = ({ goal, themePalette, pots, showDescription, onEdit, onOpenWorkspace }) => {
   const ref = useRef<HTMLDivElement>(null);
   const [dragging, setDragging] = useState(false);
 
@@ -190,6 +200,28 @@ const GoalYearCard: React.FC<{
             />
           </div>
         )}
+        <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+          <Button
+            size="sm"
+            variant="outline-primary"
+            onClick={(event) => {
+              event.stopPropagation();
+              onOpenWorkspace(goal);
+            }}
+          >
+            Planner
+          </Button>
+          <Button
+            size="sm"
+            variant="outline-secondary"
+            onClick={(event) => {
+              event.stopPropagation();
+              onEdit(goal);
+            }}
+          >
+            Edit
+          </Button>
+        </div>
       </Card.Body>
     </Card>
   );
@@ -203,6 +235,7 @@ const GoalYearColumn: React.FC<GoalYearColumnProps> = ({
   droppableId,
   showDescriptions,
   onEdit,
+  onOpenWorkspace,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
   const [isOver, setIsOver] = useState(false);
@@ -284,6 +317,7 @@ const GoalYearColumn: React.FC<GoalYearColumnProps> = ({
             pots={pots}
             showDescription={showDescriptions}
             onEdit={onEdit}
+            onOpenWorkspace={onOpenWorkspace}
           />
         ))}
         {goals.length === 0 && (
@@ -435,17 +469,32 @@ const YearDateAdjustModal: React.FC<{
 const GoalsYearPlanner: React.FC = () => {
   const { currentUser } = useAuth();
   const { currentPersona } = usePersona();
+  const [searchParams] = useSearchParams();
   const { sprints, selectedSprintId, setSelectedSprintId } = useSprint();
   const { themes } = useGlobalThemes();
   const { isCollapsed, toggleCollapse } = useSidebar();
+  const embedded = parseBooleanParam(searchParams.get('embed'));
+  const queryGoalIds = useMemo(
+    () => parseIdListParam(searchParams.get('goalIds') || searchParams.get('goalId')),
+    [searchParams],
+  );
+  const queryGoalIdSet = useMemo(() => new Set(queryGoalIds), [queryGoalIds]);
+  const queryThemeIds = useMemo(
+    () => parseNumberListParam(searchParams.get('themeIds') || searchParams.get('themeId')),
+    [searchParams],
+  );
+  const queryThemeIdSet = useMemo(() => new Set(queryThemeIds), [queryThemeIds]);
 
   const [goals, setGoals] = useState<Goal[]>([]);
+  const [storyDocs, setStoryDocs] = useState<Story[]>([]);
+  const [taskDocs, setTaskDocs] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [filterStatus, setFilterStatus] = useState('all');
   const [filterTheme, setFilterTheme] = useState('all');
   const currentYear = useMemo(() => new Date().getFullYear(), []);
-  const [allYears, setAllYears] = useState(true);
-  const [selectedYears, setSelectedYears] = useState<number[]>([currentYear]);
+  const defaultSelectedYears = useMemo(() => [currentYear, currentYear + 1, currentYear + 2], [currentYear]);
+  const [allYears, setAllYears] = useState(false);
+  const [selectedYears, setSelectedYears] = useState<number[]>(defaultSelectedYears);
   const [showNoYear, setShowNoYear] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [showGoalDescriptions, setShowGoalDescriptions] = useState(true);
@@ -456,6 +505,23 @@ const GoalsYearPlanner: React.FC = () => {
   const [dateAdjustGoal, setDateAdjustGoal] = useState<{ goal: Goal; year: number | null; sourceYear: number | null } | null>(null);
   const [pots, setPots] = useState<Record<string, { name: string; balance: number }>>({});
   const [moveError, setMoveError] = useState<string | null>(null);
+  const [moveNotice, setMoveNotice] = useState<string | null>(null);
+  const [pendingSprintChanges, setPendingSprintChanges] = useState<{
+    goalId: string;
+    targetYear: number | null;
+    startDate: number;
+    endDate: number;
+    affectedStories: GoalTimelineAffectedStory[];
+  } | null>(null);
+  const [workspaceGoal, setWorkspaceGoal] = useState<Goal | null>(null);
+
+  useEffect(() => {
+    if (queryThemeIds.length === 1) {
+      const themeId = queryThemeIds[0];
+      const matchedTheme = themes.find((entry) => entry.id === themeId);
+      setFilterTheme(matchedTheme?.label || 'all');
+    }
+  }, [queryThemeIds, themes]);
 
   useEffect(() => {
     if (!currentUser) return;
@@ -497,6 +563,42 @@ const GoalsYearPlanner: React.FC = () => {
   }, [currentUser, currentPersona]);
 
   useEffect(() => {
+    if (!currentUser) {
+      setStoryDocs([]);
+      return;
+    }
+    const storiesQuery = query(
+      collection(db, 'stories'),
+      where('ownerUid', '==', currentUser.uid),
+      where('persona', '==', currentPersona),
+      orderBy('createdAt', 'desc')
+    );
+    const unsub = onSnapshot(storiesQuery, (snapshot) => {
+      const rows = snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Story[];
+      setStoryDocs(rows);
+    });
+    return () => unsub();
+  }, [currentUser, currentPersona]);
+
+  useEffect(() => {
+    if (!currentUser) {
+      setTaskDocs([]);
+      return;
+    }
+    const tasksQuery = query(
+      collection(db, 'tasks'),
+      where('ownerUid', '==', currentUser.uid),
+      where('persona', '==', currentPersona),
+      orderBy('createdAt', 'desc')
+    );
+    const unsub = onSnapshot(tasksQuery, (snapshot) => {
+      const rows = snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Task[];
+      setTaskDocs(rows);
+    });
+    return () => unsub();
+  }, [currentUser, currentPersona]);
+
+  useEffect(() => {
     if (!currentUser?.uid) return;
     const potQuery = query(collection(db, 'monzo_pots'), where('ownerUid', '==', currentUser.uid));
     const unsub = onSnapshot(potQuery, (snap) => {
@@ -523,9 +625,9 @@ const GoalsYearPlanner: React.FC = () => {
 
   useEffect(() => {
     if (!allYears && selectedYears.length === 0) {
-      setSelectedYears([currentYear]);
+      setSelectedYears(defaultSelectedYears);
     }
-  }, [allYears, selectedYears, currentYear]);
+  }, [allYears, selectedYears, defaultSelectedYears]);
 
   useEffect(() => {
     if (!isCurrentYearOnly) {
@@ -577,6 +679,8 @@ const GoalsYearPlanner: React.FC = () => {
     }
     if (filterStatus !== 'all' && !isStatus(goal.status, filterStatus)) return false;
     if (filterTheme !== 'all' && getThemeName(goal.theme) !== filterTheme) return false;
+    if (queryThemeIdSet.size > 0 && !queryThemeIdSet.has(Number(goal.theme))) return false;
+    if (queryGoalIdSet.size > 0 && !isGoalInHierarchySet(goal.id, goals, queryGoalIdSet)) return false;
     if (showNoPotOnly) {
       if (!goalNeedsLinkedPot(goal)) return false;
     }
@@ -637,9 +741,9 @@ const GoalsYearPlanner: React.FC = () => {
       const yr = resolveGoalYear(g);
       if (yr) years.add(yr);
     });
-    years.add(currentYear);
+    defaultSelectedYears.forEach((year) => years.add(year));
     return Array.from(years).sort((a, b) => a - b);
-  }, [goals, currentYear]);
+  }, [goals, defaultSelectedYears]);
 
   const yearColumns = useMemo(() => {
     let years = allYears ? [...availableYears] : [...selectedYears];
@@ -722,31 +826,35 @@ const GoalsYearPlanner: React.FC = () => {
 
   return (
     <Container fluid style={{ padding: '24px', backgroundColor: themeVars.bg as string, minHeight: '100vh' }}>
-      <Row className="mb-4">
-        <Col>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-              <h2 style={{ margin: 0, fontSize: '28px', fontWeight: '700', color: themeVars.text as string }}>
-                Goals by Year
-              </h2>
-              <Badge bg="primary" style={{ fontSize: '12px', padding: '6px 12px' }}>
-                {currentPersona.charAt(0).toUpperCase() + currentPersona.slice(1)} Persona
-              </Badge>
+      {!embedded && (
+        <Row className="mb-4">
+          <Col>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+                <h2 style={{ margin: 0, fontSize: '28px', fontWeight: '700', color: themeVars.text as string }}>
+                  Goals by Year
+                </h2>
+                <Badge bg="primary" style={{ fontSize: '12px', padding: '6px 12px' }}>
+                  {currentPersona.charAt(0).toUpperCase() + currentPersona.slice(1)} Persona
+                </Badge>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <Button
+                  size="sm"
+                  variant="outline-secondary"
+                  title={isCollapsed ? 'Expand details panel' : 'Collapse details panel'}
+                  onClick={toggleCollapse}
+                >
+                  {isCollapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
+                </Button>
+              </div>
             </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-              <Button
-                size="sm"
-                variant="outline-secondary"
-                title={isCollapsed ? 'Expand details panel' : 'Collapse details panel'}
-                onClick={toggleCollapse}
-              >
-                {isCollapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
-              </Button>
-            </div>
-          </div>
-        </Col>
-      </Row>
+          </Col>
+        </Row>
+      )}
 
+      {!embedded && (
+        <>
       <Row className="mb-1">
         <Col lg={3} md={6} className="mb-3">
           <Card style={{ height: '100%', border: '1px solid var(--notion-border)', background: 'var(--notion-bg)' }}>
@@ -836,10 +944,17 @@ const GoalsYearPlanner: React.FC = () => {
           </Card>
         </Col>
       </Row>
+        </>
+      )}
 
       {moveError && (
         <div className="alert alert-danger" role="alert">
           {moveError}
+        </div>
+      )}
+      {moveNotice && (
+        <div className="alert alert-info" role="alert">
+          {moveNotice}
         </div>
       )}
 
@@ -922,7 +1037,7 @@ const GoalsYearPlanner: React.FC = () => {
                         const checked = e.target.checked;
                         setAllYears(checked);
                         if (!checked && selectedYears.length === 0) {
-                          setSelectedYears([currentYear]);
+                          setSelectedYears(defaultSelectedYears);
                         }
                       }}
                       className="mb-1"
@@ -1018,6 +1133,7 @@ const GoalsYearPlanner: React.FC = () => {
             droppableId={`year-${year}`}
             showDescriptions={showGoalDescriptions}
             onEdit={(g) => setEditGoal(g)}
+            onOpenWorkspace={(g) => setWorkspaceGoal(g)}
           />
         ))}
       </div>
@@ -1038,13 +1154,94 @@ const GoalsYearPlanner: React.FC = () => {
         onClose={() => setDateAdjustGoal(null)}
         onSave={async (payload) => {
           if (!dateAdjustGoal?.goal) return;
-          await updateDoc(doc(db, 'goals', dateAdjustGoal.goal.id), {
-            ...payload,
-            targetYear: dateAdjustGoal.year ?? null,
-            updatedAt: serverTimestamp(),
+          const startDate = payload.startDate ?? null;
+          const endDate = payload.endDate ?? null;
+          if (startDate == null || endDate == null || !currentUser) {
+            await updateDoc(doc(db, 'goals', dateAdjustGoal.goal.id), {
+              ...payload,
+              targetYear: dateAdjustGoal.year ?? null,
+              updatedAt: serverTimestamp(),
+            });
+            setDateAdjustGoal(null);
+            return;
+          }
+
+          const impactPlan = buildGoalTimelineImpactPlan({
+            goalId: dateAdjustGoal.goal.id,
+            newStartDate: new Date(startDate),
+            newEndDate: new Date(endDate),
+            stories: storyDocs,
+            tasks: taskDocs,
+            sprints,
           });
+
+          if (impactPlan.affectedStories.length > 0) {
+            setPendingSprintChanges({
+              goalId: dateAdjustGoal.goal.id,
+              targetYear: dateAdjustGoal.year ?? null,
+              startDate,
+              endDate,
+              affectedStories: impactPlan.affectedStories,
+            });
+            setDateAdjustGoal(null);
+            return;
+          }
+
+          await applyGoalTimelineChanges({
+            goalId: dateAdjustGoal.goal.id,
+            startDateMs: startDate,
+            endDateMs: endDate,
+            targetYear: dateAdjustGoal.year ?? null,
+            ownerUid: currentUser.uid,
+            persona: currentPersona,
+            affectedStories: [],
+          });
+          setMoveError(null);
+          setMoveNotice('Goal dates updated with no sprint moves required.');
           setDateAdjustGoal(null);
         }}
+      />
+
+      <ConfirmSprintChangesModal
+        visible={!!pendingSprintChanges}
+        pendingChanges={pendingSprintChanges ? {
+          goalId: pendingSprintChanges.goalId,
+          startDate: pendingSprintChanges.startDate,
+          endDate: pendingSprintChanges.endDate,
+          affectedStories: pendingSprintChanges.affectedStories,
+        } : null}
+        onCancel={() => setPendingSprintChanges(null)}
+        onConfirm={async () => {
+          if (!pendingSprintChanges || !currentUser) return;
+          try {
+            const result = await applyGoalTimelineChanges({
+              goalId: pendingSprintChanges.goalId,
+              startDateMs: pendingSprintChanges.startDate,
+              endDateMs: pendingSprintChanges.endDate,
+              targetYear: pendingSprintChanges.targetYear,
+              ownerUid: currentUser.uid,
+              persona: currentPersona,
+              affectedStories: pendingSprintChanges.affectedStories,
+            });
+            setMoveError(null);
+            setMoveNotice(
+              `Goal dates updated. ${result.movedStoryCount} stor${result.movedStoryCount === 1 ? 'y was' : 'ies were'} moved to the closest sprint${result.reviewStoryCount > 0 ? `, and ${result.reviewStoryCount} still need manual review.` : '.'}`
+            );
+          } catch (error: any) {
+            console.error('Failed to apply goal timeline changes from year planner:', error);
+            setMoveNotice(null);
+            setMoveError(error?.message || 'Failed to update the goal and related stories.');
+          } finally {
+            setPendingSprintChanges(null);
+          }
+        }}
+      />
+
+      <GoalPlanningWorkspaceModal
+        show={!!workspaceGoal}
+        goal={workspaceGoal}
+        allGoals={goals}
+        onHide={() => setWorkspaceGoal(null)}
       />
     </Container>
   );

--- a/react-app/src/components/HabitsManagement.tsx
+++ b/react-app/src/components/HabitsManagement.tsx
@@ -3,7 +3,6 @@ import { Card, Form, Button, Row, Col, Table, Badge, Alert } from 'react-bootstr
 import { useAuth } from '../contexts/AuthContext';
 import { db } from '../firebase';
 import { addDoc, collection, deleteDoc, doc, getDocs, onSnapshot, orderBy, query, serverTimestamp, setDoc, updateDoc, where } from 'firebase/firestore';
-import { getGoalDisplayPath, getLeafGoalOptions, resolveLeafGoalSelection } from '../utils/goalHierarchy';
 
 const HabitsManagement: React.FC = () => {
   const { currentUser } = useAuth();
@@ -16,7 +15,6 @@ const HabitsManagement: React.FC = () => {
     const y = d.getFullYear(); const m = String(d.getMonth()+1).padStart(2,'0'); const dd = String(d.getDate()).padStart(2,'0');
     return `${y}${m}${dd}`;
   }, []);
-  const leafGoalOptions = useMemo(() => getLeafGoalOptions(goals as any), [goals]);
 
   useEffect(() => {
     if (!currentUser) return;
@@ -38,15 +36,6 @@ const HabitsManagement: React.FC = () => {
       setError('Please link a goal for every habit.');
       return;
     }
-    const resolvedGoalSelection = resolveLeafGoalSelection(form.linkedGoalId || null, goals as any);
-    if (!resolvedGoalSelection.goalId) {
-      setError(
-        resolvedGoalSelection.reason === 'ambiguous_parent'
-          ? 'Habits must link to a leaf goal. Select the specific child goal this habit supports.'
-          : 'Please select a valid leaf goal for this habit.'
-      );
-      return;
-    }
     setError(null);
     const parseDays = (text: string) => {
       if (!text) return [] as number[];
@@ -62,8 +51,8 @@ const HabitsManagement: React.FC = () => {
       unit: form.unit||'times',
       scheduleTime: form.scheduleTime||'07:00',
       timeOfDay: form.timeOfDay !== 'auto' ? form.timeOfDay : null,
-      linkedGoalId: resolvedGoalSelection.goalId,
-      linkedGoalName: goals.find(g=>g.id===resolvedGoalSelection.goalId)?.title || null,
+      linkedGoalId: form.linkedGoalId || null,
+      linkedGoalName: goals.find(g=>g.id===form.linkedGoalId)?.title || null,
       daysOfWeek: Array.isArray(form.daysOfWeek) && form.daysOfWeek.length ? form.daysOfWeek : parseDays(form.daysText || ''),
       createdAt: Date.now(),
       updatedAt: Date.now(),
@@ -146,9 +135,8 @@ const HabitsManagement: React.FC = () => {
                 <Form.Label>Link Goal (required)</Form.Label>
                 <Form.Select value={form.linkedGoalId} onChange={e=>setForm({ ...form, linkedGoalId: e.target.value })}>
                   <option value="">Select a goal...</option>
-                  {leafGoalOptions.map(g => <option key={g.id} value={g.id}>{getGoalDisplayPath(g.id, goals as any)}</option>)}
+                  {goals.map(g => <option key={g.id} value={g.id}>{g.title}</option>)}
                 </Form.Select>
-                <div className="form-text">Habits must link to a leaf goal to count toward KPI adherence.</div>
               </Col>
               <Col md={3}>
                 <Form.Label>Active</Form.Label>
@@ -223,7 +211,7 @@ const HabitsManagement: React.FC = () => {
                   <td>{h.frequency}</td>
                   <td>{h.scheduleTime || '—'}</td>
                   <td>{h.timeOfDay && h.timeOfDay !== 'auto' ? <Badge bg="info">{h.timeOfDay}</Badge> : <span className="text-muted small">auto</span>}</td>
-                  <td>{h.linkedGoalId ? (goals.find(g=>g.id===h.linkedGoalId) ? getGoalDisplayPath(h.linkedGoalId, goals as any) : h.linkedGoalId) : <Badge bg="warning">Missing</Badge>}</td>
+                  <td>{h.linkedGoalId ? (goals.find(g=>g.id===h.linkedGoalId)?.title || h.linkedGoalId) : <Badge bg="warning">Missing</Badge>}</td>
                   <td>{h.isActive ? <Badge bg="success">On</Badge> : <Badge bg="secondary">Off</Badge>}</td>
                   <td className="text-end">
                     <Button size="sm" className="me-2" variant="outline-success" onClick={()=>toggleCompleteToday(h)}>Mark Done Today</Button>

--- a/react-app/src/components/KanbanBoardV2.tsx
+++ b/react-app/src/components/KanbanBoardV2.tsx
@@ -12,6 +12,7 @@ import KanbanCardV2 from './KanbanCardV2';
 import { themeVars } from '../utils/themeVars';
 import { isStatus } from '../utils/statusHelpers';
 import { isCriticalPriority } from '../utils/priorityUtils';
+import { getManualPriorityRank } from '../utils/manualPriority';
 import { useActivityTracking } from '../hooks/useActivityTracking';
 import { formatTaskTagLabel } from '../utils/tagDisplay';
 import '../styles/KanbanCards.css';
@@ -333,9 +334,17 @@ const KanbanBoardV2: React.FC<KanbanBoardV2Props> = ({
         return String(top3Date).slice(0, 10) === new Date().toISOString().slice(0, 10);
     };
 
-    const isTop3Task = (task: Task): boolean => isCurrentTop3(task);
+    const getTaskManualRank = (task: Task): number | null => {
+        const directRank = getManualPriorityRank(task);
+        if (directRank) return directRank;
+        const parentStoryId = String(task.storyId || (task.parentType === 'story' ? task.parentId || '' : '')).trim();
+        if (!parentStoryId) return null;
+        return getManualPriorityRank(stories.find((story) => story.id === parentStoryId));
+    };
 
-    const isTop3Story = (story: Story): boolean => isCurrentTop3(story);
+    const isTop3Task = (task: Task): boolean => Boolean(getTaskManualRank(task)) || isCurrentTop3(task);
+
+    const isTop3Story = (story: Story): boolean => Boolean(getManualPriorityRank(story)) || isCurrentTop3(story);
 
     const getItemDueMs = (item: any): number | null => {
         const raw = item?.dueDate ?? item?.targetDate ?? item?.endDate ?? item?.dueDateMs ?? null;
@@ -569,6 +578,9 @@ const KanbanBoardV2: React.FC<KanbanBoardV2Props> = ({
         };
 
         const sorter = (a: any, b: any) => {
+            const manualA = (a?.storyId || a?.parentId) ? getTaskManualRank(a as Task) : getManualPriorityRank(a);
+            const manualB = (b?.storyId || b?.parentId) ? getTaskManualRank(b as Task) : getManualPriorityRank(b);
+            if ((manualA || 99) !== (manualB || 99)) return (manualA || 99) - (manualB || 99);
             if (sortBy === 'ai') {
                 const sa = scoreOf(a);
                 const sb = scoreOf(b);

--- a/react-app/src/components/KanbanCardV2.tsx
+++ b/react-app/src/components/KanbanCardV2.tsx
@@ -17,6 +17,7 @@ import { addDoc, collection, serverTimestamp, updateDoc, doc, getDocs, query, wh
 import { ActivityStreamService } from '../services/ActivityStreamService';
 import DeferItemModal from './DeferItemModal';
 import NewCalendarEventModal, { BlockFormState, buildCalendarComposerInitialValues } from './planner/NewCalendarEventModal';
+import { findItemWithManualPriorityRank, getManualPriorityLabel, getManualPriorityRank, getNextManualPriorityRank } from '../utils/manualPriority';
 
 interface KanbanCardV2Props {
     item: Story | Task;
@@ -155,7 +156,13 @@ const KanbanCardV2: React.FC<KanbanCardV2Props> = ({
         return `${y}-${m}-${day}`;
     };
 
+    const manualPriorityRank = type === 'story'
+        ? getManualPriorityRank(item)
+        : (getManualPriorityRank(item) || getManualPriorityRank(parentStory));
+    const manualPriorityLabel = type === 'story' ? getManualPriorityLabel(item) : null;
+
     const isTop3 = (() => {
+        if (manualPriorityRank) return true;
         if ((item as any).aiTop3ForDay !== true) return false;
         const top3Date = (item as any).aiTop3Date;
         if (!top3Date) return true;
@@ -536,34 +543,38 @@ const KanbanCardV2: React.FC<KanbanCardV2Props> = ({
             );
             const existingFlagged = storiesSnap.docs
                 .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) }))
-                .filter((s: any) => (
-                    s.id !== story.id
-                    && s.userPriorityFlag === true
-                    && String(s.persona || 'personal') === storyPersona
-                ));
+                .filter((s: any) => String(s.persona || 'personal') === storyPersona);
 
-            for (const flagged of existingFlagged) {
-                await updateDoc(doc(db, 'stories', flagged.id), {
+            const currentRank = getManualPriorityRank(story);
+            if (currentRank) {
+                await updateDoc(doc(db, 'stories', story.id), {
                     userPriorityFlag: false,
+                    userPriorityRank: null,
                     userPriorityFlagAt: null,
                     updatedAt: serverTimestamp(),
                 });
-            }
-
-            const isAlreadyFlagged = (story as any).userPriorityFlag === true;
-            await updateDoc(doc(db, 'stories', story.id), {
-                userPriorityFlag: !isAlreadyFlagged,
-                userPriorityFlagAt: isAlreadyFlagged ? null : new Date().toISOString(),
-                updatedAt: serverTimestamp(),
-            });
-
-            if (!isAlreadyFlagged) {
+                setActionMessage(`Removed ${getManualPriorityLabel(story) || 'manual priority'}`);
+            } else {
+                const nextRank = getNextManualPriorityRank(existingFlagged, storyPersona, story.id);
+                const conflictingStory = findItemWithManualPriorityRank(existingFlagged, storyPersona, nextRank, story.id);
+                if (conflictingStory?.id) {
+                    await updateDoc(doc(db, 'stories', conflictingStory.id), {
+                        userPriorityFlag: false,
+                        userPriorityRank: null,
+                        userPriorityFlagAt: null,
+                        updatedAt: serverTimestamp(),
+                    });
+                }
+                await updateDoc(doc(db, 'stories', story.id), {
+                    userPriorityFlag: true,
+                    userPriorityRank: nextRank,
+                    userPriorityFlagAt: new Date().toISOString(),
+                    updatedAt: serverTimestamp(),
+                });
                 const rescore = httpsCallable(functions, 'deltaPriorityRescore');
                 await rescore({ entityId: story.id, entityType: 'story' }).catch(() => { });
-                setActionMessage('Marked as #1 priority');
+                setActionMessage(`Marked as manual #${nextRank} priority`);
                 setShowPriorityReplanPrompt(true);
-            } else {
-                setActionMessage('Removed #1 priority');
             }
             setTimeout(() => setActionMessage(null), 2200);
         } catch (error) {
@@ -700,15 +711,15 @@ const KanbanCardV2: React.FC<KanbanCardV2Props> = ({
                                 style={{
                                     width: 24,
                                     height: 24,
-                                    color: (item as any).userPriorityFlag ? 'var(--bs-danger)' : themeVars.muted,
+                                    color: manualPriorityRank ? 'var(--bs-danger)' : themeVars.muted,
                                     opacity: flaggingPriority ? 0.6 : 1,
                                 }}
-                                title={(item as any).userPriorityFlag ? 'Remove #1 priority flag' : 'Set as #1 priority'}
+                                title={manualPriorityRank ? `Remove ${manualPriorityLabel || 'manual priority'}` : 'Set manual priority'}
                                 onClick={handleFlagPriorityStory}
                                 onPointerDown={(e) => e.stopPropagation()}
                                 disabled={flaggingPriority}
                             >
-                                <span style={{ fontSize: 11, fontWeight: 800, lineHeight: 1 }}>1</span>
+                                <span style={{ fontSize: 11, fontWeight: 800, lineHeight: 1 }}>{manualPriorityRank || 1}</span>
                             </Button>
                         )}
                         <Button
@@ -875,7 +886,7 @@ const KanbanCardV2: React.FC<KanbanCardV2Props> = ({
                     </div>
                 )}
                 <div className="kanban-card__meta">
-                    {type === 'story' && (item as any).userPriorityFlag && (
+                    {type === 'story' && manualPriorityRank && (
                         <span
                             className="kanban-card__meta-badge"
                             style={{
@@ -883,9 +894,9 @@ const KanbanCardV2: React.FC<KanbanCardV2Props> = ({
                                 backgroundColor: 'rgba(220, 53, 69, 0.12)',
                                 color: 'var(--bs-danger)',
                             }}
-                            title="User #1 priority flag"
+                            title={manualPriorityLabel || 'Manual priority'}
                         >
-                            <span style={{ fontWeight: 800 }}>1</span>&nbsp;Priority
+                            <span style={{ fontWeight: 800 }}>{manualPriorityRank}</span>&nbsp;Priority
                         </span>
                     )}
                     {isTop3 && (
@@ -997,7 +1008,7 @@ const KanbanCardV2: React.FC<KanbanCardV2Props> = ({
             </Modal.Header>
             <Modal.Body>
                 <p className="mb-2">
-                    <strong>{(item as Story).title || 'This story'}</strong> is now flagged as #1 priority.
+                    <strong>{(item as Story).title || 'This story'}</strong> is now flagged as {manualPriorityLabel || 'a manual priority'}.
                 </p>
                 <p className="mb-0 text-muted small">
                     Run delta replan now to create or rebalance calendar blocks for the new priority.

--- a/react-app/src/components/KpiDashboardWidget.tsx
+++ b/react-app/src/components/KpiDashboardWidget.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Badge, Button, Card, ProgressBar, Spinner } from 'react-bootstrap';
 import { collection, doc, onSnapshot, query, serverTimestamp, updateDoc, where } from 'firebase/firestore';
-import { BarChart3, Gauge, Target, TrendingUp } from 'lucide-react';
+import { Activity, Pin, Target, TrendingUp } from 'lucide-react';
 import { db } from '../firebase';
+import { useSidebar } from '../contexts/SidebarContext';
 import type { Goal, Story, Task } from '../types';
 import type { Kpi } from '../types/KpiTypes';
 import { buildSprintDeferRecommendations, type CapacitySummaryLike, type SprintLike } from '../utils/prioritizationInsights';
 import { isGoalInHierarchySet } from '../utils/goalHierarchy';
+import { formatKpiValue, getKpiStateBadge, getKpiStateLabel, toKpiNumber } from '../utils/kpiDisplay';
+import { ActivityStreamService } from '../services/ActivityStreamService';
 
 interface GoalMetricDoc {
   resolvedKpis?: Array<Record<string, any>>;
@@ -38,12 +41,9 @@ interface DashboardKpiCard {
   currentDisplay: string;
   targetDisplay: string;
   series: number[];
+  healthy?: boolean | null;
+  stale?: boolean | null;
 }
-
-const toNumber = (value: any): number | null => {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-};
 
 const toSeries = (kpi: Record<string, any>): number[] => {
   const weeklyValues = Array.isArray(kpi?.weeklyValues) ? kpi.weeklyValues : [];
@@ -51,8 +51,8 @@ const toSeries = (kpi: Record<string, any>): number[] => {
     .map((entry: any) => Number(entry?.value))
     .filter((value: number) => Number.isFinite(value));
   if (values.length >= 2) return values.slice(-8);
-  const current = toNumber(kpi?.currentValue ?? kpi?.current);
-  const target = toNumber(kpi?.targetNormalized ?? kpi?.target);
+  const current = toKpiNumber(kpi?.currentValue ?? kpi?.current);
+  const target = toKpiNumber(kpi?.targetNormalized ?? kpi?.target);
   if (current != null && target != null) return [Math.max(0, current * 0.75), current, target];
   if (current != null) return [Math.max(0, current * 0.75), current];
   return [];
@@ -111,14 +111,6 @@ const renderSparkline = (values: number[], variant: 'line' | 'bar') => {
   );
 };
 
-const formatMetricValue = (value: number | null, unit: string): string => {
-  if (value == null) return '—';
-  if (unit === 'GBP') return `£${Math.round(value).toLocaleString()}`;
-  if (unit === '%') return `${Math.round(value)}%`;
-  if (unit === 'km' || unit === 'hours') return `${Number(value.toFixed(1))}`;
-  return `${Math.round(value)}`;
-};
-
 const KpiDashboardWidget: React.FC<KpiDashboardWidgetProps> = ({
   ownerUid,
   goals,
@@ -130,6 +122,7 @@ const KpiDashboardWidget: React.FC<KpiDashboardWidgetProps> = ({
   nextSprint = null,
   onOpenFocusGoals,
 }) => {
+  const { showSidebar } = useSidebar();
   const [metricsByGoal, setMetricsByGoal] = useState<Record<string, GoalMetricDoc>>({});
   const [applyingId, setApplyingId] = useState<string | null>(null);
 
@@ -173,8 +166,8 @@ const KpiDashboardWidget: React.FC<KpiDashboardWidgetProps> = ({
             const resolved = metricRows.find((entry) => String(entry?.id || entry?.metricKey || entry?.name || '') === String(kpi.id || kpi.metricId || kpi.name || ''))
               || metricRows.find((entry) => String(entry?.name || '').trim() === String(kpi.name || '').trim())
               || {};
-            const currentValue = toNumber(resolved?.currentValue ?? (kpi as any).current);
-            const targetValue = toNumber(resolved?.targetNormalized ?? resolved?.target ?? kpi.target);
+            const currentValue = toKpiNumber(resolved?.currentValue ?? (kpi as any).current);
+            const targetValue = toKpiNumber(resolved?.targetNormalized ?? resolved?.target ?? kpi.target);
             cards.push({
               goalId: goal.id,
               goalTitle: goal.title,
@@ -184,14 +177,16 @@ const KpiDashboardWidget: React.FC<KpiDashboardWidgetProps> = ({
               visualizationType: kpi.visualizationType || 'progress',
               target: targetValue,
               unit: resolved?.unit || kpi.unit || '',
-              progressPct: toNumber(resolved?.progressPct ?? (kpi as any).progress),
-              currentDisplay: String(resolved?.currentDisplay || formatMetricValue(currentValue, resolved?.unit || kpi.unit || '')),
-              targetDisplay: targetValue == null ? '—' : formatMetricValue(targetValue, resolved?.unit || kpi.unit || ''),
+              progressPct: toKpiNumber(resolved?.progressPct ?? (kpi as any).progress),
+              currentDisplay: String(resolved?.currentDisplay || formatKpiValue(currentValue, resolved?.unit || kpi.unit || '')),
+              targetDisplay: targetValue == null ? '—' : formatKpiValue(targetValue, resolved?.unit || kpi.unit || ''),
               series: toSeries({
                 ...resolved,
                 currentValue,
                 target: targetValue,
               }),
+              healthy: resolved?.healthy === true,
+              stale: resolved?.stale === true || resolved?.healthy === false,
             });
           });
       });
@@ -205,8 +200,8 @@ const KpiDashboardWidget: React.FC<KpiDashboardWidgetProps> = ({
       .forEach((goal) => {
         const resolved = (metricsByGoal[goal.id]?.resolvedKpis || [])[0];
         if (!resolved) return;
-        const currentValue = toNumber(resolved?.currentValue);
-        const targetValue = toNumber(resolved?.targetNormalized ?? resolved?.target);
+        const currentValue = toKpiNumber(resolved?.currentValue);
+        const targetValue = toKpiNumber(resolved?.targetNormalized ?? resolved?.target);
         fallback.push({
           goalId: goal.id,
           goalTitle: goal.title,
@@ -216,10 +211,12 @@ const KpiDashboardWidget: React.FC<KpiDashboardWidgetProps> = ({
           visualizationType: 'progress',
           target: targetValue,
           unit: String(resolved?.unit || ''),
-          progressPct: toNumber(resolved?.progressPct),
-          currentDisplay: String(resolved?.currentDisplay || formatMetricValue(currentValue, resolved?.unit || '')),
-          targetDisplay: targetValue == null ? '—' : formatMetricValue(targetValue, resolved?.unit || ''),
+          progressPct: toKpiNumber(resolved?.progressPct),
+          currentDisplay: String(resolved?.currentDisplay || formatKpiValue(currentValue, resolved?.unit || '')),
+          targetDisplay: targetValue == null ? '—' : formatKpiValue(targetValue, resolved?.unit || ''),
           series: toSeries(resolved),
+          healthy: resolved?.healthy === true,
+          stale: resolved?.stale === true || resolved?.healthy === false,
         });
       });
     return fallback;
@@ -239,25 +236,51 @@ const KpiDashboardWidget: React.FC<KpiDashboardWidgetProps> = ({
     if (!item.nextSprintId || !item.nextSprintStartMs) return;
     setApplyingId(item.id);
     try {
+      const sourceStory = item.type === 'story' ? stories.find((story) => story.id === item.id) || null : null;
+      const sourceTask = item.type === 'task' ? tasks.find((task) => task.id === item.id) || null : null;
       if (item.type === 'story') {
         await updateDoc(doc(db, 'stories', item.id), {
           sprintId: item.nextSprintId,
+          targetDate: item.nextSprintStartMs,
+          dueDate: item.nextSprintStartMs,
+          plannedStartDate: item.nextSprintStartMs,
           deferredUntil: item.nextSprintStartMs,
           deferredReason: `Deferred from dashboard capacity review to ${nextSprint?.name || 'next sprint'}.`,
           deferredBy: 'dashboard_capacity_review',
+          deferredAt: serverTimestamp(),
           updatedAt: serverTimestamp(),
         });
       } else {
         await updateDoc(doc(db, 'tasks', item.id), {
           sprintId: item.nextSprintId,
           dueDate: item.nextSprintStartMs,
-          targetDate: item.nextSprintStartMs,
+          dueDateMs: item.nextSprintStartMs,
           deferredUntil: item.nextSprintStartMs,
           deferredReason: `Deferred from dashboard capacity review to ${nextSprint?.name || 'next sprint'}.`,
           deferredBy: 'dashboard_capacity_review',
+          deferredAt: serverTimestamp(),
           updatedAt: serverTimestamp(),
         });
       }
+      await ActivityStreamService.addActivity({
+        entityId: item.id,
+        entityType: item.type,
+        activityType: 'sprint_changed',
+        userId: ownerUid,
+        userEmail: undefined,
+        description: `Deferred from capacity review to ${nextSprint?.name || 'next sprint'} starting ${new Date(item.nextSprintStartMs).toLocaleDateString()}.`,
+        persona: String((sourceStory as any)?.persona || (sourceTask as any)?.persona || 'personal'),
+        referenceNumber: String((sourceStory as any)?.ref || (sourceStory as any)?.referenceNumber || (sourceTask as any)?.ref || '').trim() || undefined,
+        source: 'human',
+        sourceDetails: 'dashboard_capacity_review',
+        metadata: {
+          previousSprintId: String((sourceStory as any)?.sprintId || (sourceTask as any)?.sprintId || '') || null,
+          nextSprintId: item.nextSprintId,
+          previousDueAt: (sourceStory as any)?.dueDate || (sourceStory as any)?.targetDate || (sourceTask as any)?.dueDate || null,
+          nextDueAt: item.nextSprintStartMs,
+          keepScore: item.keepScore,
+        },
+      });
     } finally {
       setApplyingId(null);
     }
@@ -267,13 +290,13 @@ const KpiDashboardWidget: React.FC<KpiDashboardWidgetProps> = ({
     <Card className="shadow-sm border-0 mb-3 h-100">
       <Card.Header className="d-flex align-items-center justify-content-between gap-2">
         <div className="fw-semibold d-flex align-items-center gap-2">
-          <Gauge size={16} /> KPI Studio
+          <Pin size={16} /> Pinned Focus KPIs
         </div>
         <div className="d-flex align-items-center gap-2">
           <Badge bg={pinnedKpis.length > 0 ? 'primary' : 'secondary'} pill>{pinnedKpis.length}</Badge>
           {onOpenFocusGoals && (
             <Button variant="outline-secondary" size="sm" onClick={onOpenFocusGoals}>
-              Open Focus
+              Open Focus Goals
             </Button>
           )}
         </div>
@@ -281,45 +304,51 @@ const KpiDashboardWidget: React.FC<KpiDashboardWidgetProps> = ({
       <Card.Body className="p-3">
         <div className="mb-3">
           <div className="text-muted small mb-2">
-            Pinned KPI cards from goal definitions, plus defer guidance when sprint load exceeds capacity.
+            Dashboard pins from your focus-goal KPI definitions, plus defer guidance when sprint load exceeds capacity.
           </div>
           {pinnedKpis.length === 0 ? (
             <div className="text-muted small">
-              No dashboard KPIs pinned yet. Add KPIs in Focus Goals and enable “Pin to dashboard”.
+              No pinned focus KPIs yet. Design them in Focus Goals and enable "Pin to dashboard".
             </div>
           ) : (
             <div className="d-grid gap-2" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
-              {pinnedKpis.map((card) => (
-                <div key={`${card.goalId}-${card.kpiId}`} className="border rounded p-2">
-                  <div className="d-flex align-items-start justify-content-between gap-2">
-                    <div>
-                      <div className="fw-semibold small">{card.name}</div>
-                      <div className="text-muted" style={{ fontSize: 11 }}>{card.goalTitle}</div>
+              {pinnedKpis.map((card) => {
+                const stateBadge = getKpiStateBadge(card.healthy, card.stale);
+                return (
+                  <div key={`${card.goalId}-${card.kpiId}`} className="border rounded p-2">
+                    <div className="d-flex align-items-start justify-content-between gap-2">
+                      <div>
+                        <div className="fw-semibold small">{card.name}</div>
+                        <div className="text-muted" style={{ fontSize: 11 }}>{card.goalTitle}</div>
+                      </div>
+                      <div className="d-flex align-items-center gap-1 flex-wrap justify-content-end">
+                        <Badge bg={stateBadge.bg}>{stateBadge.label}</Badge>
+                        <Badge bg="light" text="dark">{card.visualizationType}</Badge>
+                      </div>
                     </div>
-                    <Badge bg="light" text="dark">{card.visualizationType}</Badge>
-                  </div>
-                  <div className="d-flex align-items-end justify-content-between mt-2 gap-2">
-                    <div>
-                      <div style={{ fontSize: 18, fontWeight: 700 }}>{card.currentDisplay}</div>
-                      <div className="text-muted" style={{ fontSize: 11 }}>Target {card.targetDisplay}</div>
+                    <div className="d-flex align-items-end justify-content-between mt-2 gap-2">
+                      <div>
+                        <div style={{ fontSize: 18, fontWeight: 700 }}>{card.currentDisplay}</div>
+                        <div className="text-muted" style={{ fontSize: 11 }}>Target {card.targetDisplay}</div>
+                      </div>
+                      {(card.visualizationType === 'line' || card.visualizationType === 'bar')
+                        ? renderSparkline(card.series, card.visualizationType === 'bar' ? 'bar' : 'line')
+                        : <TrendingUp size={18} className="text-primary" />}
                     </div>
-                    {(card.visualizationType === 'line' || card.visualizationType === 'bar')
-                      ? renderSparkline(card.series, card.visualizationType === 'bar' ? 'bar' : 'line')
-                      : <TrendingUp size={18} className="text-primary" />}
-                  </div>
-                  {card.visualizationType === 'progress' && (
-                    <div className="mt-2">
-                      <ProgressBar
-                        now={Math.max(0, Math.min(100, Number(card.progressPct || 0)))}
-                        style={{ height: 6 }}
-                      />
+                    {card.visualizationType === 'progress' && (
+                      <div className="mt-2">
+                        <ProgressBar
+                          now={Math.max(0, Math.min(100, Number(card.progressPct || 0)))}
+                          style={{ height: 6 }}
+                        />
+                      </div>
+                    )}
+                    <div className="text-muted mt-2" style={{ fontSize: 11 }}>
+                      {getKpiStateLabel(card.progressPct, card.healthy, card.stale)}
                     </div>
-                  )}
-                  <div className="text-muted mt-2" style={{ fontSize: 11 }}>
-                    {card.progressPct != null ? `${Math.round(card.progressPct)}% of target` : 'Waiting for synced KPI metrics'}
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>
@@ -351,7 +380,29 @@ const KpiDashboardWidget: React.FC<KpiDashboardWidgetProps> = ({
                         {item.alignedToFocus ? ' · focus aligned' : ' · not focus aligned'}
                       </div>
                     </div>
-                    <Badge bg={item.alignedToFocus ? 'success' : 'secondary'}>Keep {Math.round(item.keepScore)}</Badge>
+                    <div className="d-flex align-items-center gap-1">
+                      {(item.type === 'story'
+                        ? stories.find((story) => story.id === item.id)
+                        : tasks.find((task) => task.id === item.id)) && (
+                        <Button
+                          size="sm"
+                          variant="outline-secondary"
+                          className="p-1 d-inline-flex align-items-center justify-content-center"
+                          title="Open activity stream"
+                          onClick={() => {
+                            const target = item.type === 'story'
+                              ? stories.find((story) => story.id === item.id)
+                              : tasks.find((task) => task.id === item.id);
+                            if (target) showSidebar(target as any, item.type);
+                          }}
+                        >
+                          <Activity size={14} />
+                        </Button>
+                      )}
+                      <Badge bg={item.alignedToFocus ? 'success' : 'secondary'}>
+                        {item.alignedToFocus ? 'Focus aligned' : 'Defer candidate'}
+                      </Badge>
+                    </div>
                   </div>
                   <div className="text-muted mt-2" style={{ fontSize: 11 }}>{item.rationale}</div>
                   <div className="mt-2">

--- a/react-app/src/components/MobileHome.tsx
+++ b/react-app/src/components/MobileHome.tsx
@@ -1,15 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Container, Card, Button, Badge, ListGroup, Form, Modal, Spinner } from 'react-bootstrap';
-import { useNavigate } from 'react-router-dom';
 import { httpsCallable } from 'firebase/functions';
 import { collection, query, where, onSnapshot, orderBy, limit, updateDoc, doc, serverTimestamp } from 'firebase/firestore';
 import { db, functions } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
 import { useSprint } from '../contexts/SprintContext';
 import { usePersona } from '../contexts/PersonaContext';
-import { Goal, Story, Task, Sprint as SprintType } from '../types';
+import { Goal, Story, Task } from '../types';
 import { ActivityStreamService } from '../services/ActivityStreamService';
-import { ChoiceHelper, StoryStatus } from '../config/choices';
+import { ChoiceHelper } from '../config/choices';
 import { getBadgeVariant, getPriorityBadge, getStatusName } from '../utils/statusHelpers';
 import { taskStatusText } from '../utils/storyCardFormatting';
 import { extractWeatherSummary, extractWeatherTemp, formatWeatherLine } from '../utils/weatherFormat';
@@ -25,11 +24,24 @@ import {
   formatFullReplanSummary,
   normalizePlannerCallableError,
 } from '../utils/plannerOrchestration';
-import DailyPlanPage from './DailyPlanPage';
+import {
+  findItemWithManualPriorityRank,
+  getManualPriorityLabel,
+  getManualPriorityRank,
+  getNextManualPriorityRank,
+} from '../utils/manualPriority';
+import { useFocusGoals } from '../hooks/useFocusGoals';
+import { getProtectedFocusGoalIds, isGoalInHierarchySet } from '../utils/goalHierarchy';
+import { schedulePlannerItem as schedulePlannerItemMutation } from '../utils/plannerScheduling';
 
-type TabKey = 'overview' | 'tasks' | 'stories' | 'goals' | 'chores' | 'daily_plan';
+type TabKey = 'overview' | 'tasks' | 'stories' | 'goals' | 'chores';
 type TaskViewFilter = 'top3' | 'due_today' | 'overdue' | 'all';
 type GoalsViewFilter = 'active_sprint' | 'year';
+type MobileSharedFilters = {
+  top3: boolean;
+  chores: boolean;
+  focusAligned: boolean;
+};
 
 const THEME_COLORS: Record<number, string> = {
   1: '#22c55e', // Health
@@ -60,10 +72,10 @@ const formatShortDate = (value?: number) => {
 };
 
 const MobileHome: React.FC = () => {
-  const navigate = useNavigate();
   const { currentUser } = useAuth();
   const { selectedSprintId, setSelectedSprintId, sprints } = useSprint();
   const { currentPersona, setPersona } = usePersona();
+  const { activeFocusGoals } = useFocusGoals(currentUser?.uid);
 
   const [activeTab, setActiveTab] = useState<TabKey>('overview');
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -90,11 +102,11 @@ const MobileHome: React.FC = () => {
   const [choreCompletionBusy, setChoreCompletionBusy] = useState<Record<string, boolean>>({});
   const [convertingTaskId, setConvertingTaskId] = useState<string | null>(null);
   const [flaggingStoryId, setFlaggingStoryId] = useState<string | null>(null);
-  const [priorityFlagConfirm, setPriorityFlagConfirm] = useState<{ story: Story; existing: Story } | null>(null);
   const [priorityReplanPromptStory, setPriorityReplanPromptStory] = useState<Story | null>(null);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [editingStory, setEditingStory] = useState<Story | null>(null);
   const [deferTarget, setDeferTarget] = useState<{ type: 'task' | 'story'; id: string; title: string } | null>(null);
+  const [sharedFilters, setSharedFilters] = useState<MobileSharedFilters>({ top3: false, chores: false, focusAligned: false });
   const todayIso = useMemo(() => new Date().toISOString().split('T')[0], []);
   const activePlanningSprints = useMemo(
     () => sprints.filter((s) => s.status === 0 || s.status === 1),
@@ -353,6 +365,13 @@ const MobileHome: React.FC = () => {
   const storiesByRef = useMemo(() => new Map(stories.map(s => [(s.ref || s.id || '').toUpperCase(), s])), [stories]);
   const tasksByRef = useMemo(() => new Map(tasks.map(t => [(t.ref || t.id || '').toUpperCase(), t])), [tasks]);
   const goalsById = useMemo(() => new Map(goals.map(g => [g.id, g])), [goals]);
+  const protectedFocusGoalIds = useMemo(() => {
+    const ids = new Set<string>();
+    activeFocusGoals.forEach((focusGoal) => {
+      getProtectedFocusGoalIds(focusGoal).forEach((goalId) => ids.add(goalId));
+    });
+    return ids;
+  }, [activeFocusGoals]);
   const currentSprint = useMemo(() => {
     const source = activePlanningSprints.length ? activePlanningSprints : sprints;
     if (!source || !source.length) return undefined;
@@ -381,21 +400,69 @@ const MobileHome: React.FC = () => {
     return normalizeAiScore((story.metadata?.aiScore ?? story.metadata?.aiCriticalityScore ?? (story as any).aiCriticalityScore ?? null));
   }, [normalizeAiScore]);
 
+  const getTaskManualRank = useCallback((task: Task) => {
+    const directRank = getManualPriorityRank(task);
+    if (directRank) return directRank;
+    const parentStoryId = String(task.storyId || (task.parentType === 'story' ? task.parentId || '' : '')).trim();
+    if (!parentStoryId) return null;
+    return getManualPriorityRank(storiesById.get(parentStoryId));
+  }, [storiesById]);
+
+  const isStoryFocusAligned = useCallback((story?: Story | null) => {
+    const goalId = String(story?.goalId || '').trim();
+    if (!goalId || protectedFocusGoalIds.size === 0) return false;
+    return isGoalInHierarchySet(goalId, goals, protectedFocusGoalIds);
+  }, [goals, protectedFocusGoalIds]);
+
+  const isTaskFocusAligned = useCallback((task?: Task | null) => {
+    const directGoalId = String((task as any)?.goalId || '').trim();
+    if (directGoalId && protectedFocusGoalIds.size > 0) {
+      return isGoalInHierarchySet(directGoalId, goals, protectedFocusGoalIds);
+    }
+    const parentStoryId = String(task?.storyId || (task?.parentType === 'story' ? task?.parentId || '' : '')).trim();
+    if (!parentStoryId) return false;
+    return isStoryFocusAligned(storiesById.get(parentStoryId));
+  }, [goals, protectedFocusGoalIds, isStoryFocusAligned, storiesById]);
+
   const isTop3Task = useCallback((task: Task) => {
+    if (getTaskManualRank(task)) return true;
     const flagged = (task as any).aiTop3ForDay === true;
     if (!flagged) return false;
     const aiDate = (task as any).aiTop3Date;
     if (!aiDate) return true;
     return String(aiDate).slice(0, 10) === todayIso;
-  }, [todayIso]);
+  }, [getTaskManualRank, todayIso]);
 
   const isTop3Story = useCallback((story: Story) => {
+    if (getManualPriorityRank(story)) return true;
     const flagged = (story as any).aiTop3ForDay === true;
     if (!flagged) return false;
     const aiDate = (story as any).aiTop3Date;
     if (!aiDate) return true;
     return String(aiDate).slice(0, 10) === todayIso;
   }, [todayIso]);
+
+  const matchesTaskSharedFilters = useCallback((task: Task) => {
+    if (sharedFilters.top3 && !isTop3Task(task)) return false;
+    if (sharedFilters.chores && !getChoreKind(task)) return false;
+    if (sharedFilters.focusAligned && !isTaskFocusAligned(task)) return false;
+    return true;
+  }, [sharedFilters, isTop3Task, getChoreKind, isTaskFocusAligned]);
+
+  const matchesStorySharedFilters = useCallback((story: Story) => {
+    if (sharedFilters.top3 && !isTop3Story(story)) return false;
+    if (sharedFilters.chores) return false;
+    if (sharedFilters.focusAligned && !isStoryFocusAligned(story)) return false;
+    return true;
+  }, [sharedFilters, isTop3Story, isStoryFocusAligned]);
+
+  const matchesTimelineSharedFilters = useCallback((item: MobileTimelineItem) => {
+    if (!sharedFilters.top3 && !sharedFilters.chores && !sharedFilters.focusAligned) return true;
+    if (item.kind === 'event') return false;
+    if (item.story) return matchesStorySharedFilters(item.story);
+    if (item.task) return matchesTaskSharedFilters(item.task);
+    return false;
+  }, [sharedFilters, matchesStorySharedFilters, matchesTaskSharedFilters]);
 
   const sprintDaysLeft = useMemo(() => {
     if (!currentSprint) return null;
@@ -456,11 +523,6 @@ const MobileHome: React.FC = () => {
   const openNoteModal = (type: 'task'|'story'|'goal', id: string) => {
     setNoteText('');
     setNoteModal({ type, id, show: true });
-  };
-
-  const openDeepLink = (task: Task) => {
-    const href = task.ref ? `/tasks/${task.ref}` : `/tasks/${task.id}`;
-    window.open(href, '_blank');
   };
 
   const saveNote = async () => {
@@ -556,13 +618,6 @@ const MobileHome: React.FC = () => {
   };
 
   const handleFlagPriorityStory = async (story: Story) => {
-    const existing = stories.find(
-      (s) => s.id !== story.id && (s as any).userPriorityFlag === true && s.status !== 4
-    );
-    if (existing) {
-      setPriorityFlagConfirm({ story, existing });
-      return;
-    }
     await applyPriorityFlag(story);
   };
 
@@ -573,39 +628,72 @@ const MobileHome: React.FC = () => {
 
   const applyDeferredDate = useCallback(async ({ dateMs, rationale, source }: { dateMs: number; rationale: string; source: string }) => {
     if (!deferTarget) return;
-    const collectionName = deferTarget.type === 'story' ? 'stories' : 'tasks';
-    await updateDoc(doc(db, collectionName, deferTarget.id), {
-      deferredUntil: dateMs,
-      deferredReason: rationale,
-      deferredBy: source,
-      deferredAt: serverTimestamp(),
-      updatedAt: serverTimestamp(),
-    } as any);
+    const debugRequestId = `mobile-defer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const targetEntity = deferTarget.type === 'task'
+      ? tasks.find((task) => task.id === deferTarget.id) || null
+      : stories.find((story) => story.id === deferTarget.id) || null;
+    console.info('[MobileHome] defer_confirmed', {
+      debugRequestId,
+      itemType: deferTarget.type,
+      itemId: deferTarget.id,
+      title: deferTarget.title,
+      dateMs,
+      source,
+      rationale,
+    });
+    const targetBucketRaw = String((targetEntity as any)?.timeOfDay || '').trim().toLowerCase();
+    const targetBucket = targetBucketRaw === 'morning' || targetBucketRaw === 'afternoon' || targetBucketRaw === 'evening' || targetBucketRaw === 'anytime'
+      ? targetBucketRaw
+      : null;
+    await schedulePlannerItemMutation({
+      itemType: deferTarget.type,
+      itemId: deferTarget.id,
+      targetDateMs: dateMs,
+      targetBucket,
+      intent: 'defer',
+      source: source || 'mobile_home',
+      rationale,
+      durationMinutes: deferTarget.type === 'task'
+        ? Math.max(15, Number((targetEntity as any)?.estimateMin || 30))
+        : Math.max(15, Number((targetEntity as any)?.estimateMin || 60)),
+      debugRequestId,
+    });
     setDeferTarget(null);
-  }, [deferTarget]);
+  }, [deferTarget, tasks, stories]);
 
   const applyPriorityFlag = async (story: Story) => {
     setFlaggingStoryId(story.id);
     try {
-      // Clear any existing flag
-      const existingFlagged = stories.filter(
-        (s) => s.id !== story.id && (s as any).userPriorityFlag === true
-      );
-      for (const s of existingFlagged) {
-        await updateDoc(doc(db, 'stories', s.id), {
+      const storyPersona = String((story as any).persona || 'personal');
+      const currentRank = getManualPriorityRank(story);
+      if (currentRank) {
+        await updateDoc(doc(db, 'stories', story.id), {
           userPriorityFlag: false,
+          userPriorityRank: null,
+          userPriorityFlagAt: null,
           updatedAt: serverTimestamp(),
         });
-      }
-      // Set new flag (toggle if already flagged)
-      const isAlreadyFlagged = (story as any).userPriorityFlag === true;
-      await updateDoc(doc(db, 'stories', story.id), {
-        userPriorityFlag: !isAlreadyFlagged,
-        userPriorityFlagAt: isAlreadyFlagged ? null : new Date().toISOString(),
-        updatedAt: serverTimestamp(),
-      });
-      // Trigger rescore + replan
-      if (!isAlreadyFlagged) {
+      } else {
+        const nextRank = getNextManualPriorityRank(
+          stories.filter((entry) => entry.status !== 4),
+          storyPersona,
+          story.id,
+        );
+        const conflictingStory = findItemWithManualPriorityRank(stories, storyPersona, nextRank, story.id);
+        if (conflictingStory?.id) {
+          await updateDoc(doc(db, 'stories', conflictingStory.id), {
+            userPriorityFlag: false,
+            userPriorityRank: null,
+            userPriorityFlagAt: null,
+            updatedAt: serverTimestamp(),
+          });
+        }
+        await updateDoc(doc(db, 'stories', story.id), {
+          userPriorityFlag: true,
+          userPriorityRank: nextRank,
+          userPriorityFlagAt: new Date().toISOString(),
+          updatedAt: serverTimestamp(),
+        });
         const rescore = httpsCallable(functions, 'deltaPriorityRescore');
         await rescore({ entityId: story.id, entityType: 'story' }).catch(() => {});
         setPriorityReplanPromptStory(story);
@@ -614,7 +702,6 @@ const MobileHome: React.FC = () => {
       console.error('Failed to flag priority story', e);
     } finally {
       setFlaggingStoryId(null);
-      setPriorityFlagConfirm(null);
     }
   };
 
@@ -692,23 +779,27 @@ const MobileHome: React.FC = () => {
     return Number.isNaN(parsed) ? null : parsed;
   };
 
-  const getTaskDueValue = (task: Task) => {
+  const getTaskDueValue = useCallback((task: Task) => {
     const candidate = task.dueDate || task.dueDateMs || task.targetDate || null;
     return resolveDateValue(candidate) ?? Infinity;
-  };
+  }, []);
 
   const pendingTasks = useMemo(() => {
     let base = showCompleted ? tasks : tasks.filter(t => t.status !== 2);
     if (aiFocusOnly) {
       base = base.filter((task) => {
+        if (getTaskManualRank(task)) return true;
         const aiScore = getTaskAiScore(task);
         return aiScore != null && aiScore >= aiThreshold;
       });
     }
     return base;
-  }, [tasks, showCompleted, aiFocusOnly, aiThreshold, getTaskAiScore]);
+  }, [tasks, showCompleted, aiFocusOnly, aiThreshold, getTaskAiScore, getTaskManualRank]);
   const sortedPendingTasks = useMemo(() => {
     return [...pendingTasks].sort((a, b) => {
+      const manualA = getTaskManualRank(a) || 99;
+      const manualB = getTaskManualRank(b) || 99;
+      if (manualA !== manualB) return manualA - manualB;
       const aiA = getTaskAiScore(a) ?? 0;
       const aiB = getTaskAiScore(b) ?? 0;
       if (aiA !== aiB) return aiB - aiA;
@@ -717,17 +808,18 @@ const MobileHome: React.FC = () => {
       if (dueA !== dueB) return dueA - dueB;
       return (b.priority || 0) - (a.priority || 0);
     });
-  }, [pendingTasks, getTaskAiScore]);
+  }, [pendingTasks, getTaskAiScore, getTaskManualRank, getTaskDueValue]);
 
-  const getStoryDueValue = (story: Story) => {
+  const getStoryDueValue = useCallback((story: Story) => {
     const candidate = story.dueDate || story.targetDate || story.plannedStartDate || null;
     return resolveDateValue(candidate) ?? Infinity;
-  };
+  }, []);
 
   const filteredStories = useMemo(() => {
     let base = showCompleted ? stories : stories.filter(s => s.status !== 4);
     if (aiFocusOnly) {
       base = base.filter((story) => {
+        if (getManualPriorityRank(story)) return true;
         const aiScore = getStoryAiScore(story);
         return aiScore != null && aiScore >= aiThreshold;
       });
@@ -737,6 +829,9 @@ const MobileHome: React.FC = () => {
 
   const sortedStories = useMemo(() => {
     return [...filteredStories].sort((a, b) => {
+      const manualA = getManualPriorityRank(a) || 99;
+      const manualB = getManualPriorityRank(b) || 99;
+      if (manualA !== manualB) return manualA - manualB;
       const aiA = getStoryAiScore(a) ?? 0;
       const aiB = getStoryAiScore(b) ?? 0;
       if (aiA !== aiB) return aiB - aiA;
@@ -745,7 +840,7 @@ const MobileHome: React.FC = () => {
       if (dueA !== dueB) return dueA - dueB;
       return (b.priority || 0) - (a.priority || 0);
     });
-  }, [filteredStories, getStoryAiScore]);
+  }, [filteredStories, getStoryAiScore, getStoryDueValue]);
 
   const top3Tasks = useMemo(() => {
     return tasks
@@ -753,6 +848,9 @@ const MobileHome: React.FC = () => {
       .filter(t => t.status !== 2)
       .filter(isTop3Task)
       .sort((a, b) => {
+        const manualA = getTaskManualRank(a) || 99;
+        const manualB = getTaskManualRank(b) || 99;
+        if (manualA !== manualB) return manualA - manualB;
         const ar = Number((a as any).aiPriorityRank || 0) || 99;
         const br = Number((b as any).aiPriorityRank || 0) || 99;
         if (ar !== br) return ar - br;
@@ -762,13 +860,16 @@ const MobileHome: React.FC = () => {
         return String(a.title || '').localeCompare(String(b.title || ''));
       })
       .slice(0, 3);
-  }, [tasks, isTop3Task, getTaskAiScore]);
+  }, [tasks, isTop3Task, getTaskAiScore, getTaskManualRank]);
 
   const top3Stories = useMemo(() => {
     return stories
       .filter(s => s.status !== 4)
       .filter(isTop3Story)
       .sort((a, b) => {
+        const manualA = getManualPriorityRank(a) || 99;
+        const manualB = getManualPriorityRank(b) || 99;
+        if (manualA !== manualB) return manualA - manualB;
         const ar = Number((a as any).aiFocusStoryRank || 0) || 99;
         const br = Number((b as any).aiFocusStoryRank || 0) || 99;
         if (ar !== br) return ar - br;
@@ -779,8 +880,6 @@ const MobileHome: React.FC = () => {
       })
       .slice(0, 3);
   }, [stories, isTop3Story, getStoryAiScore]);
-
-  const top3TaskIdSet = useMemo(() => new Set(top3Tasks.map((task) => task.id)), [top3Tasks]);
 
   const tasksDueTodayForMobile = useMemo(() => {
     const today = new Date();
@@ -805,17 +904,28 @@ const MobileHome: React.FC = () => {
   }, [sortedPendingTasks, getTaskDueMs]);
 
   const visibleTaskRows = useMemo(() => {
+    let rows: Task[];
     if (tasksViewFilter === 'top3') {
-      return sortedPendingTasks.filter((task) => top3TaskIdSet.has(task.id));
+      rows = sortedPendingTasks.filter((task) => isTop3Task(task));
+    } else if (tasksViewFilter === 'due_today') {
+      rows = tasksDueTodayForMobile;
+    } else if (tasksViewFilter === 'overdue') {
+      rows = tasksOverdueForMobile;
+    } else {
+      rows = sortedPendingTasks;
     }
-    if (tasksViewFilter === 'due_today') {
-      return tasksDueTodayForMobile;
-    }
-    if (tasksViewFilter === 'overdue') {
-      return tasksOverdueForMobile;
-    }
-    return sortedPendingTasks;
-  }, [tasksViewFilter, sortedPendingTasks, top3TaskIdSet, tasksDueTodayForMobile, tasksOverdueForMobile]);
+    return rows.filter(matchesTaskSharedFilters);
+  }, [tasksViewFilter, sortedPendingTasks, isTop3Task, tasksDueTodayForMobile, tasksOverdueForMobile, matchesTaskSharedFilters]);
+
+  const visibleStoryRows = useMemo(
+    () => sortedStories.filter(matchesStorySharedFilters),
+    [sortedStories, matchesStorySharedFilters],
+  );
+
+  const visibleChoreRows = useMemo(
+    () => choresDueToday.filter(matchesTaskSharedFilters),
+    [choresDueToday, matchesTaskSharedFilters],
+  );
 
   const filteredGoalsForMobile = useMemo(() => {
     const currentYear = new Date().getFullYear();
@@ -842,7 +952,7 @@ const MobileHome: React.FC = () => {
     story?: Story;
   };
 
-  const bucketFromTime = (ms: number | null | undefined, timeOfDay?: string | null): MobileTimelineBucket => {
+  const bucketFromTime = useCallback((ms: number | null | undefined, timeOfDay?: string | null): MobileTimelineBucket => {
     const tod = String(timeOfDay || '').toLowerCase().trim();
     if (tod === 'morning' || tod === 'afternoon' || tod === 'evening') return tod as MobileTimelineBucket;
     if (!ms || !Number.isFinite(ms)) return 'morning';
@@ -851,7 +961,7 @@ const MobileHome: React.FC = () => {
     if (minute >= 300 && minute <= 779) return 'morning';
     if (minute >= 780 && minute <= 1139) return 'afternoon';
     return 'evening';
-  };
+  }, []);
 
   const timelineTimeLabel = (startMs: number | null | undefined, endMs?: number | null): string => {
     if (!startMs || !Number.isFinite(startMs)) return 'Anytime';
@@ -976,13 +1086,15 @@ const MobileHome: React.FC = () => {
       });
     });
 
-    return rows.sort((a, b) => {
+    return rows
+      .filter(matchesTimelineSharedFilters)
+      .sort((a, b) => {
       const aTime = a.sortMs ?? Number.MAX_SAFE_INTEGER;
       const bTime = b.sortMs ?? Number.MAX_SAFE_INTEGER;
       if (aTime !== bTime) return aTime - bTime;
       return a.title.localeCompare(b.title);
     });
-  }, [tasksDueTodayForMobile, choresDueToday, sortedStories, overviewCalendarEvents, getTaskDueMs]);
+  }, [tasksDueTodayForMobile, choresDueToday, sortedStories, overviewCalendarEvents, getTaskDueMs, matchesTimelineSharedFilters, bucketFromTime]);
 
   const renderChoresHabitsWidget = () => {
     // Group by time-of-day bucket, respecting explicit timeOfDay field before falling back to schedule time.
@@ -993,7 +1105,7 @@ const MobileHome: React.FC = () => {
       { key: 'evening' as const, label: 'Evening' },
     ] as const;
     const grouped = { morning: [] as Task[], afternoon: [] as Task[], evening: [] as Task[] };
-    choresDueToday.forEach((task) => {
+    visibleChoreRows.forEach((task) => {
       const bucket = bucketFromTime(toChoreMs(task), (task as any).timeOfDay);
       grouped[bucket].push(task);
     });
@@ -1007,6 +1119,10 @@ const MobileHome: React.FC = () => {
       const dueLabel = formatDueLabel(dueMs);
       const isOverdue = !!dueMs && dueMs < todayStartMs;
       const busy = !!choreCompletionBusy[task.id];
+      const aiScore = getTaskAiScore(task);
+      const manualPriority = getManualPriorityLabel(task) || null;
+      const top3 = isTop3Task(task);
+      const focusAligned = isTaskFocusAligned(task);
       return (
         <ListGroup.Item key={task.id} className="d-flex align-items-center gap-2" style={{ fontSize: 14 }}>
           <Form.Check
@@ -1019,6 +1135,12 @@ const MobileHome: React.FC = () => {
           <div className="flex-grow-1">
             <div className="fw-semibold">{task.title}</div>
             <div className="text-muted small">{isOverdue ? `Overdue · ${dueLabel}` : `Due ${dueLabel}`}</div>
+            <div className="d-flex flex-wrap gap-1 mt-1">
+              {manualPriority && <Badge bg="danger">{manualPriority}</Badge>}
+              {top3 && <Badge bg="warning" text="dark">Top 3</Badge>}
+              {focusAligned && <Badge bg="success">Focus</Badge>}
+              {aiScore != null && <Badge bg="secondary">AI {Math.round(aiScore)}/100</Badge>}
+            </div>
           </div>
           <div className="d-flex flex-column align-items-end gap-1">
             {isOverdue && <Badge bg="danger">Overdue</Badge>}
@@ -1033,13 +1155,13 @@ const MobileHome: React.FC = () => {
         <Card.Header className="py-2 d-flex align-items-center justify-content-between" style={{ background: 'transparent', border: 'none' }}>
           <div>
             <strong>Chores &amp; Habits</strong>
-            <Badge bg="secondary" pill className="ms-2">{choresDueToday.length}</Badge>
+            <Badge bg="secondary" pill className="ms-2">{visibleChoreRows.length}</Badge>
           </div>
         </Card.Header>
         <Card.Body className="pt-0">
           {choresLoading ? (
             <div className="text-muted small">Loading chores…</div>
-          ) : choresDueToday.length === 0 ? (
+          ) : visibleChoreRows.length === 0 ? (
             <div className="text-muted small">No chores, habits, or routines due today.</div>
           ) : hasGroups ? (
             <>
@@ -1060,7 +1182,7 @@ const MobileHome: React.FC = () => {
             </>
           ) : (
             <ListGroup variant="flush">
-              {choresDueToday.map(renderChoreItem)}
+              {visibleChoreRows.map(renderChoreItem)}
             </ListGroup>
           )}
         </Card.Body>
@@ -1232,11 +1354,11 @@ const MobileHome: React.FC = () => {
         </Card>
       </div>
       {/* AI Daily Summary + Focus */}
-      {/* Tabs: Overview | Tasks | Stories | Goals | Chores | Daily Plan */}
+      {/* Tabs: Overview | Tasks | Stories | Goals | Chores */}
       <div className="mobile-filter-tabs mb-3">
         <div className="d-flex align-items-center gap-1 flex-nowrap" style={{ overflowX: 'auto', WebkitOverflowScrolling: 'touch' }}>
           <div className="btn-group flex-nowrap w-100" role="group">
-            {(['overview','tasks','stories','goals','chores','daily_plan'] as TabKey[]).map(key => (
+            {(['overview','tasks','stories','goals','chores'] as TabKey[]).map(key => (
               <Button
                 key={key}
                 variant={activeTab === key ? 'primary' : 'outline-primary'}
@@ -1244,22 +1366,46 @@ const MobileHome: React.FC = () => {
                 onClick={() => setActiveTab(key)}
                 style={{ padding: '3px 6px', fontSize: 11, whiteSpace: 'nowrap' }}
               >
-                {key === 'overview'
-                  ? 'Overview'
-                  : key === 'tasks'
-                    ? 'Tasks'
-                    : key === 'stories'
-                      ? 'Stories'
-                      : key === 'goals'
-                        ? 'Goals'
-                        : key === 'chores'
-                          ? 'Chores'
-                          : 'Daily Plan'}
+                {key === 'overview' ? 'Overview' : key === 'tasks' ? 'Tasks' : key === 'stories' ? 'Stories' : key === 'goals' ? 'Goals' : 'Chores'}
               </Button>
             ))}
           </div>
         </div>
       </div>
+
+      {activeTab !== 'goals' && (
+        <>
+          <div className="d-flex flex-wrap gap-2 mb-2">
+            <Button
+              size="sm"
+              variant={sharedFilters.top3 ? 'danger' : 'outline-danger'}
+              className="rounded-pill"
+              onClick={() => setSharedFilters((prev) => ({ ...prev, top3: !prev.top3 }))}
+            >
+              Top 3
+            </Button>
+            <Button
+              size="sm"
+              variant={sharedFilters.chores ? 'success' : 'outline-success'}
+              className="rounded-pill"
+              onClick={() => setSharedFilters((prev) => ({ ...prev, chores: !prev.chores }))}
+            >
+              Chores
+            </Button>
+            <Button
+              size="sm"
+              variant={sharedFilters.focusAligned ? 'primary' : 'outline-primary'}
+              className="rounded-pill"
+              onClick={() => setSharedFilters((prev) => ({ ...prev, focusAligned: !prev.focusAligned }))}
+            >
+              Focus aligned
+            </Button>
+          </div>
+          <div className="text-muted small mb-3">
+            Top 3 is AI-ranked by default. Manual <strong>#1</strong>, <strong>#2</strong>, and <strong>#3</strong> override AI ranking, and any unassigned Top 3 slots are filled by AI during replanning.
+          </div>
+        </>
+      )}
 
       {(activeTab === 'tasks' || activeTab === 'stories' || activeTab === 'goals') && (
         <div className="d-flex flex-wrap gap-2 mb-3 align-items-center">
@@ -1530,18 +1676,137 @@ const MobileHome: React.FC = () => {
             </Card>
           )}
 
-          <Card className="mb-3" style={{ background: '#eef2ff' }}>
-            <Card.Header className="py-2 d-flex align-items-center justify-content-between" style={{ background: 'transparent', border: 'none' }}>
-              <div>
+              <Card className="mb-3" style={{ background: '#eef2ff' }}>
+              <Card.Header className="py-2 d-flex align-items-center justify-content-between" style={{ background: 'transparent', border: 'none' }}>
+                <div>
                 <strong>Daily Plan</strong>
-                <Badge bg="info" pill className="ms-2">Tab</Badge>
+                <Badge bg="secondary" pill className="ms-2">{unifiedTimelineItems.length}</Badge>
               </div>
             </Card.Header>
             <Card.Body className="pt-0">
-              <div className="text-muted small mb-2">Daily Plan is available as its own tab in the mobile overview menu.</div>
-              <Button size="sm" variant="outline-primary" onClick={() => setActiveTab('daily_plan')}>
-                Open Daily Plan tab
-              </Button>
+              <div className="text-muted small mb-2">Tip: Use the clock icon on task/story cards to defer with smart suggestions.</div>
+              {unifiedTimelineItems.length === 0 ? (
+                <div className="text-muted small">No tasks, stories, chores, or calendar events scheduled today.</div>
+              ) : (
+                (['morning', 'afternoon', 'evening'] as MobileTimelineBucket[]).map((bucket) => {
+                  const items = unifiedTimelineItems.filter((row) => row.bucket === bucket);
+                  if (items.length === 0) return null;
+                  const label = bucket === 'morning' ? 'Morning' : bucket === 'afternoon' ? 'Afternoon' : 'Evening';
+                  return (
+                    <div key={bucket} className="mb-2">
+                      <div className="text-uppercase text-muted small fw-semibold mb-1">{label}</div>
+                      <ListGroup variant="flush">
+                        {items.map((item) => {
+                          const isTask = item.kind === 'task' || item.kind === 'chore';
+                          const isDone = !!item.task && Number(item.task.status ?? 0) === 2;
+                          const aiScore = item.task ? getTaskAiScore(item.task) : item.story ? getStoryAiScore(item.story) : null;
+                          const manualPriority = item.task
+                            ? getManualPriorityLabel(item.task)
+                            : item.story
+                              ? getManualPriorityLabel(item.story)
+                              : null;
+                          const top3 = item.task ? isTop3Task(item.task) : item.story ? isTop3Story(item.story) : false;
+                          const focusAligned = item.task ? isTaskFocusAligned(item.task) : item.story ? isStoryFocusAligned(item.story) : false;
+                          const badgeVariant =
+                            item.kind === 'story' ? 'info' :
+                            item.kind === 'chore' ? 'success' :
+                            item.kind === 'event' ? 'secondary' : 'primary';
+                          const badgeLabel =
+                            item.kind === 'story' ? 'Story' :
+                            item.kind === 'chore' ? 'Chore' :
+                            item.kind === 'event' ? 'Event' : 'Task';
+                          return (
+                            <ListGroup.Item key={item.id} className="d-flex align-items-center gap-2" style={{ fontSize: 14 }}>
+                              {isTask && item.task ? (
+                                <Form.Check
+                                  type="checkbox"
+                                  checked={isDone || !!choreCompletionBusy[item.task.id]}
+                                  disabled={isDone || !!choreCompletionBusy[item.task.id]}
+                                  onChange={() => {
+                                    if (item.kind === 'chore') {
+                                      void handleCompleteChoreTask(item.task!);
+                                    } else {
+                                      void updateTaskField(item.task!, { status: 2 });
+                                    }
+                                  }}
+                                  aria-label={`Complete ${item.title}`}
+                                />
+                              ) : (
+                                <span style={{ width: 14 }} />
+                              )}
+                              <div className="flex-grow-1">
+                                <div className="fw-semibold">
+                                  {item.task ? (
+                                    <button
+                                      type="button"
+                                      className="btn btn-link p-0 text-decoration-none text-start align-baseline"
+                                      onClick={() => setEditingTask(item.task!)}
+                                    >
+                                      {item.title}
+                                    </button>
+                                  ) : item.story ? (
+                                    <button
+                                      type="button"
+                                      className="btn btn-link p-0 text-decoration-none text-start align-baseline"
+                                      onClick={() => setEditingStory(item.story!)}
+                                    >
+                                      {item.title}
+                                    </button>
+                                  ) : (
+                                    item.title
+                                  )}
+                                </div>
+                                <div className="text-muted small">{item.timeLabel}</div>
+                                {(manualPriority || top3 || focusAligned || aiScore != null || item.task || item.story) && (
+                                  <div className="d-flex flex-wrap gap-1 mt-1">
+                                    {manualPriority && <Badge bg="danger">{manualPriority}</Badge>}
+                                    {top3 && <Badge bg="warning" text="dark">Top 3</Badge>}
+                                    {focusAligned && <Badge bg="success">Focus</Badge>}
+                                    {aiScore != null && <Badge bg="secondary">AI {Math.round(aiScore)}/100</Badge>}
+                                  </div>
+                                )}
+                                {(item.task || item.story) && (
+                                  <div className="d-flex flex-wrap gap-2 mt-2">
+                                    <Button
+                                      variant="outline-secondary"
+                                      size="sm"
+                                      onClick={() => openNoteModal(item.task ? 'task' : 'story', item.task ? item.task.id : item.story!.id)}
+                                    >
+                                      Note
+                                    </Button>
+                                    <Button
+                                      variant="outline-warning"
+                                      size="sm"
+                                      onClick={() => setDeferTarget({
+                                        type: item.story ? 'story' : 'task',
+                                        id: item.story ? item.story.id : item.task!.id,
+                                        title: item.title,
+                                      })}
+                                    >
+                                      Defer
+                                    </Button>
+                                    <Button
+                                      variant="outline-primary"
+                                      size="sm"
+                                      onClick={() => {
+                                        if (item.task) setEditingTask(item.task);
+                                        if (item.story) setEditingStory(item.story);
+                                      }}
+                                    >
+                                      Edit
+                                    </Button>
+                                  </div>
+                                )}
+                              </div>
+                              <Badge bg={badgeVariant}>{badgeLabel}</Badge>
+                            </ListGroup.Item>
+                          );
+                        })}
+                      </ListGroup>
+                    </div>
+                  );
+                })
+              )}
             </Card.Body>
           </Card>
 
@@ -1657,7 +1922,9 @@ const MobileHome: React.FC = () => {
                 const storyLabel = story ? `${story.ref} · ${story.title}` : task.ref;
                 const goalLabel = goal ? `Goal: ${goal.title}` : 'Unlinked goal';
                 const aiScore = getTaskAiScore(task);
-                const isCriticalTask = (task.priority || 0) >= 4;
+                const manualPriorityLabel = getManualPriorityLabel(task);
+                const isTaskTop3 = isTop3Task(task);
+                const focusAligned = isTaskFocusAligned(task);
                 return (
                   <ListGroup.Item
                     key={task.id}
@@ -1691,14 +1958,12 @@ const MobileHome: React.FC = () => {
                             <option value={3}>High</option>
                             <option value={4}>Critical</option>
                           </select>
-                          {aiScore != null && (
-                            <Badge pill bg="secondary">AI {Math.round(aiScore)}/100</Badge>
-                          )}
                         </div>
                       </div>
                       <div className="d-flex align-items-center gap-2 mt-2 flex-nowrap" style={{ minWidth: 0 }}>
                         <Form.Select
                           size="sm"
+                          className="dashboard-chip-select"
                           value={Number(task.status)}
                           onChange={(e) => updateTaskField(task, { status: Number(e.target.value) as any })}
                           style={{ flex: 1, minWidth: 0 }}
@@ -1721,6 +1986,14 @@ const MobileHome: React.FC = () => {
                       <div className="d-flex flex-wrap gap-2 mt-1 align-items-center small text-muted">
                         <span>Status: {taskStatusText(task.status)}</span>
                         <span>Due: {formatShortDate(task.dueDate)}</span>
+                      </div>
+                      <div className="d-flex flex-wrap gap-1 mt-2">
+                        {manualPriorityLabel && <Badge pill bg="danger">{manualPriorityLabel}</Badge>}
+                        {isTaskTop3 && <Badge pill bg="warning" text="dark">Top 3</Badge>}
+                        {focusAligned && <Badge pill bg="success">Focus</Badge>}
+                        {aiScore != null && (
+                          <Badge pill bg="secondary">AI {Math.round(aiScore)}/100</Badge>
+                        )}
                       </div>
                       <div className="d-flex flex-wrap gap-2 mt-2 align-items-center">
                         <Button variant="outline-secondary" size="sm" onClick={() => openNoteModal('task', task.id)}>Note</Button>
@@ -1754,20 +2027,28 @@ const MobileHome: React.FC = () => {
         </div>
       )}
 
-      {activeTab === 'daily_plan' && (
-        <div>
-          <DailyPlanPage />
-        </div>
-      )}
-
       {activeTab === 'stories' && (
+        visibleStoryRows.length === 0 ? (
+          <Card className="text-center p-4">
+            <Card.Body>
+              <div className="text-muted">No stories match the current mobile filters.</div>
+            </Card.Body>
+          </Card>
+        ) : (
         <ListGroup>
-          {sortedStories.map(story => {
+          {visibleStoryRows.map(story => {
             const goal = goalsById.get(story.goalId);
             const themeColor = resolveThemeColor(goal?.theme ?? story.theme);
             const acceptance = story.acceptanceCriteria?.slice(0, 2).join(' · ');
-            const isCriticalStory = (story.priority || 0) >= 4;
             const aiScore = getStoryAiScore(story);
+            const manualPriorityRank = getManualPriorityRank(story);
+            const focusAligned = isStoryFocusAligned(story);
+            const isStoryTop3 = isTop3Story(story);
+            const suggestedManualRank = manualPriorityRank || getNextManualPriorityRank(
+              stories.filter((entry) => entry.status !== 4),
+              String((story as any).persona || 'personal'),
+              story.id,
+            );
             return (
               <ListGroup.Item
                 key={story.id}
@@ -1803,17 +2084,12 @@ const MobileHome: React.FC = () => {
                           </select>
                         );
                       })()}
-                      {(story as any).userPriorityFlag && (
-                        <Badge pill bg="danger">#1 Priority</Badge>
-                      )}
-                      {aiScore != null && (
-                        <Badge pill bg="secondary">AI {Math.round(aiScore)}/100</Badge>
-                      )}
                     </div>
                   </div>
                   <div className="d-flex flex-wrap gap-2 align-items-center mt-2">
                     <Form.Select
                       size="sm"
+                      className="dashboard-chip-select"
                       value={Number(story.status)}
                       onChange={(e) => updateStoryField(story, { status: Number(e.target.value) as any })}
                       style={{ minWidth: 160 }}
@@ -1824,13 +2100,13 @@ const MobileHome: React.FC = () => {
                     </Form.Select>
                     <Button variant="outline-secondary" size="sm" onClick={() => openNoteModal('story', story.id)}>Add Note</Button>
                     <Button
-                      variant={(story as any).userPriorityFlag ? 'danger' : 'outline-warning'}
+                      variant={manualPriorityRank ? 'danger' : 'outline-warning'}
                       size="sm"
                       disabled={flaggingStoryId === story.id}
                       onClick={() => handleFlagPriorityStory(story)}
-                      title={(story as any).userPriorityFlag ? 'Remove #1 priority flag' : 'Flag as #1 priority for calendar'}
+                      title={manualPriorityRank ? `Remove manual ${getManualPriorityLabel(story)}` : `Set manual #${suggestedManualRank} priority`}
                     >
-                      <AlertCircle size={14} /> {(story as any).userPriorityFlag ? '#1' : 'Priority'}
+                      <AlertCircle size={14} /> #{manualPriorityRank || suggestedManualRank}
                     </Button>
                     <Button
                       variant="outline-secondary"
@@ -1843,6 +2119,10 @@ const MobileHome: React.FC = () => {
                   </div>
                   <div className="d-flex flex-wrap gap-2 mt-2">
                     <Badge pill bg="dark">Pts {story.points || 0}</Badge>
+                    {manualPriorityRank && <Badge pill bg="danger">{getManualPriorityLabel(story)}</Badge>}
+                    {isStoryTop3 && <Badge pill bg="warning" text="dark">Top 3</Badge>}
+                    {focusAligned && <Badge pill bg="success">Focus</Badge>}
+                    {aiScore != null && <Badge pill bg="secondary">AI {Math.round(aiScore)}/100</Badge>}
                     {sprintDaysLeft != null && (
                       <Badge
                         pill
@@ -1861,6 +2141,7 @@ const MobileHome: React.FC = () => {
             );
           })}
         </ListGroup>
+        )
       )}
 
       {activeTab === 'goals' && (
@@ -1980,37 +2261,13 @@ const MobileHome: React.FC = () => {
         </Modal.Footer>
       </Modal>
 
-      {/* Priority flag confirmation modal */}
-      <Modal show={!!priorityFlagConfirm} onHide={() => setPriorityFlagConfirm(null)} centered>
-        <Modal.Header closeButton>
-          <Modal.Title style={{ fontSize: 16 }}>#1 Priority Already Set</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <p>
-            <strong>{priorityFlagConfirm?.existing?.title}</strong> is already flagged as the #1 priority story.
-          </p>
-          <p>Replace it with <strong>{priorityFlagConfirm?.story?.title}</strong>?</p>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button variant="secondary" size="sm" onClick={() => setPriorityFlagConfirm(null)}>Cancel</Button>
-          <Button
-            variant="danger"
-            size="sm"
-            disabled={!!flaggingStoryId}
-            onClick={() => priorityFlagConfirm && applyPriorityFlag(priorityFlagConfirm.story)}
-          >
-            {flaggingStoryId ? <Spinner animation="border" size="sm" /> : 'Replace'}
-          </Button>
-        </Modal.Footer>
-      </Modal>
-
       <Modal show={!!priorityReplanPromptStory} onHide={() => setPriorityReplanPromptStory(null)} centered>
         <Modal.Header closeButton>
           <Modal.Title style={{ fontSize: 16 }}>Run Delta Replan?</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <p className="mb-2">
-            <strong>{priorityReplanPromptStory?.title || 'This story'}</strong> is now flagged as your #1 priority.
+            <strong>{priorityReplanPromptStory?.title || 'This story'}</strong> is now flagged as {getManualPriorityLabel(priorityReplanPromptStory) || 'a manual priority'}.
           </p>
           <p className="mb-0 text-muted small">
             Run delta replan now to create or rebalance calendar blocks around the new priority.

--- a/react-app/src/components/ModernGoalsTable.tsx
+++ b/react-app/src/components/ModernGoalsTable.tsx
@@ -41,7 +41,8 @@ import {
   Activity,
   Wand2,
   Pencil,
-  Trash2
+  Trash2,
+  CalendarDays
 } from 'lucide-react';
 import { Goal, Story } from '../types';
 import { ChoiceHelper } from '../config/choices';
@@ -87,6 +88,7 @@ interface ModernGoalsTableProps {
   onGoalDelete: (goalId: string) => Promise<void>;
   onGoalPriorityChange: (goalId: string, newPriority: number) => Promise<void>;
   onEditModal?: (goal: Goal) => void;
+  onOpenWorkspace?: (goal: Goal) => void;
   onGoalReorder?: (activeId: string, overId: string) => Promise<void>;
   highlightStoryId?: string;
   highlightGoalId?: string;
@@ -146,7 +148,7 @@ const defaultColumns: Column[] = [
   {
     key: 'linkedPotId',
     label: 'Linked Pot',
-    width: '20%',
+    width: '16%',
     visible: true,
     editable: true,
     type: 'text'
@@ -250,6 +252,7 @@ interface SortableRowProps {
   onGoalUpdate: (goalId: string, updates: Partial<Goal>) => void;
   onGoalDelete: (goalId: string) => void;
   onEditModal: (goal: Goal) => void;
+  onOpenWorkspace?: (goal: Goal) => void;
   onRowClick: (goal: Goal) => void;
   expandedGoalId: string | null;
   goalStories: { [goalId: string]: Story[] };
@@ -322,6 +325,7 @@ const SortableRow: React.FC<SortableRowProps> = ({
   onGoalUpdate,
   onGoalDelete,
   onEditModal,
+  onOpenWorkspace,
   onRowClick,
   onGoalExpand,
   onStoryUpdate,
@@ -1074,6 +1078,29 @@ const SortableRow: React.FC<SortableRowProps> = ({
               <Wand2 size={14} />
             </button>
             <button
+              onClick={() => onOpenWorkspace?.(goal)}
+              style={{
+                color: themeVars.brand as string,
+                padding: '4px',
+                borderRadius: '4px',
+                border: 'none',
+                backgroundColor: 'transparent',
+                cursor: 'pointer',
+                transition: 'all 0.15s ease',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = rgbaCard(0.08);
+                e.currentTarget.style.color = themeVars.brand as string;
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = 'transparent';
+                e.currentTarget.style.color = themeVars.brand as string;
+              }}
+              title="Open planning workspace"
+            >
+              <CalendarDays size={14} />
+            </button>
+            <button
               onClick={() => handleEditClick()}
               style={{
                 color: themeVars.brand as string,
@@ -1167,6 +1194,7 @@ const ModernGoalsTable: React.FC<ModernGoalsTableProps> = ({
   onGoalDelete,
   onGoalPriorityChange,
   onEditModal,
+  onOpenWorkspace,
   onGoalReorder,
   highlightStoryId,
   highlightGoalId,
@@ -1863,6 +1891,7 @@ const ModernGoalsTable: React.FC<ModernGoalsTableProps> = ({
                       onGoalUpdate={onGoalUpdate}
                       onGoalDelete={onGoalDelete}
                       onEditModal={onEditModal ? onEditModal : handleEditModal}
+                      onOpenWorkspace={onOpenWorkspace}
                       onRowClick={handleRowClick}
                       onGoalExpand={handleGoalExpand}
                       onStoryUpdate={handleStoryUpdate}

--- a/react-app/src/components/ModernKanbanBoard.tsx
+++ b/react-app/src/components/ModernKanbanBoard.tsx
@@ -50,7 +50,7 @@ import { normalizePriorityValue, isCriticalPriority } from '../utils/priorityUti
 import { cascadeTaskPersona } from '../utils/personaCascade';
 import { formatTaskTagLabel } from '../utils/tagDisplay';
 import { useGlobalThemes } from '../hooks/useGlobalThemes';
-import NewCalendarEventModal, { BlockFormState, buildCalendarComposerInitialValues } from './planner/NewCalendarEventModal';
+import { getManualPriorityRank } from '../utils/manualPriority';
 
 const formatDueDate = (task: Task): string => {
   const ms = getTaskDueMs(task);
@@ -114,17 +114,6 @@ const isCurrentTop3 = (item: any): boolean => {
   const top3Date = item?.aiTop3Date;
   if (!top3Date) return true;
   return String(top3Date).slice(0, 10) === new Date().toISOString().slice(0, 10);
-};
-
-const isTop3Task = (task: Task): boolean => isCurrentTop3(task);
-
-const isTop3Story = (story: Story): boolean => isCurrentTop3(story);
-
-const getRoutineLikeTaskKind = (task: Task): 'chore' | 'routine' | 'habit' | null => {
-  const raw = String((task as any)?.type || (task as any)?.task_type || '').trim().toLowerCase();
-  const normalized = raw === 'habitual' ? 'habit' : raw;
-  if (normalized === 'chore' || normalized === 'routine' || normalized === 'habit') return normalized;
-  return null;
 };
 
 const matchesCriticalOrHighAi = (item: Story | Task): boolean => {
@@ -529,6 +518,13 @@ const ModernKanbanBoard: React.FC<ModernKanbanBoardProps> = ({ onItemSelect, spr
   const [showAddStoryModal, setShowAddStoryModal] = useState(false);
   const [addType, setAddType] = useState<'story' | 'task'>('story');
   const [scheduleStory, setScheduleStory] = useState<Story | null>(null);
+  const [showScheduleModal, setShowScheduleModal] = useState(false);
+  const [scheduleForm, setScheduleForm] = useState<{ title: string; startLocal: string; durationMin: number }>({
+    title: '',
+    startLocal: '',
+    durationMin: 60,
+  });
+  const [scheduleSaving, setScheduleSaving] = useState(false);
   const [autoLinkMessage, setAutoLinkMessage] = useState<string | null>(null);
   const [deferTarget, setDeferTarget] = useState<{ type: 'task' | 'story'; id: string; title: string } | null>(null);
 
@@ -564,6 +560,22 @@ const ModernKanbanBoard: React.FC<ModernKanbanBoardProps> = ({ onItemSelect, spr
       return true;
     }
   });
+
+  const getTaskManualRank = useCallback((task: Task): number | null => {
+    const directRank = getManualPriorityRank(task);
+    if (directRank) return directRank;
+    const parentStoryId = String(task.storyId || (task.parentType === 'story' ? task.parentId || '' : '')).trim();
+    if (!parentStoryId) return null;
+    return getManualPriorityRank(stories.find((story) => story.id === parentStoryId));
+  }, [stories]);
+
+  const isTop3Task = useCallback((task: Task): boolean => {
+    return Boolean(getTaskManualRank(task)) || isCurrentTop3(task);
+  }, [getTaskManualRank]);
+
+  const isTop3Story = useCallback((story: Story): boolean => {
+    return Boolean(getManualPriorityRank(story)) || isCurrentTop3(story);
+  }, []);
   const formatTaskTag = useCallback(
     (tag: string) => formatTaskTagLabel(tag, goals, sprints),
     [goals, sprints]
@@ -749,23 +761,49 @@ const ModernKanbanBoard: React.FC<ModernKanbanBoardProps> = ({ onItemSelect, spr
   }, []);
 
   const openScheduleModal = useCallback((story: Story) => {
+    const nextHour = new Date();
+    nextHour.setMinutes(0, 0, 0);
+    nextHour.setHours(nextHour.getHours() + 1);
+    const local = new Date(nextHour.getTime() - nextHour.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
     setScheduleStory(story);
+    setScheduleForm({
+      title: story.title || 'Focus block',
+      startLocal: local,
+      durationMin: 60,
+    });
+    setShowScheduleModal(true);
   }, []);
 
-  const scheduleInitialValues = useMemo(() => {
-    if (!scheduleStory) return undefined;
-    return buildCalendarComposerInitialValues({
-      title: scheduleStory.title || 'Focus block',
-      rationale: 'Manual schedule from kanban board',
-      persona: ((scheduleStory as any).persona || currentPersona || 'personal') as 'personal' | 'work',
-      theme: String((scheduleStory as any).theme || 'General'),
-      category: (((scheduleStory as any).persona || currentPersona) === 'work' ? 'Work (Main Gig)' : 'Wellbeing') as any,
-      storyId: scheduleStory.id,
-      points: getStoryPointsRemaining(scheduleStory),
-      aiScore: Number.isFinite(Number((scheduleStory as any).aiCriticalityScore)) ? Number((scheduleStory as any).aiCriticalityScore) : null,
-      aiReason: String((scheduleStory as any).aiReason || (scheduleStory as any).aiPriorityReason || '').trim() || null,
-    }) as Partial<BlockFormState>;
-  }, [scheduleStory, currentPersona, getStoryPointsRemaining]);
+  const saveManualSchedule = useCallback(async () => {
+    if (!currentUser?.uid || !scheduleStory || !scheduleForm.startLocal) return;
+    setScheduleSaving(true);
+    try {
+      const start = new Date(scheduleForm.startLocal);
+      const durationMin = Math.max(15, Number(scheduleForm.durationMin || 60));
+      const end = new Date(start.getTime() + durationMin * 60 * 1000);
+      await addDoc(collection(db, 'calendar_blocks'), {
+        ownerUid: currentUser.uid,
+        title: String(scheduleForm.title || scheduleStory.title || 'Focus block').trim(),
+        start: start.getTime(),
+        end: end.getTime(),
+        storyId: scheduleStory.id,
+        source: 'manual',
+        entryMethod: 'manual_kanban',
+        isAiGenerated: false,
+        status: 'planned',
+        persona: currentPersona || 'personal',
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      });
+      setShowScheduleModal(false);
+      setScheduleStory(null);
+    } catch (error) {
+      console.error('[ModernKanbanBoard] manual schedule failed', error);
+      alert((error as any)?.message || 'Failed to create calendar block.');
+    } finally {
+      setScheduleSaving(false);
+    }
+  }, [currentUser?.uid, currentPersona, scheduleForm, scheduleStory]);
 
   const applyDeferredDate = useCallback(async ({ dateMs, rationale, source }: { dateMs: number; rationale: string; source: string }) => {
     if (!deferTarget) return;
@@ -963,7 +1001,6 @@ const ModernKanbanBoard: React.FC<ModernKanbanBoardProps> = ({ onItemSelect, spr
   });
 
   const filteredTasks = tasksInScope.filter((task) => {
-    if (getRoutineLikeTaskKind(task)) return false;
     if (filterTop3Only && !isTop3Task(task)) return false;
     if (filterCriticalOnly && !(isCriticalPriority(task.priority) || isTop3Task(task))) return false;
     if (filterCriticalAiOnly && !matchesCriticalOrHighAi(task)) return false;
@@ -978,6 +1015,9 @@ const ModernKanbanBoard: React.FC<ModernKanbanBoardProps> = ({ onItemSelect, spr
     const score = getAiScoreValue;
     const dueMs = (story: Story) => getStoryDueMs(story);
     arr.sort((a, b) => {
+      const manualA = getManualPriorityRank(a) || 99;
+      const manualB = getManualPriorityRank(b) || 99;
+      if (manualA !== manualB) return manualA - manualB;
       if (sortMode === 'ai') return (score(b) || -Infinity) - (score(a) || -Infinity);
       if (sortMode === 'overdue') {
         const da = dueMs(a); const db = dueMs(b);
@@ -1001,6 +1041,9 @@ const ModernKanbanBoard: React.FC<ModernKanbanBoardProps> = ({ onItemSelect, spr
       return Math.max(0, now - due);
     };
     arr.sort((a, b) => {
+      const manualA = getTaskManualRank(a) || 99;
+      const manualB = getTaskManualRank(b) || 99;
+      if (manualA !== manualB) return manualA - manualB;
       if (sortMode === 'ai') return (score(b) || -Infinity) - (score(a) || -Infinity);
       if (sortMode === 'due') return (getTaskDueMs(a) || Infinity) - (getTaskDueMs(b) || Infinity);
       if (sortMode === 'overdue') return overdueMs(b) - overdueMs(a);
@@ -1008,7 +1051,7 @@ const ModernKanbanBoard: React.FC<ModernKanbanBoardProps> = ({ onItemSelect, spr
       return 0;
     });
     return arr;
-  }, [filteredTasks, sortMode]);
+  }, [filteredTasks, getTaskManualRank, sortMode]);
 
   const getStoriesForLane = (status: string): Story[] => {
     const lane = (status as LaneStatus) || 'backlog';
@@ -1844,13 +1887,53 @@ const ModernKanbanBoard: React.FC<ModernKanbanBoardProps> = ({ onItemSelect, spr
           </Modal.Footer>
         </Modal>
 
-        <NewCalendarEventModal
-          show={!!scheduleStory}
-          onHide={() => setScheduleStory(null)}
-          initialValues={scheduleInitialValues}
-          stories={scheduleStory ? [scheduleStory] : []}
-          onSaved={() => setScheduleStory(null)}
-        />
+        <Modal show={showScheduleModal} onHide={() => setShowScheduleModal(false)} centered>
+          <Modal.Header closeButton>
+            <Modal.Title>Schedule Story Block</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <div className="mb-2"><strong>{scheduleStory?.title || 'Story'}</strong></div>
+            {scheduleStory && (
+              <div className="text-muted small mb-3">
+                Recommendation: create about {Math.max(1, Math.ceil(getStoryPointsRemaining(scheduleStory) / 2))} calendar block{Math.max(1, Math.ceil(getStoryPointsRemaining(scheduleStory) / 2)) === 1 ? '' : 's'} based on ~{getStoryPointsRemaining(scheduleStory)} points remaining.
+              </div>
+            )}
+            <Form.Group className="mb-3">
+              <Form.Label>Event title</Form.Label>
+              <Form.Control
+                type="text"
+                value={scheduleForm.title}
+                onChange={(e) => setScheduleForm((prev) => ({ ...prev, title: e.target.value }))}
+              />
+            </Form.Group>
+            <Form.Group className="mb-3">
+              <Form.Label>Start</Form.Label>
+              <Form.Control
+                type="datetime-local"
+                value={scheduleForm.startLocal}
+                onChange={(e) => setScheduleForm((prev) => ({ ...prev, startLocal: e.target.value }))}
+              />
+            </Form.Group>
+            <Form.Group>
+              <Form.Label>Duration (minutes)</Form.Label>
+              <Form.Control
+                type="number"
+                min={15}
+                step={15}
+                value={scheduleForm.durationMin}
+                onChange={(e) => setScheduleForm((prev) => ({ ...prev, durationMin: Number(e.target.value) || 60 }))}
+              />
+            </Form.Group>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={() => setShowScheduleModal(false)}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={saveManualSchedule} disabled={scheduleSaving || !scheduleForm.startLocal}>
+              {scheduleSaving ? 'Scheduling…' : 'Create calendar event'}
+            </Button>
+          </Modal.Footer>
+        </Modal>
 
         <DeferItemModal
           show={Boolean(deferTarget)}

--- a/react-app/src/components/ModernSprintsTable.tsx
+++ b/react-app/src/components/ModernSprintsTable.tsx
@@ -33,6 +33,7 @@ import { usePersona } from '../contexts/PersonaContext';
 import { Sprint, Story, Task, Goal } from '../types';
 import { generateRef } from '../utils/referenceGenerator';
 import { isStatus, getStatusName } from '../utils/statusHelpers';
+import { getGoalDisplayPath, isLeafGoal } from '../utils/goalHierarchy';
 
 // Sprint status helpers with null checking
 const getSprintStatusLabel = (status: number | undefined): string => {
@@ -698,12 +699,13 @@ const ModernSprintsTable: React.FC<ModernSprintsTableProps> = ({
                 <div style={{ maxHeight: 180, overflowY: 'auto', border: '1px solid var(--bs-border-color)', borderRadius: 6, padding: 10 }}>
                   {goals.map((goal) => {
                     const checked = formData.focusGoalIds.includes(goal.id);
+                    const leaf = isLeafGoal(goal.id, goals);
                     return (
                       <Form.Check
                         key={goal.id}
                         type="checkbox"
                         id={`sprint-focus-goal-${goal.id}`}
-                        label={goal.title}
+                        label={`${getGoalDisplayPath(goal.id, goals)} ${leaf ? '(Leaf goal)' : '(Program goal)'}`}
                         checked={checked}
                         onChange={(e) => {
                           const nextIds = e.target.checked
@@ -718,7 +720,7 @@ const ModernSprintsTable: React.FC<ModernSprintsTableProps> = ({
                 </div>
               )}
               <Form.Text className="text-muted">
-                If status is Active, at least one sprint focus goal is required.
+                If status is Active, at least one sprint focus goal is required. Program goals cover their child leaf goals; stories still attach to the leaf goal itself.
               </Form.Text>
             </Form.Group>
           </Form>

--- a/react-app/src/components/ModernStoriesTable.tsx
+++ b/react-app/src/components/ModernStoriesTable.tsx
@@ -41,10 +41,11 @@ import { useSidebar } from '../contexts/SidebarContext';
 import { useNavigate } from 'react-router-dom';
 import { useSprint } from '../contexts/SprintContext';
 import { themeVars, rgbaCard } from '../utils/themeVars';
-import { storyStatusText } from '../utils/storyCardFormatting';
+import { priorityLabel, storyStatusText } from '../utils/storyCardFormatting';
 import { parsePointsValue } from '../utils/points';
 import { MISSING_INFO_CELL_BG, MISSING_INFO_CELL_BG_HOVER, hasLinkedId, isBlankText, isMissingPoints } from '../utils/dataQuality';
 import { planningSprints } from '../utils/sprintFilter';
+import { getManualPriorityLabel, getManualPriorityRank } from '../utils/manualPriority';
 
 interface StoryTableRow extends Story {
   goalTitle?: string;
@@ -125,10 +126,10 @@ const defaultColumns: Column[] = [
     key: 'priority', 
     label: 'Priority', 
     width: '8%', 
-    visible: false, 
+    visible: true, 
     editable: true, 
     type: 'select',
-    options: ['low', 'medium', 'high', 'critical']
+    options: ['Critical', 'High', 'Medium', 'Low']
   },
   { 
     key: 'points',
@@ -483,6 +484,24 @@ const SortableRow: React.FC<SortableRowProps> = ({
           'complete': 4,
         };
         valueToSave = map[label] ?? valueToSave;
+      } else if (actualKey === 'priority') {
+        const label = String(valueToSave).toLowerCase();
+        const map: Record<string, number> = {
+          '4': 4,
+          critical: 4,
+          p0: 4,
+          '3': 3,
+          high: 3,
+          p1: 3,
+          '2': 2,
+          medium: 2,
+          med: 2,
+          p2: 2,
+          '1': 1,
+          low: 1,
+          p3: 1,
+        };
+        valueToSave = map[label] ?? valueToSave;
       } else if (actualKey === 'points') {
         const parsedPoints = parsePointsValue(valueToSave);
         const fallbackPoints = parsePointsValue((story as any).points) ?? 1;
@@ -546,6 +565,9 @@ const SortableRow: React.FC<SortableRowProps> = ({
     if (key === 'status') {
       return storyStatusText(value);
     }
+    if (key === 'priority') {
+      return priorityLabel(value, 'Medium');
+    }
     if (key === 'sprintId' && value) {
       const sprint = sprints.find(s => s.id === value);
       return sprint ? sprint.name : value;
@@ -583,6 +605,9 @@ const SortableRow: React.FC<SortableRowProps> = ({
       }
       if (column.key === 'status') {
         return storyStatusText(value);
+      }
+      if (column.key === 'priority') {
+        return priorityLabel(value, 'Medium');
       }
       if (column.key === 'sprintId') {
         return value == null ? '' : String(value);
@@ -965,7 +990,7 @@ const SortableRow: React.FC<SortableRowProps> = ({
             <button
               onClick={() => onPriorityFlag(story)}
               style={{
-                color: (story as any).userPriorityFlag ? 'var(--bs-danger)' : themeVars.brand as string,
+                color: getManualPriorityRank(story) ? 'var(--bs-danger)' : themeVars.brand as string,
                 padding: '4px',
                 borderRadius: '4px',
                 border: 'none',
@@ -973,7 +998,7 @@ const SortableRow: React.FC<SortableRowProps> = ({
                 cursor: 'pointer',
                 transition: 'all 0.15s ease',
               }}
-              title={(story as any).userPriorityFlag ? 'Remove #1 priority flag' : 'Flag as #1 priority for calendar'}
+              title={getManualPriorityRank(story) ? `Remove ${getManualPriorityLabel(story) || 'manual priority'}` : 'Set manual priority for calendar'}
             >
               <CalendarClock size={14} />
             </button>
@@ -1543,9 +1568,10 @@ const ModernStoriesTable: React.FC<ModernStoriesTableProps> = ({
             }}
           >
             <option value="">All Priorities</option>
-            <option value="1">P1 (High)</option>
-            <option value="2">P2 (Medium)</option>
-            <option value="3">P3 (Low)</option>
+            <option value="4">Critical</option>
+            <option value="3">High</option>
+            <option value="2">Medium</option>
+            <option value="1">Low</option>
           </select>
         </div>
 

--- a/react-app/src/components/ModernTaskTable.tsx
+++ b/react-app/src/components/ModernTaskTable.tsx
@@ -49,6 +49,7 @@ import { useGlobalThemes } from '../hooks/useGlobalThemes';
 import { normalizeTaskTags } from '../utils/taskTagging';
 import { parsePointsValue } from '../utils/points';
 import EditTaskModal from './EditTaskModal';
+import EditStoryModal from './EditStoryModal';
 import { MISSING_INFO_CELL_BG, MISSING_INFO_CELL_BG_HOVER, hasLinkedId, isBlankText, isMissingPoints } from '../utils/dataQuality';
 
 interface TaskTableRow extends Task {
@@ -353,6 +354,7 @@ interface SortableRowProps {
   onTaskUpdate: (taskId: string, updates: Partial<Task>) => Promise<void>;
   onTaskDelete: (taskId: string) => Promise<void>;
   onEditRequest: (task: TaskTableRow) => void;
+  onStoryEditRequest: (story: Story | null) => void;
   onSprintAssign: (taskId: string, sprintId: string | null) => Promise<void>;
   onConvertToStory: (task: TaskTableRow) => Promise<void>;
   convertLoadingId: string | null;
@@ -367,6 +369,7 @@ const SortableRow: React.FC<SortableRowProps> = ({
   onTaskUpdate,
   onTaskDelete,
   onEditRequest,
+  onStoryEditRequest,
   onSprintAssign,
   onConvertToStory,
   convertLoadingId,
@@ -762,7 +765,7 @@ const SortableRow: React.FC<SortableRowProps> = ({
                   type="button"
                   onClick={(e) => {
                     e.stopPropagation();
-                    if (linkedStory) showSidebar(linkedStory, 'story');
+                    onStoryEditRequest(linkedStory || null);
                   }}
                   style={{
                     background: 'none',
@@ -973,6 +976,8 @@ const ModernTaskTable: React.FC<ModernTaskTableProps> = ({
   // Edit modal state
   const [showEditModal, setShowEditModal] = useState(false);
   const [editingTask, setEditingTask] = useState<TaskTableRow | null>(null);
+  const [showStoryEditModal, setShowStoryEditModal] = useState(false);
+  const [editingStory, setEditingStory] = useState<Story | null>(null);
   const [editForm, setEditForm] = useState<Partial<TaskTableRow>>({});
   const [storySearch, setStorySearch] = useState('');
   const [goalSearch, setGoalSearch] = useState('');
@@ -987,6 +992,12 @@ const ModernTaskTable: React.FC<ModernTaskTableProps> = ({
   };
 
   const closeToast = () => setToastState(prev => ({ ...prev, show: false }));
+
+  const handleStoryEditRequest = (story: Story | null) => {
+    if (!story) return;
+    setEditingStory(story);
+    setShowStoryEditModal(true);
+  };
 
   // Activity stream helpers
   const { addNote, trackFieldChange } = useActivityTracking();
@@ -1615,6 +1626,7 @@ const ModernTaskTable: React.FC<ModernTaskTableProps> = ({
                           setEditingTask(t);
                           setShowEditModal(true);
                         }}
+                        onStoryEditRequest={handleStoryEditRequest}
                         onSprintAssign={handleSprintAssign}
                         onConvertToStory={handleConvertToStory}
                         convertLoadingId={convertLoadingId}
@@ -1926,6 +1938,15 @@ const ModernTaskTable: React.FC<ModernTaskTableProps> = ({
         task={editingTask as Task | null}
         onHide={() => { setShowEditModal(false); setEditingTask(null); }}
       />
+      <EditStoryModal
+        show={showStoryEditModal && !!editingStory}
+        story={editingStory}
+        goals={goals}
+        onHide={() => {
+          setShowStoryEditModal(false);
+          setEditingStory(null);
+        }}
+      />
 
       {/* Create Task Modal (lightweight, only used for inline add) */}
       {showEditModal && !editingTask && (
@@ -1997,8 +2018,11 @@ const ModernTaskTable: React.FC<ModernTaskTableProps> = ({
                           min={1}
                           max={365}
                           className="form-control"
-                          value={(editForm as any).repeatInterval || 1}
-                          onChange={(e) => setEditForm({ ...editForm, repeatInterval: Number(e.target.value) || 1 })}
+                          value={(editForm as any).repeatInterval ?? ''}
+                          onChange={(e) => setEditForm({
+                            ...editForm,
+                            repeatInterval: (e.target.value === '' ? '' : e.target.value) as any,
+                          } as any)}
                         />
                       </div>
                     </div>

--- a/react-app/src/components/SettingsPage.tsx
+++ b/react-app/src/components/SettingsPage.tsx
@@ -114,6 +114,16 @@ const SettingsPage: React.FC = () => {
   const [excludeWithDadFromMetrics, setExcludeWithDadFromMetrics] = useState(true);
   const [targetWeightKg, setTargetWeightKg] = useState('');
   const [targetBodyFatPct, setTargetBodyFatPct] = useState('');
+  const [targetStepsPerDay, setTargetStepsPerDay] = useState('');
+  const [targetDistanceKmPerDay, setTargetDistanceKmPerDay] = useState('');
+  const [targetWorkoutMinutesPerWeek, setTargetWorkoutMinutesPerWeek] = useState('');
+  const [targetAwakeHoursPerDay, setTargetAwakeHoursPerDay] = useState('');
+  const [targetWorkHoursPerDay, setTargetWorkHoursPerDay] = useState('');
+  const [targetWorkoutPctOfFreeTime, setTargetWorkoutPctOfFreeTime] = useState('');
+  const [targetProteinG, setTargetProteinG] = useState('');
+  const [targetFatG, setTargetFatG] = useState('');
+  const [targetCarbsG, setTargetCarbsG] = useState('');
+  const [targetCaloriesKcal, setTargetCaloriesKcal] = useState('');
   const [locationName, setLocationName] = useState('');
   const [locationLat, setLocationLat] = useState<string>('');
   const [locationLon, setLocationLon] = useState<string>('');
@@ -319,6 +329,16 @@ const SettingsPage: React.FC = () => {
         setExcludeWithDadFromMetrics(p.excludeWithDadFromMetrics !== false);
           setTargetWeightKg(p.targetWeightKg != null ? String(p.targetWeightKg) : (p.healthTargetWeightKg != null ? String(p.healthTargetWeightKg) : ''));
           setTargetBodyFatPct(p.targetBodyFatPct != null ? String(p.targetBodyFatPct) : (p.healthTargetBodyFatPct != null ? String(p.healthTargetBodyFatPct) : ''));
+          setTargetStepsPerDay(p.targetStepsPerDay != null ? String(p.targetStepsPerDay) : (p.dailyStepTarget != null ? String(p.dailyStepTarget) : (p.healthTargetStepsPerDay != null ? String(p.healthTargetStepsPerDay) : '')));
+          setTargetDistanceKmPerDay(p.targetDistanceKmPerDay != null ? String(p.targetDistanceKmPerDay) : (p.dailyDistanceTargetKm != null ? String(p.dailyDistanceTargetKm) : (p.healthTargetDistanceKmPerDay != null ? String(p.healthTargetDistanceKmPerDay) : '')));
+          setTargetWorkoutMinutesPerWeek(p.weeklyWorkoutTargetMinutes != null ? String(p.weeklyWorkoutTargetMinutes) : (p.targetWorkoutMinutesPerWeek != null ? String(p.targetWorkoutMinutesPerWeek) : (p.healthTargetWorkoutMinutesWeekly != null ? String(p.healthTargetWorkoutMinutesWeekly) : '')));
+          setTargetAwakeHoursPerDay(p.awakeHoursPerDay != null ? String(p.awakeHoursPerDay) : (p.targetAwakeHoursPerDay != null ? String(p.targetAwakeHoursPerDay) : (p.healthAwakeHoursPerDay != null ? String(p.healthAwakeHoursPerDay) : '')));
+          setTargetWorkHoursPerDay(p.workHoursPerDay != null ? String(p.workHoursPerDay) : (p.targetWorkHoursPerDay != null ? String(p.targetWorkHoursPerDay) : (p.healthWorkHoursPerDay != null ? String(p.healthWorkHoursPerDay) : '')));
+          setTargetWorkoutPctOfFreeTime(p.targetWorkoutPctOfFreeTime != null ? String(p.targetWorkoutPctOfFreeTime) : (p.weeklyWorkoutTargetPercent != null ? String(p.weeklyWorkoutTargetPercent) : (p.trainingTimePercent != null ? String(p.trainingTimePercent) : '')));
+          setTargetProteinG(p.targetProteinG != null ? String(p.targetProteinG) : (p.dailyProteinTargetG != null ? String(p.dailyProteinTargetG) : (p.healthTargetProteinG != null ? String(p.healthTargetProteinG) : '')));
+          setTargetFatG(p.targetFatG != null ? String(p.targetFatG) : (p.dailyFatTargetG != null ? String(p.dailyFatTargetG) : (p.healthTargetFatG != null ? String(p.healthTargetFatG) : '')));
+          setTargetCarbsG(p.targetCarbsG != null ? String(p.targetCarbsG) : (p.dailyCarbsTargetG != null ? String(p.dailyCarbsTargetG) : (p.healthTargetCarbsG != null ? String(p.healthTargetCarbsG) : '')));
+          setTargetCaloriesKcal(p.targetCaloriesKcal != null ? String(p.targetCaloriesKcal) : (p.dailyCaloriesTargetKcal != null ? String(p.dailyCaloriesTargetKcal) : (p.healthTargetCaloriesKcal != null ? String(p.healthTargetCaloriesKcal) : '')));
         setMonzoConnected(!!p.monzoConnected);
         setLocationName(p.locationName || '');
         setLocationLat(p.locationLat != null ? String(p.locationLat) : '');
@@ -1159,6 +1179,16 @@ firebase deploy --only functions:remindersPush,functions:remindersPull --project
                                 try {
                                   const parsedTargetWeightKg = targetWeightKg.trim() !== '' ? Number(targetWeightKg) : null;
                                   const parsedTargetBodyFatPct = targetBodyFatPct.trim() !== '' ? Number(targetBodyFatPct) : null;
+                                  const parsedTargetStepsPerDay = targetStepsPerDay.trim() !== '' ? Number(targetStepsPerDay) : null;
+                                  const parsedTargetDistanceKmPerDay = targetDistanceKmPerDay.trim() !== '' ? Number(targetDistanceKmPerDay) : null;
+                                  const parsedTargetWorkoutMinutesPerWeek = targetWorkoutMinutesPerWeek.trim() !== '' ? Number(targetWorkoutMinutesPerWeek) : null;
+                                  const parsedTargetAwakeHoursPerDay = targetAwakeHoursPerDay.trim() !== '' ? Number(targetAwakeHoursPerDay) : null;
+                                  const parsedTargetWorkHoursPerDay = targetWorkHoursPerDay.trim() !== '' ? Number(targetWorkHoursPerDay) : null;
+                                  const parsedTargetWorkoutPctOfFreeTime = targetWorkoutPctOfFreeTime.trim() !== '' ? Number(targetWorkoutPctOfFreeTime) : null;
+                                  const parsedTargetProteinG = targetProteinG.trim() !== '' ? Number(targetProteinG) : null;
+                                  const parsedTargetFatG = targetFatG.trim() !== '' ? Number(targetFatG) : null;
+                                  const parsedTargetCarbsG = targetCarbsG.trim() !== '' ? Number(targetCarbsG) : null;
+                                  const parsedTargetCaloriesKcal = targetCaloriesKcal.trim() !== '' ? Number(targetCaloriesKcal) : null;
                                   await setDoc(doc(db, 'profiles', currentUser.uid), {
                                     ownerUid: currentUser.uid,
                                     parkrunAthleteId,
@@ -1174,6 +1204,36 @@ firebase deploy --only functions:remindersPush,functions:remindersPull --project
                                     healthTargetWeightKg: parsedTargetWeightKg,
                                     targetBodyFatPct: parsedTargetBodyFatPct,
                                     healthTargetBodyFatPct: parsedTargetBodyFatPct,
+                                    targetStepsPerDay: parsedTargetStepsPerDay,
+                                    dailyStepTarget: parsedTargetStepsPerDay,
+                                    healthTargetStepsPerDay: parsedTargetStepsPerDay,
+                                    targetDistanceKmPerDay: parsedTargetDistanceKmPerDay,
+                                    dailyDistanceTargetKm: parsedTargetDistanceKmPerDay,
+                                    healthTargetDistanceKmPerDay: parsedTargetDistanceKmPerDay,
+                                    weeklyWorkoutTargetMinutes: parsedTargetWorkoutMinutesPerWeek,
+                                    targetWorkoutMinutesPerWeek: parsedTargetWorkoutMinutesPerWeek,
+                                    healthTargetWorkoutMinutesWeekly: parsedTargetWorkoutMinutesPerWeek,
+                                    awakeHoursPerDay: parsedTargetAwakeHoursPerDay,
+                                    targetAwakeHoursPerDay: parsedTargetAwakeHoursPerDay,
+                                    healthAwakeHoursPerDay: parsedTargetAwakeHoursPerDay,
+                                    workHoursPerDay: parsedTargetWorkHoursPerDay,
+                                    targetWorkHoursPerDay: parsedTargetWorkHoursPerDay,
+                                    healthWorkHoursPerDay: parsedTargetWorkHoursPerDay,
+                                    targetWorkoutPctOfFreeTime: parsedTargetWorkoutPctOfFreeTime,
+                                    weeklyWorkoutTargetPercent: parsedTargetWorkoutPctOfFreeTime,
+                                    trainingTimePercent: parsedTargetWorkoutPctOfFreeTime,
+                                    targetProteinG: parsedTargetProteinG,
+                                    dailyProteinTargetG: parsedTargetProteinG,
+                                    healthTargetProteinG: parsedTargetProteinG,
+                                    targetFatG: parsedTargetFatG,
+                                    dailyFatTargetG: parsedTargetFatG,
+                                    healthTargetFatG: parsedTargetFatG,
+                                    targetCarbsG: parsedTargetCarbsG,
+                                    dailyCarbsTargetG: parsedTargetCarbsG,
+                                    healthTargetCarbsG: parsedTargetCarbsG,
+                                    targetCaloriesKcal: parsedTargetCaloriesKcal,
+                                    dailyCaloriesTargetKcal: parsedTargetCaloriesKcal,
+                                    healthTargetCaloriesKcal: parsedTargetCaloriesKcal,
                                   }, { merge: true });
                                   setSaveProfileMsg('Saved');
                                   setTimeout(() => setSaveProfileMsg(''), 2500);
@@ -1217,9 +1277,134 @@ firebase deploy --only functions:remindersPush,functions:remindersPull --project
                               />
                             </Form.Group>
                           </Col>
+                          <Col md={3}>
+                            <Form.Group>
+                              <Form.Label style={{ color: colors.primary }}>Steps Target</Form.Label>
+                              <Form.Control
+                                type="number"
+                                step="100"
+                                placeholder="e.g., 10000"
+                                value={targetStepsPerDay}
+                                onChange={(e) => setTargetStepsPerDay(e.target.value)}
+                              />
+                            </Form.Group>
+                          </Col>
+                          <Col md={3}>
+                            <Form.Group>
+                              <Form.Label style={{ color: colors.primary }}>Distance Target (km/day)</Form.Label>
+                              <Form.Control
+                                type="number"
+                                step="0.1"
+                                placeholder="e.g., 5"
+                                value={targetDistanceKmPerDay}
+                                onChange={(e) => setTargetDistanceKmPerDay(e.target.value)}
+                              />
+                            </Form.Group>
+                          </Col>
+                          <Col md={3}>
+                            <Form.Group>
+                              <Form.Label style={{ color: colors.primary }}>Workout Target Override (min/week)</Form.Label>
+                              <Form.Control
+                                type="number"
+                                step="5"
+                                placeholder="Leave blank to derive"
+                                value={targetWorkoutMinutesPerWeek}
+                                onChange={(e) => setTargetWorkoutMinutesPerWeek(e.target.value)}
+                              />
+                              <Form.Text className="text-muted">Optional explicit override. Leave blank to derive from awake/work hours and training %.</Form.Text>
+                            </Form.Group>
+                          </Col>
+                          <Col md={3}>
+                            <Form.Group>
+                              <Form.Label style={{ color: colors.primary }}>Awake Hours / Day</Form.Label>
+                              <Form.Control
+                                type="number"
+                                step="0.5"
+                                placeholder="e.g., 16"
+                                value={targetAwakeHoursPerDay}
+                                onChange={(e) => setTargetAwakeHoursPerDay(e.target.value)}
+                              />
+                            </Form.Group>
+                          </Col>
+                          <Col md={3}>
+                            <Form.Group>
+                              <Form.Label style={{ color: colors.primary }}>Work Hours / Day</Form.Label>
+                              <Form.Control
+                                type="number"
+                                step="0.5"
+                                placeholder="e.g., 8"
+                                value={targetWorkHoursPerDay}
+                                onChange={(e) => setTargetWorkHoursPerDay(e.target.value)}
+                              />
+                            </Form.Group>
+                          </Col>
+                          <Col md={3}>
+                            <Form.Group>
+                              <Form.Label style={{ color: colors.primary }}>Workout % Of Free Time</Form.Label>
+                              <Form.Control
+                                type="number"
+                                step="1"
+                                placeholder="e.g., 20"
+                                value={targetWorkoutPctOfFreeTime}
+                                onChange={(e) => setTargetWorkoutPctOfFreeTime(e.target.value)}
+                              />
+                            </Form.Group>
+                          </Col>
+                        </Row>
+                        <Row className="g-3 mt-1">
+                          <Col md={3}>
+                            <Form.Group>
+                              <Form.Label style={{ color: colors.primary }}>Protein Target (g/day)</Form.Label>
+                              <Form.Control
+                                type="number"
+                                step="1"
+                                placeholder="e.g., 180"
+                                value={targetProteinG}
+                                onChange={(e) => setTargetProteinG(e.target.value)}
+                              />
+                            </Form.Group>
+                          </Col>
+                          <Col md={3}>
+                            <Form.Group>
+                              <Form.Label style={{ color: colors.primary }}>Fat Target (g/day)</Form.Label>
+                              <Form.Control
+                                type="number"
+                                step="1"
+                                placeholder="e.g., 70"
+                                value={targetFatG}
+                                onChange={(e) => setTargetFatG(e.target.value)}
+                              />
+                            </Form.Group>
+                          </Col>
+                          <Col md={3}>
+                            <Form.Group>
+                              <Form.Label style={{ color: colors.primary }}>Carbs Target (g/day)</Form.Label>
+                              <Form.Control
+                                type="number"
+                                step="1"
+                                placeholder="e.g., 250"
+                                value={targetCarbsG}
+                                onChange={(e) => setTargetCarbsG(e.target.value)}
+                              />
+                            </Form.Group>
+                          </Col>
+                          <Col md={3}>
+                            <Form.Group>
+                              <Form.Label style={{ color: colors.primary }}>Calories Target (kcal/day)</Form.Label>
+                              <Form.Control
+                                type="number"
+                                step="10"
+                                placeholder="e.g., 2400"
+                                value={targetCaloriesKcal}
+                                onChange={(e) => setTargetCaloriesKcal(e.target.value)}
+                              />
+                            </Form.Group>
+                          </Col>
+                        </Row>
+                        <Row className="g-3 mt-1">
                           <Col md={6} className="d-flex align-items-end">
                             <Form.Text className="text-muted">
-                              These targets feed the dashboard health progress card and the health trends shown on the fitness dashboard.
+                              These targets feed the dashboard health card, the `/fitness` compliance cards, and the health/nutrition trends shown across the app.
                             </Form.Text>
                           </Col>
                         </Row>

--- a/react-app/src/components/SidebarLayout.tsx
+++ b/react-app/src/components/SidebarLayout.tsx
@@ -127,7 +127,6 @@ const SidebarLayout: React.FC<SidebarLayoutProps> = ({ children, onSignOut }) =>
       icon: 'book',
       items: [
         { label: 'Stories List', path: '/stories', icon: 'list' },
-        { label: 'Sprint Planner', path: '/sprints/planning', icon: 'th' },
         { label: 'Kanban Board', path: '/sprints/kanban', icon: 'kanban' },
         { label: 'Calendar', path: '/calendar', icon: 'calendar' }
       ]

--- a/react-app/src/components/SprintKanbanPageV2.tsx
+++ b/react-app/src/components/SprintKanbanPageV2.tsx
@@ -477,13 +477,6 @@ const SprintKanbanPageV2: React.FC = () => {
                                 <Button
                                     variant="outline-secondary"
                                     size="sm"
-                                    onClick={() => navigate('/sprints/planning')}
-                                >
-                                    Sprint planner
-                                </Button>
-                                <Button
-                                    variant="outline-secondary"
-                                    size="sm"
                                     onClick={() => navigate('/dashboard')}
                                 >
                                     View overview
@@ -495,6 +488,13 @@ const SprintKanbanPageV2: React.FC = () => {
                                 >
                                     <CalendarIcon size={14} className="me-1" />
                                     View calendar
+                                </Button>
+                                <Button
+                                    variant="outline-secondary"
+                                    size="sm"
+                                    onClick={() => navigate('/sprints/planning')}
+                                >
+                                    View planner
                                 </Button>
                                 <Button
                                     variant="outline-primary"

--- a/react-app/src/components/SprintPlanningMatrix.tsx
+++ b/react-app/src/components/SprintPlanningMatrix.tsx
@@ -6,6 +6,7 @@ import { collection, query, where, onSnapshot, updateDoc, doc, serverTimestamp, 
 import { useAuth } from '../contexts/AuthContext';
 import { usePersona } from '../contexts/PersonaContext';
 import { useSprint } from '../contexts/SprintContext';
+import { useFocusGoals } from '../hooks/useFocusGoals';
 import { Story, Sprint, Goal } from '../types';
 import { Calendar, Filter, Plus, ArrowUpDown, ArrowRight, Target, Maximize2, Minimize2, LayoutGrid, ArrowRightLeft } from 'lucide-react';
 import KanbanCardV2 from './KanbanCardV2';
@@ -14,11 +15,16 @@ import type { GlobalTheme } from '../constants/globalThemes';
 import { themeVars } from '../utils/themeVars';
 import '../styles/KanbanCards.css';
 import { goalThemeColor } from '../utils/storyCardFormatting';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { formatTaskTagLabel } from '../utils/tagDisplay';
 import { useGlobalThemes } from '../hooks/useGlobalThemes';
 import { isStatus } from '../utils/statusHelpers';
-import { isGoalInHierarchySet } from '../utils/goalHierarchy';
+import { getGoalDisplayPath, isGoalInHierarchySet } from '../utils/goalHierarchy';
+import { planningSprints as getPlanningSprints } from '../utils/sprintFilter';
+import DeferItemModal from './DeferItemModal';
+import { buildSprintCapacitySummary, storyPoints } from '../utils/plannerCapacity';
+import { schedulePlannerItem as schedulePlannerItemMutation } from '../utils/plannerScheduling';
+import { parseBooleanParam, parseIdListParam, parseNumberListParam } from '../utils/planningQuery';
 
 // Normalize sprint identifiers so we handle doc refs, strings, and legacy placeholders
 const normalizeSprintId = (value: any): string | null => {
@@ -81,13 +87,20 @@ const SprintColumn: React.FC<{
   sprint: Sprint | null;
   stories: Story[];
   goals: Goal[];
+  capacitySummary?: {
+    capacityPoints: number;
+    plannedPoints: number;
+    remainingPoints: number;
+    utilizationPct: number;
+    overCapacity: boolean;
+  } | null;
   isBacklog?: boolean;
   placeholderLabel?: string;
   droppableId: string;
   showDescriptions: boolean;
   formatTag?: (tag: string) => string;
   themes?: GlobalTheme[];
-}> = ({ sprint, stories, goals, isBacklog = false, placeholderLabel, droppableId, showDescriptions, formatTag, themes }) => {
+}> = ({ sprint, stories, goals, capacitySummary = null, isBacklog = false, placeholderLabel, droppableId, showDescriptions, formatTag, themes }) => {
   const ref = useRef<HTMLDivElement>(null);
   const [isOver, setIsOver] = useState(false);
 
@@ -170,7 +183,17 @@ const SprintColumn: React.FC<{
         <div className="sprint-column__stats">
           <span>{stories.length} stories</span>
           <span>{totalPoints} pts</span>
+          {!isBacklog && capacitySummary && (
+            <span style={{ color: capacitySummary.overCapacity ? '#dc2626' : capacitySummary.remainingPoints <= 2 ? '#d97706' : undefined }}>
+              {capacitySummary.remainingPoints.toFixed(1)} pts free
+            </span>
+          )}
         </div>
+        {!isBacklog && capacitySummary && (
+          <div style={{ fontSize: 11, color: capacitySummary.overCapacity ? '#dc2626' : '#6b7280' }}>
+            {capacitySummary.plannedPoints.toFixed(1)}/{capacitySummary.capacityPoints.toFixed(1)} pts · {capacitySummary.utilizationPct}%
+          </div>
+        )}
       </div>
 
       <div
@@ -214,38 +237,103 @@ const SprintColumn: React.FC<{
   );
 };
 
+const GroupedSprintCell: React.FC<{
+  title: string;
+  stories: Story[];
+  goals: Goal[];
+  showDescriptions: boolean;
+  formatTag?: (tag: string) => string;
+  themes?: GlobalTheme[];
+}> = ({ title, stories, goals, showDescriptions, formatTag, themes }) => (
+  <Card style={{ border: '1px solid rgba(0,0,0,0.08)', minWidth: 240 }}>
+    <Card.Body style={{ padding: 10 }}>
+      <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 8, color: themeVars.text as string }}>
+        {title}
+      </div>
+      {stories.length === 0 ? (
+        <div style={{ fontSize: 12, color: themeVars.muted as string }}>No matching stories</div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {stories.map((story) => {
+            const goal = goals.find((candidate) => candidate.id === story.goalId);
+            const themeColor = goalThemeColor(goal, themes);
+            return (
+              <KanbanCardV2
+                key={`${title}-${story.id}`}
+                item={story}
+                type="story"
+                goal={goal}
+                themeColor={themeColor || undefined}
+                taskCount={0}
+                showDescription={showDescriptions}
+                formatTag={formatTag}
+                themes={themes}
+              />
+            );
+          })}
+        </div>
+      )}
+    </Card.Body>
+  </Card>
+);
+
 const SprintPlanningMatrix: React.FC = () => {
   const { currentUser } = useAuth();
   const { currentPersona } = usePersona();
+  const [searchParams] = useSearchParams();
   const { sprints } = useSprint();
+  const { activeFocusGoals } = useFocusGoals(currentUser?.uid);
   const { themes: globalThemes } = useGlobalThemes();
   const navigate = useNavigate();
   const containerRef = useRef<HTMLDivElement>(null);
+  const embedded = parseBooleanParam(searchParams.get('embed'));
+  const initialGoalIds = useMemo(
+    () => parseIdListParam(searchParams.get('goalIds') || searchParams.get('goalId')),
+    [searchParams],
+  );
+  const initialThemeIds = useMemo(
+    () => parseNumberListParam(searchParams.get('themeIds') || searchParams.get('themeId')),
+    [searchParams],
+  );
+  const initialFocusOnly = parseBooleanParam(searchParams.get('focusOnly'));
+  const initialGroupBy = (() => {
+    const raw = String(searchParams.get('groupBy') || '').trim().toLowerCase();
+    if (raw === 'goal' || raw === 'theme') return raw as 'goal' | 'theme';
+    if (initialGoalIds.length > 0) return 'goal';
+    if (initialThemeIds.length > 0) return 'theme';
+    return 'none' as const;
+  })();
   
   // State
   const [stories, setStories] = useState<Story[]>([]);
   const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
   const [moveError, setMoveError] = useState<string | null>(null);
+  const [deferTarget, setDeferTarget] = useState<Story | null>(null);
+  const [deferPromptMessage, setDeferPromptMessage] = useState<string | null>(null);
   const [showDescriptions, setShowDescriptions] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const formatTag = (tag: string) => formatTaskTagLabel(tag, goals, sprints);
   
   // Filters
-  const [filterGoal, setFilterGoal] = useState<string>('all');
-  const [filterTheme, setFilterTheme] = useState<number | null>(null);
+  const [selectedGoalIds, setSelectedGoalIds] = useState<string[]>(initialGoalIds);
+  const [selectedThemeIds, setSelectedThemeIds] = useState<number[]>(initialThemeIds);
   const [showCompletedSprints, setShowCompletedSprints] = useState(false);
   const [showCompletedItems, setShowCompletedItems] = useState(false);
   const [showTop3Only, setShowTop3Only] = useState(false);
   const [showAiScoredOnly, setShowAiScoredOnly] = useState(false);
   const [activeFocusGoalIds, setActiveFocusGoalIds] = useState<Set<string>>(new Set());
-  const [applyFocusOnlyFilter, setApplyFocusOnlyFilter] = useState(false);
+  const [applyFocusOnlyFilter, setApplyFocusOnlyFilter] = useState(initialFocusOnly);
   const [focusToggleTouched, setFocusToggleTouched] = useState(false);
   const [sortField, setSortField] = useState<MatrixSortField>('none');
   const [sortDirection, setSortDirection] = useState<MatrixSortDirection>('desc');
   const [goalSearch, setGoalSearch] = useState('');
+  const [rowGrouping, setRowGrouping] = useState<'none' | 'goal' | 'theme'>(initialGroupBy);
   const [bulkMoveLoading, setBulkMoveLoading] = useState(false);
   const [moveNotice, setMoveNotice] = useState<string | null>(null);
+  const [selectedSprintIds, setSelectedSprintIds] = useState<string[]>([]);
+  const [showAllSprintColumns, setShowAllSprintColumns] = useState(false);
+  const [sprintColumnsTouched, setSprintColumnsTouched] = useState(false);
 
   useEffect(() => {
     const handler = () => {
@@ -373,34 +461,67 @@ const SprintPlanningMatrix: React.FC = () => {
     }
   }, [activeFocusGoalIds, focusToggleTouched]);
 
+  useEffect(() => {
+    if (initialGoalIds.length > 0) {
+      setSelectedGoalIds(initialGoalIds);
+    }
+  }, [initialGoalIds]);
+
+  useEffect(() => {
+    if (initialThemeIds.length > 0) {
+      setSelectedThemeIds(initialThemeIds);
+    }
+  }, [initialThemeIds]);
+
+  useEffect(() => {
+    if (initialFocusOnly) {
+      setApplyFocusOnlyFilter(true);
+      setFocusToggleTouched(true);
+    }
+  }, [initialFocusOnly]);
+
   // Filter stories
   const filteredStories = useMemo(() => {
+    const goalIdSet = new Set(selectedGoalIds);
+    const themeIdSet = new Set(selectedThemeIds);
     return stories.filter((story) => {
       if (!showCompletedItems && isStatus((story as any).status, 'done')) return false;
       if (applyFocusOnlyFilter && activeFocusGoalIds.size > 0) {
         const goalId = String(story.goalId || '').trim();
         if (!goalId || !isGoalInHierarchySet(goalId, goals, activeFocusGoalIds)) return false;
       }
-      if (filterGoal !== 'all' && story.goalId !== filterGoal) return false;
+      if (goalIdSet.size > 0) {
+        const storyGoalId = String(story.goalId || '').trim();
+        if (!storyGoalId || !isGoalInHierarchySet(storyGoalId, goals, goalIdSet)) return false;
+      }
       if (showTop3Only && !isTop3Story(story)) return false;
       if (showAiScoredOnly && getStoryAiScore(story) == null) return false;
-      if (filterTheme) {
+      if (themeIdSet.size > 0) {
         const goal = goals.find((g) => g.id === story.goalId);
         const storyTheme = (story as any).theme ?? goal?.theme ?? null;
-        if (storyTheme !== filterTheme) return false;
+        if (!themeIdSet.has(Number(storyTheme))) return false;
       }
       return true;
     });
-  }, [stories, goals, filterGoal, filterTheme, showCompletedItems, showTop3Only, showAiScoredOnly, applyFocusOnlyFilter, activeFocusGoalIds]);
+  }, [stories, goals, selectedGoalIds, selectedThemeIds, showCompletedItems, showTop3Only, showAiScoredOnly, applyFocusOnlyFilter, activeFocusGoalIds]);
 
-  const filteredGoals = useMemo(() => {
+  const goalFilterOptions = useMemo(() => {
     const baseGoals = applyFocusOnlyFilter && activeFocusGoalIds.size > 0
       ? goals.filter((goal) => isGoalInHierarchySet(goal.id, goals, activeFocusGoalIds))
       : goals;
-    if (!goalSearch.trim()) return baseGoals;
+    const themeScoped = selectedThemeIds.length > 0
+      ? baseGoals.filter((goal) => selectedThemeIds.includes(Number(goal.theme)))
+      : baseGoals;
+    if (!goalSearch.trim()) return themeScoped;
     const q = goalSearch.toLowerCase();
-    return baseGoals.filter((g) => g.title.toLowerCase().includes(q));
-  }, [goals, goalSearch, applyFocusOnlyFilter, activeFocusGoalIds]);
+    return themeScoped.filter((g) => g.title.toLowerCase().includes(q));
+  }, [goals, goalSearch, selectedThemeIds, applyFocusOnlyFilter, activeFocusGoalIds]);
+
+  const filteredGoals = useMemo(() => (
+    selectedGoalIds.length > 0
+      ? goalFilterOptions.filter((goal) => isGoalInHierarchySet(goal.id, goals, new Set(selectedGoalIds)))
+      : goalFilterOptions
+  ), [goalFilterOptions, goals, selectedGoalIds]);
 
   const sortedStories = useMemo(() => {
     const next = [...filteredStories];
@@ -436,7 +557,7 @@ const SprintPlanningMatrix: React.FC = () => {
 
   const backlogStories = storiesBySprint.backlog ?? [];
 
-  const visibleSprints = useMemo(() => {
+  const sprintColumnPool = useMemo(() => {
     return [...sprints]
       .filter((s) => {
         if (showCompletedSprints) return true;
@@ -448,26 +569,147 @@ const SprintPlanningMatrix: React.FC = () => {
       .sort((a, b) => (a.startDate ?? 0) - (b.startDate ?? 0));
   }, [sprints, showCompletedSprints]);
 
-  const planningSprints = useMemo(() => {
-    return [...sprints]
-      .filter((s) => {
-        const statusValue = (s as any).status;
-        if (typeof statusValue === 'number') return statusValue <= 1;
-        const normalized = String(statusValue ?? '').toLowerCase();
-        return normalized === '' || normalized.includes('plan') || normalized.includes('active');
-      })
-      .sort((a, b) => (a.startDate ?? 0) - (b.startDate ?? 0));
+  const planningSprintPool = useMemo(
+    () => [...getPlanningSprints(sprints as Sprint[])].sort((a, b) => (a.startDate ?? 0) - (b.startDate ?? 0)),
+    [sprints],
+  );
+
+  const defaultSelectedSprintIds = useMemo(
+    () => planningSprintPool.slice(0, 3).map((sprint) => sprint.id),
+    [planningSprintPool],
+  );
+
+  useEffect(() => {
+    if (!sprintColumnsTouched) {
+      setSelectedSprintIds(defaultSelectedSprintIds);
+      setShowAllSprintColumns(false);
+    }
+  }, [defaultSelectedSprintIds, sprintColumnsTouched]);
+
+  useEffect(() => {
+    setSelectedSprintIds((prev) => prev.filter((id) => sprints.some((sprint) => sprint.id === id)));
   }, [sprints]);
 
+  const visibleSprints = useMemo(() => {
+    if (showAllSprintColumns) return sprintColumnPool;
+    const effectiveIds = (selectedSprintIds.length ? selectedSprintIds : defaultSelectedSprintIds)
+      .filter((id) => sprintColumnPool.some((sprint) => sprint.id === id));
+    if (!effectiveIds.length) {
+      return sprintColumnPool.filter((sprint) => defaultSelectedSprintIds.includes(sprint.id));
+    }
+    return sprintColumnPool.filter((sprint) => effectiveIds.includes(sprint.id));
+  }, [showAllSprintColumns, sprintColumnPool, selectedSprintIds, defaultSelectedSprintIds]);
+
+  const goalFilterLabel = useMemo(() => {
+    if (selectedGoalIds.length === 0) return 'All Goals';
+    const labels = selectedGoalIds
+      .map((goalId) => {
+        const goal = goals.find((candidate) => candidate.id === goalId);
+        return goal ? getGoalDisplayPath(goal.id, goals) : goalId;
+      })
+      .filter(Boolean);
+    if (labels.length <= 2) return labels.join(', ');
+    return `${labels.length} goals`;
+  }, [goals, selectedGoalIds]);
+
+  const themeFilterLabel = useMemo(() => {
+    if (selectedThemeIds.length === 0) return 'All Themes';
+    const labels = selectedThemeIds
+      .map((themeId) => GLOBAL_THEMES.find((theme) => theme.id === themeId)?.label || `Theme ${themeId}`)
+      .filter(Boolean);
+    if (labels.length <= 2) return labels.join(', ');
+    return `${labels.length} themes`;
+  }, [selectedThemeIds]);
+
+  const sprintColumnFilterLabel = useMemo(() => {
+    if (showAllSprintColumns) return 'All visible sprints';
+    const effectiveIds = (selectedSprintIds.length ? selectedSprintIds : defaultSelectedSprintIds)
+      .filter((id) => sprintColumnPool.some((sprint) => sprint.id === id));
+    if (!effectiveIds.length) return 'Next 3 sprints';
+    if (effectiveIds.length <= 2) {
+      return effectiveIds
+        .map((id) => sprintColumnPool.find((sprint) => sprint.id === id)?.name || 'Sprint')
+        .join(', ');
+    }
+    return `${effectiveIds.length} sprints`;
+  }, [showAllSprintColumns, selectedSprintIds, defaultSelectedSprintIds, sprintColumnPool]);
+
   const currentPlanningSprint = useMemo(() => {
-    const active = planningSprints.find((s) => Number((s as any)?.status ?? 0) === 1);
-    return active || planningSprints[0] || null;
-  }, [planningSprints]);
+    const active = planningSprintPool.find((s) => Number((s as any)?.status ?? 0) === 1);
+    return active || planningSprintPool[0] || null;
+  }, [planningSprintPool]);
 
   const nextPlanningSprint = useMemo(() => {
     if (!currentPlanningSprint) return null;
-    return planningSprints.find((s) => Number(s.startDate ?? 0) > Number(currentPlanningSprint.startDate ?? 0)) || null;
-  }, [currentPlanningSprint, planningSprints]);
+    return planningSprintPool.find((s) => Number(s.startDate ?? 0) > Number(currentPlanningSprint.startDate ?? 0)) || null;
+  }, [currentPlanningSprint, planningSprintPool]);
+
+  const sprintCapacityById = useMemo(() => {
+    const next = new Map<string, ReturnType<typeof buildSprintCapacitySummary>>();
+    visibleSprints.forEach((sprint) => {
+      next.set(
+        sprint.id,
+        buildSprintCapacitySummary({
+          sprint,
+          stories: stories.filter((story) => normalizeSprintId((story as any).sprintId) === sprint.id && !isStatus((story as any).status, 'done')),
+          goals,
+          activeFocusGoalIds,
+        }),
+      );
+    });
+    return next;
+  }, [visibleSprints, stories, goals, activeFocusGoalIds]);
+
+  const groupedRows = useMemo(() => {
+    if (rowGrouping === 'none') return [];
+
+    if (rowGrouping === 'goal') {
+      const rowGoals = (selectedGoalIds.length > 0
+        ? goals.filter((goal) => selectedGoalIds.includes(goal.id))
+        : filteredGoals
+      ).filter((goal) => filteredStories.some((story) => isGoalInHierarchySet(String(story.goalId || ''), goals, new Set([goal.id]))));
+
+      return rowGoals.map((goal) => ({
+        key: goal.id,
+        label: getGoalDisplayPath(goal.id, goals),
+        subtitle: `${filteredStories.filter((story) => isGoalInHierarchySet(String(story.goalId || ''), goals, new Set([goal.id]))).length} stories`,
+        storiesBySprint: filteredStories.reduce<Record<string, Story[]>>((acc, story) => {
+          if (!isGoalInHierarchySet(String(story.goalId || ''), goals, new Set([goal.id]))) return acc;
+          const sprintKey = normalizeSprintId((story as any).sprintId) ?? 'backlog';
+          if (!acc[sprintKey]) acc[sprintKey] = [];
+          acc[sprintKey].push(story);
+          return acc;
+        }, {}),
+      }));
+    }
+
+    const availableThemeIds = selectedThemeIds.length > 0
+      ? selectedThemeIds
+      : Array.from(new Set(filteredStories
+        .map((story) => {
+          const goal = goals.find((candidate) => candidate.id === story.goalId);
+          return Number((story as any).theme ?? goal?.theme);
+        })
+        .filter((themeId) => Number.isFinite(themeId))));
+
+    return availableThemeIds.map((themeId) => ({
+      key: String(themeId),
+      label: GLOBAL_THEMES.find((theme) => theme.id === themeId)?.label || `Theme ${themeId}`,
+      subtitle: `${filteredStories.filter((story) => {
+        const goal = goals.find((candidate) => candidate.id === story.goalId);
+        return Number((story as any).theme ?? goal?.theme) === themeId;
+      }).length} stories`,
+      storiesBySprint: filteredStories.reduce<Record<string, Story[]>>((acc, story) => {
+        const goal = goals.find((candidate) => candidate.id === story.goalId);
+        const storyThemeId = Number((story as any).theme ?? goal?.theme);
+        if (storyThemeId !== themeId) return acc;
+        const sprintKey = normalizeSprintId((story as any).sprintId) ?? 'backlog';
+        if (!acc[sprintKey]) acc[sprintKey] = [];
+        acc[sprintKey].push(story);
+        return acc;
+      }, {}),
+    }));
+  }, [filteredGoals, filteredStories, goals, rowGrouping, selectedGoalIds, selectedThemeIds]);
 
   const handleBulkMoveLowAiScore = async () => {
     if (!currentUser || !currentPersona) return;
@@ -541,6 +783,35 @@ const SprintPlanningMatrix: React.FC = () => {
           const currentSprintId = normalizeSprintId((story as any).sprintId);
           if (normalizedTarget === currentSprintId) return;
 
+          if (normalizedTarget) {
+            const targetSprint = sprints.find((sprint) => sprint.id === normalizedTarget) || null;
+            const targetSummary = sprintCapacityById.get(normalizedTarget)
+              || buildSprintCapacitySummary({
+                sprint: targetSprint,
+                stories: stories.filter((row) => normalizeSprintId((row as any).sprintId) === normalizedTarget && !isStatus((row as any).status, 'done')),
+                goals,
+                activeFocusGoalIds,
+              });
+            const projectedPoints = targetSummary.plannedPoints + storyPoints(story);
+            const storyGoalId = String(story.goalId || '').trim();
+            const outsideFocus = activeFocusGoalIds.size > 0 && (!storyGoalId || !isGoalInHierarchySet(storyGoalId, goals, activeFocusGoalIds));
+            const overCapacity = projectedPoints > targetSummary.capacityPoints + 0.01;
+            if (overCapacity || outsideFocus) {
+              const reasons: string[] = [];
+              if (overCapacity) {
+                reasons.push(`${targetSprint?.name || 'target sprint'} would be ${projectedPoints.toFixed(1)}/${targetSummary.capacityPoints.toFixed(1)} pts`);
+              }
+              if (outsideFocus) {
+                reasons.push('this story is outside active focus goals');
+              }
+              setDeferPromptMessage(`Move blocked: ${reasons.join(' and ')}. Use intelligent defer instead.`);
+              setDeferTarget(story);
+              setMoveNotice(`Opened intelligent defer for ${story.title}.`);
+              setMoveError(null);
+              return;
+            }
+          }
+
           // Optimistic update
           setStories((prev) =>
             prev.map((s) => (s.id === story.id ? { ...s, sprintId: normalizedTarget ?? undefined } : s))
@@ -559,7 +830,7 @@ const SprintPlanningMatrix: React.FC = () => {
         }
       },
     });
-  }, [currentUser, currentPersona]);
+  }, [activeFocusGoalIds, currentUser, currentPersona, goals, sprintCapacityById, sprints, stories]);
 
   if (loading) {
     return (
@@ -575,53 +846,55 @@ const SprintPlanningMatrix: React.FC = () => {
   return (
     <Container fluid style={{ padding: '24px', backgroundColor: themeVars.bg as string, minHeight: '100vh' }} ref={containerRef}>
       {/* Header */}
-      <Row className="mb-4">
-        <Col>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-              <h2 style={{ margin: 0, fontSize: '28px', fontWeight: '700', color: themeVars.text as string }}>
-                Sprint Planning Matrix
-              </h2>
-              <Badge bg="primary" style={{ fontSize: '12px', padding: '6px 12px' }}>
-                {currentPersona.charAt(0).toUpperCase() + currentPersona.slice(1)} Persona
-              </Badge>
+      {!embedded && (
+        <Row className="mb-4">
+          <Col>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+                <h2 style={{ margin: 0, fontSize: '28px', fontWeight: '700', color: themeVars.text as string }}>
+                  Sprint Planning Matrix
+                </h2>
+                <Badge bg="primary" style={{ fontSize: '12px', padding: '6px 12px' }}>
+                  {currentPersona.charAt(0).toUpperCase() + currentPersona.slice(1)} Persona
+                </Badge>
+              </div>
+              
+              <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                <Button
+                  variant="outline-secondary"
+                  size="sm"
+                  onClick={() => navigate('/sprints/kanban')}
+                  className="d-inline-flex align-items-center"
+                >
+                  <LayoutGrid size={16} style={{ marginRight: 6 }} />
+                  Kanban
+                </Button>
+                <Button
+                  variant="outline-secondary"
+                  size="sm"
+                  onClick={() => {
+                    const el = containerRef.current;
+                    if (!el) return;
+                    if (!document.fullscreenElement) {
+                      el.requestFullscreen().catch(() => {});
+                    } else {
+                      document.exitFullscreen().catch(() => {});
+                    }
+                  }}
+                  className="d-inline-flex align-items-center"
+                >
+                  {isFullscreen ? <Minimize2 size={16} style={{ marginRight: 6 }} /> : <Maximize2 size={16} style={{ marginRight: 6 }} />}
+                  {isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
+                </Button>
+                <Button variant="primary" href="/sprints/new">
+                  <Plus size={16} style={{ marginRight: '8px' }} />
+                  Create Sprint
+                </Button>
+              </div>
             </div>
-            
-            <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-              <Button
-                variant="outline-secondary"
-                size="sm"
-                onClick={() => navigate('/sprints/kanban')}
-                className="d-inline-flex align-items-center"
-              >
-                <LayoutGrid size={16} style={{ marginRight: 6 }} />
-                Kanban
-              </Button>
-              <Button
-                variant="outline-secondary"
-                size="sm"
-                onClick={() => {
-                  const el = containerRef.current;
-                  if (!el) return;
-                  if (!document.fullscreenElement) {
-                    el.requestFullscreen().catch(() => {});
-                  } else {
-                    document.exitFullscreen().catch(() => {});
-                  }
-                }}
-                className="d-inline-flex align-items-center"
-              >
-                {isFullscreen ? <Minimize2 size={16} style={{ marginRight: 6 }} /> : <Maximize2 size={16} style={{ marginRight: 6 }} />}
-                {isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
-              </Button>
-              <Button variant="primary" href="/sprints/new">
-                <Plus size={16} style={{ marginRight: '8px' }} />
-                Create Sprint
-              </Button>
-            </div>
-          </div>
-        </Col>
-      </Row>
+          </Col>
+        </Row>
+      )}
 
       {/* Filters */}
       <Row className="mb-4">
@@ -632,13 +905,11 @@ const SprintPlanningMatrix: React.FC = () => {
                 <Col md={3}>
                   <Form.Label style={{ fontSize: '12px', fontWeight: '600', marginBottom: '4px' }}>
                     <Target size={14} style={{ marginRight: '6px' }} />
-                    Filter by Goal
+                    Goals
                   </Form.Label>
-                  <Dropdown>
+                  <Dropdown autoClose="outside">
                     <Dropdown.Toggle variant="outline-secondary" size="sm" style={{ minWidth: '200px' }} className="text-truncate">
-                      {filterGoal === 'all'
-                        ? 'All Goals'
-                        : (goals.find(g => g.id === filterGoal)?.title || 'Unknown Goal')}
+                      {goalFilterLabel}
                     </Dropdown.Toggle>
                     <Dropdown.Menu style={{ maxHeight: '420px', overflowY: 'auto', minWidth: '260px' }}>
                       <div className="p-2 sticky-top bg-white border-bottom">
@@ -650,19 +921,33 @@ const SprintPlanningMatrix: React.FC = () => {
                           autoFocus
                         />
                       </div>
-                      <Dropdown.Item onClick={() => setFilterGoal('all')} active={filterGoal === 'all'}>
-                        All Goals
-                      </Dropdown.Item>
+                      <Form.Check
+                        type="checkbox"
+                        id="goal-filter-all"
+                        label="All Goals"
+                        checked={selectedGoalIds.length === 0}
+                        onChange={(e) => {
+                          if (e.target.checked) setSelectedGoalIds([]);
+                        }}
+                        className="px-3 py-1"
+                      />
                       <Dropdown.Divider />
                       {filteredGoals.length > 0 ? (
                         filteredGoals.map(goal => (
-                          <Dropdown.Item
+                          <Form.Check
                             key={goal.id}
-                            onClick={() => setFilterGoal(goal.id)}
-                            active={filterGoal === goal.id}
-                          >
-                            <div className="text-truncate" title={goal.title}>{goal.title}</div>
-                          </Dropdown.Item>
+                            type="checkbox"
+                            id={`goal-filter-${goal.id}`}
+                            label={getGoalDisplayPath(goal.id, goals)}
+                            checked={selectedGoalIds.includes(goal.id)}
+                            onChange={(e) => {
+                              const nextIds = e.target.checked
+                                ? [...selectedGoalIds, goal.id]
+                                : selectedGoalIds.filter((id) => id !== goal.id);
+                              setSelectedGoalIds(nextIds);
+                            }}
+                            className="px-3 py-1"
+                          />
                         ))
                       ) : (
                         <div className="p-2 text-center text-muted small">No goals found</div>
@@ -673,33 +958,105 @@ const SprintPlanningMatrix: React.FC = () => {
                 <Col md={3}>
                   <Form.Label style={{ fontSize: '12px', fontWeight: '600', marginBottom: '4px' }}>
                     <Filter size={14} style={{ marginRight: '6px' }} />
-                    Filter by Theme
+                    Themes
                   </Form.Label>
-                  <Dropdown>
+                  <Dropdown autoClose="outside">
                     <Dropdown.Toggle variant="outline-secondary" size="sm" style={{ minWidth: '200px' }}>
-                      {filterTheme === null
-                        ? 'All Themes'
-                        : (GLOBAL_THEMES.find(t => t.id === filterTheme)?.label || 'Unknown Theme')}
+                      {themeFilterLabel}
                     </Dropdown.Toggle>
                     <Dropdown.Menu style={{ maxHeight: '420px', overflowY: 'auto' }}>
-                      <Dropdown.Item onClick={() => setFilterTheme(null)} active={filterTheme === null}>
-                        All Themes
-                      </Dropdown.Item>
+                      <Form.Check
+                        type="checkbox"
+                        id="theme-filter-all"
+                        label="All Themes"
+                        checked={selectedThemeIds.length === 0}
+                        onChange={(e) => {
+                          if (e.target.checked) setSelectedThemeIds([]);
+                        }}
+                        className="px-3 py-1"
+                      />
                       <Dropdown.Divider />
                       {GLOBAL_THEMES.map(theme => (
-                        <Dropdown.Item
+                        <Form.Check
                           key={theme.id}
-                          onClick={() => setFilterTheme(theme.id)}
-                          active={filterTheme === theme.id}
-                        >
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                            <div style={{ width: 12, height: 12, borderRadius: '50%', backgroundColor: theme.color }} />
-                            {theme.label}
-                          </div>
-                        </Dropdown.Item>
+                          type="checkbox"
+                          id={`theme-filter-${theme.id}`}
+                          label={theme.label}
+                          checked={selectedThemeIds.includes(theme.id)}
+                          onChange={(e) => {
+                            const nextIds = e.target.checked
+                              ? [...selectedThemeIds, theme.id]
+                              : selectedThemeIds.filter((id) => id !== theme.id);
+                            setSelectedThemeIds(nextIds);
+                          }}
+                          className="px-3 py-1"
+                        />
                       ))}
                     </Dropdown.Menu>
                   </Dropdown>
+                </Col>
+                <Col md={3}>
+                  <Form.Label style={{ fontSize: '12px', fontWeight: '600', marginBottom: '4px' }}>
+                    <LayoutGrid size={14} style={{ marginRight: '6px' }} />
+                    Sprint columns
+                  </Form.Label>
+                  <Dropdown autoClose="outside">
+                    <Dropdown.Toggle variant="outline-secondary" size="sm" style={{ minWidth: '200px' }} className="text-truncate">
+                      {sprintColumnFilterLabel}
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu style={{ maxHeight: '420px', overflowY: 'auto', minWidth: '260px', padding: 8 }}>
+                      <Form.Check
+                        type="checkbox"
+                        id="sprint-columns-all"
+                        label="All visible sprints"
+                        checked={showAllSprintColumns}
+                        onChange={(e) => {
+                          const checked = e.target.checked;
+                          setShowAllSprintColumns(checked);
+                          setSprintColumnsTouched(true);
+                          if (!checked && selectedSprintIds.length === 0) {
+                            setSelectedSprintIds(defaultSelectedSprintIds);
+                          }
+                        }}
+                        className="mb-2"
+                      />
+                      <Dropdown.Divider />
+                      {sprintColumnPool.length > 0 ? sprintColumnPool.map((sprint) => {
+                        const checked = selectedSprintIds.includes(sprint.id);
+                        return (
+                          <Form.Check
+                            key={sprint.id}
+                            type="checkbox"
+                            id={`sprint-column-${sprint.id}`}
+                            label={sprint.name}
+                            checked={checked}
+                            onChange={(e) => {
+                              const nextIds = e.target.checked
+                                ? [...selectedSprintIds, sprint.id]
+                                : selectedSprintIds.filter((id) => id !== sprint.id);
+                              setSelectedSprintIds(nextIds);
+                              setShowAllSprintColumns(false);
+                              setSprintColumnsTouched(true);
+                            }}
+                            className="mb-1"
+                          />
+                        );
+                      }) : (
+                        <div className="text-muted small px-1 py-2">No sprints available.</div>
+                      )}
+                    </Dropdown.Menu>
+                  </Dropdown>
+                </Col>
+                <Col md={3}>
+                  <Form.Label style={{ fontSize: '12px', fontWeight: '600', marginBottom: '4px' }}>
+                    <ArrowUpDown size={14} style={{ marginRight: '6px' }} />
+                    Row grouping
+                  </Form.Label>
+                  <Form.Select size="sm" value={rowGrouping} onChange={(e) => setRowGrouping(e.target.value as 'none' | 'goal' | 'theme')}>
+                    <option value="none">No grouped rows</option>
+                    <option value="goal">Group rows by goal</option>
+                    <option value="theme">Group rows by theme</option>
+                  </Form.Select>
                 </Col>
                 <Col md={3}>
                   <Form.Label style={{ fontSize: '12px', fontWeight: '600', marginBottom: '4px' }}>
@@ -809,8 +1166,8 @@ const SprintPlanningMatrix: React.FC = () => {
                       variant="outline-secondary"
                       size="sm"
                       onClick={() => {
-                        setFilterGoal('all');
-                        setFilterTheme(null);
+                        setSelectedGoalIds([]);
+                        setSelectedThemeIds([]);
                         setShowCompletedSprints(false);
                         setShowCompletedItems(false);
                         setShowTop3Only(false);
@@ -820,7 +1177,11 @@ const SprintPlanningMatrix: React.FC = () => {
                         setShowDescriptions(false);
                         setSortField('none');
                         setSortDirection('desc');
+                        setRowGrouping('none');
                         setGoalSearch('');
+                        setSelectedSprintIds(defaultSelectedSprintIds);
+                        setShowAllSprintColumns(false);
+                        setSprintColumnsTouched(false);
                       }}
                     >
                       Clear Filters
@@ -866,6 +1227,69 @@ const SprintPlanningMatrix: React.FC = () => {
         </Row>
       )}
 
+      {deferPromptMessage && (
+        <Row className="mt-3">
+          <Col>
+            <Alert variant="warning" dismissible onClose={() => setDeferPromptMessage(null)}>
+              {deferPromptMessage}
+            </Alert>
+          </Col>
+        </Row>
+      )}
+
+      {rowGrouping !== 'none' && groupedRows.length > 0 && (
+        <Row className="mb-4">
+          <Col>
+            <Card style={{ border: 'none', boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}>
+              <Card.Body>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+                  <div>
+                    <div style={{ fontSize: 14, fontWeight: 600, color: themeVars.text as string }}>
+                      Grouped planning rows
+                    </div>
+                    <div style={{ fontSize: 12, color: themeVars.muted as string }}>
+                      Selected goals or themes appear as horizontal rows against the visible sprint columns.
+                    </div>
+                  </div>
+                  <Badge bg="light" text="dark">{groupedRows.length} rows</Badge>
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+                  {groupedRows.map((row) => (
+                    <div key={row.key} style={{ border: '1px solid rgba(0,0,0,0.08)', borderRadius: 12, padding: 12 }}>
+                      <div style={{ marginBottom: 10 }}>
+                        <div style={{ fontSize: 14, fontWeight: 600, color: themeVars.text as string }}>{row.label}</div>
+                        <div style={{ fontSize: 12, color: themeVars.muted as string }}>{row.subtitle}</div>
+                      </div>
+                      <div style={{ display: 'grid', gridTemplateColumns: `repeat(${visibleSprints.length + 1}, minmax(240px, 1fr))`, gap: 12, overflowX: 'auto' }}>
+                        <GroupedSprintCell
+                          title="Backlog"
+                          stories={row.storiesBySprint.backlog || []}
+                          goals={goals}
+                          showDescriptions={showDescriptions}
+                          formatTag={formatTag}
+                          themes={globalThemes}
+                        />
+                        {visibleSprints.map((sprint) => (
+                          <GroupedSprintCell
+                            key={`${row.key}-${sprint.id}`}
+                            title={sprint.name}
+                            stories={row.storiesBySprint[sprint.id] || []}
+                            goals={goals}
+                            showDescriptions={showDescriptions}
+                            formatTag={formatTag}
+                            themes={globalThemes}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+      )}
+
       {/* Sprint Matrix */}
       <div className="sprint-planning-grid">
         <SprintColumn
@@ -884,6 +1308,7 @@ const SprintPlanningMatrix: React.FC = () => {
             sprint={sprint}
             stories={storiesBySprint[sprint.id] || []}
             goals={goals}
+            capacitySummary={sprintCapacityById.get(sprint.id) || null}
             placeholderLabel={undefined}
             droppableId={sprint.id}
             showDescriptions={showDescriptions}
@@ -894,26 +1319,28 @@ const SprintPlanningMatrix: React.FC = () => {
       </div>
 
       {/* Instructions */}
-      <Row className="mt-4">
-        <Col>
-          <Card style={{ border: 'none', backgroundColor: '#f0f9ff', padding: '16px' }}>
-            <Card.Body>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                <ArrowRight size={20} style={{ color: '#2563eb' }} />
-                <div>
-                  <h6 style={{ margin: 0, fontSize: '14px', fontWeight: '600', color: '#1e40af' }}>
-                    Drag & Drop Instructions
-                  </h6>
-                  <p style={{ margin: '4px 0 0 0', fontSize: '12px', color: '#1e40af' }}>
-                    Drag stories between backlog and sprints to plan your work. 
-                    Stories will automatically update their sprint assignment.
-                  </p>
+      {!embedded && (
+        <Row className="mt-4">
+          <Col>
+            <Card style={{ border: 'none', backgroundColor: '#f0f9ff', padding: '16px' }}>
+              <Card.Body>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                  <ArrowRight size={20} style={{ color: '#2563eb' }} />
+                  <div>
+                    <h6 style={{ margin: 0, fontSize: '14px', fontWeight: '600', color: '#1e40af' }}>
+                      Drag & Drop Instructions
+                    </h6>
+                    <p style={{ margin: '4px 0 0 0', fontSize: '12px', color: '#1e40af' }}>
+                      Drag stories between backlog and sprints to plan your work. 
+                      Stories will automatically update their sprint assignment.
+                    </p>
+                  </div>
                 </div>
-              </div>
-            </Card.Body>
-          </Card>
-        </Col>
-      </Row>
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+      )}
 
       {/* Empty State */}
       {sortedStories.length === 0 && (
@@ -934,6 +1361,46 @@ const SprintPlanningMatrix: React.FC = () => {
             </Card>
           </Col>
         </Row>
+      )}
+
+      {deferTarget && (
+        <DeferItemModal
+          show={!!deferTarget}
+          onHide={() => setDeferTarget(null)}
+          itemType="story"
+          itemId={deferTarget.id}
+          itemTitle={deferTarget.title}
+          focusContext={{
+            isFocusAligned: (() => {
+              const goalId = String(deferTarget.goalId || '').trim();
+              return !!goalId && isGoalInHierarchySet(goalId, goals, activeFocusGoalIds);
+            })(),
+            activeFocusGoals: activeFocusGoals.map((focusGoal) => ({
+              id: focusGoal.id,
+              title: focusGoal.title || null,
+              focusRootGoalIds: Array.isArray((focusGoal as any).focusRootGoalIds) ? (focusGoal as any).focusRootGoalIds : [],
+              focusLeafGoalIds: Array.isArray((focusGoal as any).focusLeafGoalIds) ? (focusGoal as any).focusLeafGoalIds : [],
+              goalIds: Array.isArray((focusGoal as any).goalIds) ? (focusGoal as any).goalIds : [],
+            })),
+          }}
+          onApply={async (payload) => {
+            if (!deferTarget || !currentUser) return;
+            const result = await schedulePlannerItemMutation({
+              itemType: 'story',
+              itemId: deferTarget.id,
+              targetDateMs: payload.dateMs,
+              targetBucket: null,
+              intent: 'defer',
+              source: payload.source || 'sprint_planning_matrix',
+              rationale: payload.rationale,
+              durationMinutes: Math.max(30, Math.round(storyPoints(deferTarget) * 60)),
+            });
+            setMoveNotice(`${deferTarget.title} deferred to ${new Date(result.appliedStartMs).toLocaleDateString()}.`);
+            setMoveError(null);
+            setDeferPromptMessage(null);
+            setDeferTarget(null);
+          }}
+        />
       )}
     </Container>
   );

--- a/react-app/src/components/StoriesCardView.tsx
+++ b/react-app/src/components/StoriesCardView.tsx
@@ -1,24 +1,28 @@
 import React, { useState, useEffect, useCallback, useMemo, useLayoutEffect, useRef } from 'react';
-import { Card, Badge, Button, Dropdown, Form } from 'react-bootstrap';
-import { Edit3, Trash2, ChevronDown, Target, Calendar, Activity, Clock } from 'lucide-react';
+import { Card, Badge, Button, Form, Toast, ToastContainer } from 'react-bootstrap';
+import { Edit3, Trash2, Target, Calendar, Activity, Clock, Clock3 } from 'lucide-react';
 import { collection, query, where, orderBy, limit, getDocs } from 'firebase/firestore';
 import { db } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
+import { usePersona } from '../contexts/PersonaContext';
 import { useSidebar } from '../contexts/SidebarContext';
 import { Story, Goal } from '../types';
-import { getStatusName, getPriorityColor } from '../utils/statusHelpers';
+import { getStatusName } from '../utils/statusHelpers';
 import { themeVars } from '../utils/themeVars';
 import { useGlobalThemes } from '../hooks/useGlobalThemes';
 import { GLOBAL_THEMES, migrateThemeValue, type GlobalTheme } from '../constants/globalThemes';
 import { displayRefForEntity, validateRef } from '../utils/referenceGenerator';
 import { ActivityStreamService } from '../services/ActivityStreamService';
-import { priorityLabel, storyStatusText } from '../utils/storyCardFormatting';
+import { priorityLabel, priorityPillClass, storyStatusText } from '../utils/storyCardFormatting';
+import { getManualPriorityLabel, getManualPriorityRank } from '../utils/manualPriority';
 import DeferItemModal from './DeferItemModal';
+import NewCalendarEventModal, { type BlockFormState, buildCalendarComposerInitialValues } from './planner/NewCalendarEventModal';
+import '../styles/KanbanCards.css';
 
 interface StoriesCardViewProps {
   stories: Story[];
   goals: Goal[];
-  onStoryUpdate: (storyId: string, updates: any) => void;
+  onStoryUpdate: (storyId: string, updates: any) => void | Promise<void>;
   onStoryDelete: (storyId: string) => void;
   onStorySelect: (story: Story) => void;
   onEditStory: (story: Story) => void;
@@ -35,6 +39,7 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
   selectedStoryId
 }) => {
   const { currentUser } = useAuth();
+  const { currentPersona } = usePersona();
   const { showSidebar } = useSidebar();
   const { themes: globalThemes } = useGlobalThemes();
   const [latestActivities, setLatestActivities] = useState<{ [storyId: string]: any }>({});
@@ -60,6 +65,12 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
   const [rowSpans, setRowSpans] = useState<Record<string, number>>({});
   const gridRef = useRef<HTMLDivElement | null>(null);
   const [deferStory, setDeferStory] = useState<Story | null>(null);
+  const [scheduleStory, setScheduleStory] = useState<Story | null>(null);
+  const [feedback, setFeedback] = useState<{ show: boolean; message: string; variant: 'success' | 'danger' | 'info' }>({
+    show: false,
+    message: '',
+    variant: 'info',
+  });
 
   useEffect(() => {
     try {
@@ -124,37 +135,11 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
     return defaultTheme;
   };
 
-  const hexToRgb = (hex: string) => {
-    const value = hex.replace('#', '');
-    const full = value.length === 3 ? value.split('').map(c => c + c).join('') : value;
-    const bigint = parseInt(full, 16);
-    const r = (bigint >> 16) & 255;
-    const g = (bigint >> 8) & 255;
-    const b = bigint & 255;
-    return { r, g, b };
-  };
-
-  const rgbToHex = (r: number, g: number, b: number) => `#${[r, g, b]
-    .map(v => {
-      const clamped = Math.max(0, Math.min(255, Math.round(v)));
-      return clamped.toString(16).padStart(2, '0');
-    })
-    .join('')}`;
-
   const withAlpha = (color: string, alpha: number) => {
     const pct = Math.round(Math.max(0, Math.min(1, alpha)) * 100);
     if (pct <= 0) return 'transparent';
     if (pct >= 100) return color;
     return `color-mix(in srgb, ${color} ${pct}%, transparent)`;
-  };
-
-  const lightenColor = (hex: string, amount: number) => {
-    const { r, g, b } = hexToRgb(hex);
-    const factor = Math.max(0, Math.min(1, amount));
-    const nr = r + (255 - r) * factor;
-    const ng = g + (255 - g) * factor;
-    const nb = b + (255 - b) * factor;
-    return rgbToHex(nr, ng, nb);
   };
 
   const getGoalForStory = (storyGoalId: string): Goal | undefined => {
@@ -268,14 +253,45 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
     showSidebar(story, 'story');
   };
 
-  const handleStatusChange = (storyId: string, newStatus: 'Backlog' | 'In Progress' | 'Done' | 'Blocked') => {
-    const numericStatus = newStatus === 'Backlog' ? 0 : newStatus === 'In Progress' ? 2 : newStatus === 'Done' ? 4 : 3;
-    onStoryUpdate(storyId, { status: numericStatus });
+  const cycleStoryStatus = (story: Story) => {
+    const sequence = [0, 2, 4, 3];
+    const current = Number((story as any).status ?? 0);
+    const currentIndex = sequence.indexOf(current);
+    const nextValue = sequence[(currentIndex + 1) % sequence.length];
+    onStoryUpdate(story.id, { status: nextValue });
   };
 
-  const handlePriorityChange = (storyId: string, newPriority: number) => {
-    onStoryUpdate(storyId, { priority: newPriority });
+  const cycleStoryPriority = (story: Story) => {
+    const sequence = [0, 1, 2, 3, 4];
+    const current = Number((story as any).priority ?? 0);
+    const currentIndex = sequence.indexOf(current);
+    const nextValue = sequence[(currentIndex + 1) % sequence.length];
+    onStoryUpdate(story.id, { priority: nextValue });
   };
+
+  const showToast = (message: string, variant: 'success' | 'danger' | 'info' = 'info') => {
+    setFeedback({ show: true, message, variant });
+  };
+
+  const scheduleInitialValues = useMemo(() => {
+    if (!scheduleStory) return undefined;
+    const progressPct = Number((scheduleStory as any).progressPct || 0);
+    const points = Number((scheduleStory as any).points || 0);
+    const pointsRemaining = Number.isFinite(points) && points > 0
+      ? Math.max(0, Math.ceil((points * (1 - Math.min(100, Math.max(0, progressPct)) / 100)) * 10) / 10)
+      : 0;
+    return buildCalendarComposerInitialValues({
+      title: scheduleStory.title || 'Focus block',
+      rationale: 'Manual schedule from story card',
+      persona: ((scheduleStory as any).persona || currentPersona || 'personal') as 'personal' | 'work',
+      theme: String((scheduleStory as any).theme || 'General'),
+      category: (((scheduleStory as any).persona || currentPersona) === 'work' ? 'Work (Main Gig)' : 'Wellbeing') as any,
+      storyId: scheduleStory.id,
+      points: pointsRemaining,
+      aiScore: Number.isFinite(Number((scheduleStory as any).aiCriticalityScore)) ? Number((scheduleStory as any).aiCriticalityScore) : null,
+      aiReason: String((scheduleStory as any).aiReason || (scheduleStory as any).aiPriorityReason || '').trim() || null,
+    }) as Partial<BlockFormState>;
+  }, [currentPersona, scheduleStory]);
 
   const toDate = (value: any) => {
     if (!value) return null;
@@ -285,12 +301,20 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
     return Number.isNaN(parsed.getTime()) ? null : parsed;
   };
 
-  const statusColors = {
-    Backlog: 'var(--muted)',
-    'In Progress': 'var(--green)',
-    Done: 'var(--brand)',
-    Blocked: 'var(--red)'
-  } as const;
+  const statusPillClass = (label: string) => {
+    const normalized = String(label).toLowerCase();
+    const base = 'kanban-card__meta-pill';
+    if (normalized.includes('done')) return `${base} kanban-card__meta-pill--success`;
+    if (normalized.includes('progress')) return `${base} kanban-card__meta-pill--orange`;
+    if (normalized.includes('block')) return `${base} kanban-card__meta-pill--danger`;
+    return base;
+  };
+
+  const formatDateChip = (value: any) => {
+    const date = toDate(value);
+    if (!date) return null;
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  };
 
   if (stories.length === 0) {
     return (
@@ -330,14 +354,11 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
           const themeDef = resolveTheme(themeValue);
           const themeColor = themeDef.color || (themeVars.brand as string);
           const themeTextColor = themeDef.textColor || (themeVars.onAccent as string);
-          const gradientStart = lightenColor(themeColor, 0.4);
-          const gradientEnd = lightenColor(themeColor, 0.75);
-          const cardBackground = `linear-gradient(165deg, ${gradientStart} 0%, ${gradientEnd} 100%)`;
           const textColor = themeVars.text as string;
           const mutedTextColor = themeVars.muted as string;
           const aiScore = Number((story as any).aiCriticalityScore ?? NaN);
           const storyPriorityText = priorityLabel(story.priority, `P${story.priority ?? 3}`);
-          const storyPriorityVariant = getPriorityColor(story.priority);
+          const manualPriorityLabel = getManualPriorityLabel(story);
           const statusLabel = storyStatusText(story.status);
           const latestActivity = latestActivities[story.id];
           const showActivity = showUpdates && !!latestActivity;
@@ -346,6 +367,7 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
           const updatedAt = toDate((story as any).updatedAt);
           const rowSpan = rowSpans[story.id];
           const nextBlock = nextBlocks[story.id];
+          const dueChip = formatDateChip((story as any).targetDate || (story as any).dueDate || (story as any).plannedStartDate);
 
           const refLabel = (() => {
             const shortRef = (story as any).referenceNumber || story.ref;
@@ -376,14 +398,13 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
                   overflow: 'hidden',
                   transition: 'all 0.3s ease',
                   cursor: 'pointer',
-                  background: cardBackground,
+                  background: 'var(--bs-body-bg, #fff)',
                   color: textColor,
                   display: 'flex',
                   flexDirection: 'column'
                 }}
                 onClick={() => {
                   onStorySelect(story);
-                  try { showSidebar(story, 'story'); } catch { }
                 }}
                 onMouseEnter={(e) => {
                   if (selectedStoryId !== story.id) {
@@ -398,18 +419,30 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
                   }
                 }}
               >
-                <div style={{ height: '6px', backgroundColor: themeColor }} />
-                <Card.Body style={{ padding: '14px 12px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+                <Card.Body style={{ padding: '14px 12px', display: 'flex', flexDirection: 'column', gap: '10px', borderLeft: `4px solid ${themeColor}` }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
                     <div style={{ flex: 1, minWidth: 0 }}>
                       <div style={{ fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.4px', color: mutedTextColor }}>
                         {refLabel}
                       </div>
-                      <h5 style={{ margin: '4px 0 0 0', fontSize: '16px', fontWeight: 600, lineHeight: '1.3', color: textColor }}>
+                      <h5 className="kanban-card__title" style={{ margin: '4px 0 0 0', fontSize: '16px', fontWeight: 600, lineHeight: '1.3', color: textColor }}>
                         {story.title}
                       </h5>
                     </div>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      <Button
+                        variant="link"
+                        size="sm"
+                        className="p-0"
+                        style={{ width: 24, height: 24, color: textColor }}
+                        title="Schedule story"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setScheduleStory(story);
+                        }}
+                      >
+                        <Calendar size={14} />
+                      </Button>
                       <Button
                         variant="link"
                         size="sm"
@@ -433,44 +466,39 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
                       >
                         <Edit3 size={14} />
                       </Button>
-                      <Dropdown onClick={(e) => e.stopPropagation()}>
-                        <Dropdown.Toggle
-                          variant="outline-secondary"
-                          size="sm"
-                          style={{ border: 'none', padding: '4px 6px', color: textColor }}
-                        >
-                          <ChevronDown size={16} />
-                        </Dropdown.Toggle>
-                        <Dropdown.Menu style={{ zIndex: 2000 }} popperConfig={{ strategy: 'fixed' }}>
-                          <Dropdown.Header>Change Status</Dropdown.Header>
-                          <Dropdown.Item onClick={() => handleStatusChange(story.id, 'Backlog')}>Backlog</Dropdown.Item>
-                          <Dropdown.Item onClick={() => handleStatusChange(story.id, 'In Progress')}>In Progress</Dropdown.Item>
-                          <Dropdown.Item onClick={() => handleStatusChange(story.id, 'Done')}>Done</Dropdown.Item>
-                          <Dropdown.Item onClick={() => handleStatusChange(story.id, 'Blocked')}>Blocked</Dropdown.Item>
-                          <Dropdown.Divider />
-                          <Dropdown.Header>Change Priority</Dropdown.Header>
-                          <Dropdown.Item onClick={() => handlePriorityChange(story.id, 4)}>Critical (4)</Dropdown.Item>
-                          <Dropdown.Item onClick={() => handlePriorityChange(story.id, 3)}>High (3)</Dropdown.Item>
-                          <Dropdown.Item onClick={() => handlePriorityChange(story.id, 2)}>Medium (2)</Dropdown.Item>
-                          <Dropdown.Item onClick={() => handlePriorityChange(story.id, 1)}>Low (1)</Dropdown.Item>
-                          <Dropdown.Divider />
-                          <Dropdown.Item onClick={() => setDeferStory(story)}>
-                            Defer intelligently
-                          </Dropdown.Item>
-                          <Dropdown.Item
-                            className="text-danger"
-                            onClick={() => {
-                              if (window.confirm('Delete this story? This cannot be undone.')) {
-                                onStoryDelete(story.id);
-                              }
-                            }}
-                          >
-                            <Trash2 size={14} className="me-2" />
-                            Delete Story
-                          </Dropdown.Item>
-                        </Dropdown.Menu>
-                      </Dropdown>
                     </div>
+                  </div>
+
+                  <div className="d-flex align-items-center gap-2 flex-wrap">
+                    <Badge bg="info">Story</Badge>
+                    <button
+                      type="button"
+                      className={statusPillClass(statusLabel)}
+                      style={{ appearance: 'none', backgroundClip: 'padding-box', cursor: 'pointer' }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        cycleStoryStatus(story);
+                      }}
+                      title="Tap to cycle status"
+                    >
+                      {statusLabel}
+                    </button>
+                    <button
+                      type="button"
+                      className={priorityPillClass(story.priority ?? null)}
+                      style={{ appearance: 'none', backgroundClip: 'padding-box', cursor: 'pointer' }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        cycleStoryPriority(story);
+                      }}
+                      title="Tap to cycle priority"
+                    >
+                      {storyPriorityText}
+                    </button>
+                    {dueChip && <Badge bg="light" text="dark">Due {dueChip}</Badge>}
+                    {Number.isFinite(aiScore) && <Badge bg="secondary">AI {Math.round(aiScore)}/100</Badge>}
+                    {getManualPriorityRank(story) && manualPriorityLabel && <Badge bg="danger">{manualPriorityLabel}</Badge>}
+                    {story.points != null && <Badge bg="dark">Pts {story.points || 0}</Badge>}
                   </div>
 
                   {(showStoryDescription || showActivity) && (
@@ -562,34 +590,34 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
                     </div>
                   )}
 
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+                  <div className="d-flex align-items-center gap-2 flex-wrap">
                     <Badge style={{ backgroundColor: themeColor, color: themeTextColor, fontSize: '11px' }}>
                       {themeDef.label}
                     </Badge>
-                    <Badge
-                      style={{
-                        backgroundColor: statusColors[statusLabel as keyof typeof statusColors] || 'var(--muted)',
-                        color: 'var(--on-accent)',
-                        fontSize: '11px'
+                    <Button
+                      variant="outline-warning"
+                      size="sm"
+                      className="d-inline-flex align-items-center gap-1"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setDeferStory(story);
                       }}
                     >
-                      {statusLabel}
-                    </Badge>
-                    <Badge bg={storyPriorityVariant} style={{ fontSize: '11px' }}>
-                      {storyPriorityText}
-                    </Badge>
-                    {Number.isFinite(aiScore) && (
-                      <Badge
-                        bg="light"
-                        text="dark"
-                        style={{ fontSize: '10px' }}
-                        title={((story as any).aiTop3ForDay && (story as any).aiTop3Reason)
-                          ? (story as any).aiTop3Reason
-                          : ((story as any).aiCriticalityReason || 'AI priority')}
-                      >
-                        AI {Math.round(aiScore)}/100
-                      </Badge>
-                    )}
+                      <Clock3 size={14} /> Defer
+                    </Button>
+                    <Button
+                      variant="outline-danger"
+                      size="sm"
+                      className="d-inline-flex align-items-center gap-1"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (window.confirm('Delete this story? This cannot be undone.')) {
+                          onStoryDelete(story.id);
+                        }
+                      }}
+                    >
+                      <Trash2 size={14} /> Delete
+                    </Button>
                   </div>
 
                   {nextBlock && (
@@ -661,15 +689,45 @@ const StoriesCardView: React.FC<StoriesCardViewProps> = ({
         itemTitle={deferStory?.title || ''}
         onApply={async ({ dateMs, rationale, source }) => {
           if (!deferStory) return;
-          onStoryUpdate(deferStory.id, {
-            targetDate: dateMs,
-            deferredUntil: dateMs,
-            deferredReason: rationale,
-            deferredBy: source,
-          });
-          setDeferStory(null);
+          try {
+            await Promise.resolve(onStoryUpdate(deferStory.id, {
+              targetDate: dateMs,
+              deferredUntil: dateMs,
+              deferredReason: rationale,
+              deferredBy: source,
+            }));
+            showToast(`${deferStory.title} deferred to ${new Date(dateMs).toLocaleDateString()}.`, 'success');
+            setDeferStory(null);
+          } catch (error) {
+            console.error('StoriesCardView: failed to defer story', error);
+            showToast('Failed to defer story.', 'danger');
+          }
         }}
       />
+      <NewCalendarEventModal
+        show={Boolean(scheduleStory)}
+        onHide={() => setScheduleStory(null)}
+        initialValues={scheduleInitialValues}
+        stories={scheduleStory ? [scheduleStory] : []}
+        onSaved={() => {
+          const title = scheduleStory?.title || 'Story';
+          setScheduleStory(null);
+          showToast(`${title} added to your calendar.`, 'success');
+        }}
+      />
+      <ToastContainer position="bottom-end" className="p-3" style={{ zIndex: 1080 }}>
+        <Toast
+          bg={feedback.variant}
+          onClose={() => setFeedback((prev) => ({ ...prev, show: false }))}
+          show={feedback.show}
+          delay={3500}
+          autohide
+        >
+          <Toast.Body className={feedback.variant === 'info' ? '' : 'text-white'}>
+            {feedback.message}
+          </Toast.Body>
+        </Toast>
+      </ToastContainer>
     </div>
   );
 };

--- a/react-app/src/components/TaskListView.tsx
+++ b/react-app/src/components/TaskListView.tsx
@@ -30,6 +30,7 @@ const TaskListView: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [viewMode, setViewMode] = useState<'list' | 'cards'>('list');
   const [showAddTaskModal, setShowAddTaskModal] = useState(false);
+  const [editTask, setEditTask] = useState<Task | null>(null);
   const { selectedSprintId, setSelectedSprintId, sprints: rawSprints } = useSprint();
   const { themes: globalThemes } = useGlobalThemes();
   const location = useLocation();
@@ -544,6 +545,7 @@ const TaskListView: React.FC = () => {
                 onTaskUpdate={handleTaskUpdate}
                 onTaskDelete={handleTaskDelete}
                 onTaskPriorityChange={handleTaskPriorityChange}
+                onEditTask={setEditTask}
               />
             ) : (
               <div style={{ height: '600px', overflow: 'auto' }}>
@@ -566,6 +568,12 @@ const TaskListView: React.FC = () => {
         task={null}
         onHide={() => setShowAddTaskModal(false)}
         onUpdated={() => setShowAddTaskModal(false)}
+      />
+      <EditTaskModal
+        show={!!editTask}
+        task={editTask}
+        onHide={() => setEditTask(null)}
+        onUpdated={() => setEditTask(null)}
       />
     </div>
   );

--- a/react-app/src/components/TasksCardView.tsx
+++ b/react-app/src/components/TasksCardView.tsx
@@ -1,26 +1,29 @@
 import React, { useState, useEffect, useCallback, useMemo, useLayoutEffect, useRef } from 'react';
-import { Card, Badge, Button, Dropdown, Form } from 'react-bootstrap';
-import { Edit3, Trash2, ChevronDown, Target, Calendar, Activity, Clock } from 'lucide-react';
+import { Card, Badge, Button, Form, Toast, ToastContainer } from 'react-bootstrap';
+import { Edit3, Trash2, Target, Calendar, Activity, Clock, Clock3 } from 'lucide-react';
 import { collection, query, where, orderBy, limit, getDocs } from 'firebase/firestore';
 import { db } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
+import { usePersona } from '../contexts/PersonaContext';
 import { useSidebar } from '../contexts/SidebarContext';
 import { Task, Story, Goal } from '../types';
-import { getPriorityColor } from '../utils/statusHelpers';
 import { themeVars } from '../utils/themeVars';
 import { useGlobalThemes } from '../hooks/useGlobalThemes';
 import { GLOBAL_THEMES, migrateThemeValue, type GlobalTheme } from '../constants/globalThemes';
 import { ActivityStreamService } from '../services/ActivityStreamService';
-import { priorityLabel, taskStatusText } from '../utils/storyCardFormatting';
+import { priorityLabel, priorityPillClass, taskStatusText } from '../utils/storyCardFormatting';
 import DeferItemModal from './DeferItemModal';
+import NewCalendarEventModal, { type BlockFormState, buildCalendarComposerInitialValues } from './planner/NewCalendarEventModal';
+import '../styles/KanbanCards.css';
 
 interface TasksCardViewProps {
   tasks: Task[];
   stories: Story[];
   goals: Goal[];
-  onTaskUpdate: (taskId: string, updates: Partial<Task>) => void;
+  onTaskUpdate: (taskId: string, updates: Partial<Task>) => void | Promise<void>;
   onTaskDelete: (taskId: string) => void;
   onTaskPriorityChange: (taskId: string, newPriority: number) => void;
+  onEditTask: (task: Task) => void;
 }
 
 const TasksCardView: React.FC<TasksCardViewProps> = ({
@@ -29,9 +32,11 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
   goals,
   onTaskUpdate,
   onTaskDelete,
-  onTaskPriorityChange
+  onTaskPriorityChange,
+  onEditTask
 }) => {
   const { currentUser } = useAuth();
+  const { currentPersona } = usePersona();
   const { showSidebar } = useSidebar();
   const { themes: globalThemes } = useGlobalThemes();
   const [latestActivities, setLatestActivities] = useState<{ [taskId: string]: any }>({});
@@ -57,6 +62,12 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
   const [rowSpans, setRowSpans] = useState<Record<string, number>>({});
   const gridRef = useRef<HTMLDivElement | null>(null);
   const [deferTask, setDeferTask] = useState<Task | null>(null);
+  const [scheduleTask, setScheduleTask] = useState<Task | null>(null);
+  const [feedback, setFeedback] = useState<{ show: boolean; message: string; variant: 'success' | 'danger' | 'info' }>({
+    show: false,
+    message: '',
+    variant: 'info',
+  });
 
   useEffect(() => {
     try {
@@ -121,37 +132,11 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
     return defaultTheme;
   };
 
-  const hexToRgb = (hex: string) => {
-    const value = hex.replace('#', '');
-    const full = value.length === 3 ? value.split('').map(c => c + c).join('') : value;
-    const bigint = parseInt(full, 16);
-    const r = (bigint >> 16) & 255;
-    const g = (bigint >> 8) & 255;
-    const b = bigint & 255;
-    return { r, g, b };
-  };
-
-  const rgbToHex = (r: number, g: number, b: number) => `#${[r, g, b]
-    .map(v => {
-      const clamped = Math.max(0, Math.min(255, Math.round(v)));
-      return clamped.toString(16).padStart(2, '0');
-    })
-    .join('')}`;
-
   const withAlpha = (color: string, alpha: number) => {
     const pct = Math.round(Math.max(0, Math.min(1, alpha)) * 100);
     if (pct <= 0) return 'transparent';
     if (pct >= 100) return color;
     return `color-mix(in srgb, ${color} ${pct}%, transparent)`;
-  };
-
-  const lightenColor = (hex: string, amount: number) => {
-    const { r, g, b } = hexToRgb(hex);
-    const factor = Math.max(0, Math.min(1, amount));
-    const nr = r + (255 - r) * factor;
-    const ng = g + (255 - g) * factor;
-    const nb = b + (255 - b) * factor;
-    return rgbToHex(nr, ng, nb);
   };
 
   const getStoryForTask = (task: Task): Story | undefined => {
@@ -269,10 +254,49 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
     return () => observer.disconnect();
   }, [tasks, showDescriptions, showUpdates]);
 
-  const handleStatusChange = (taskId: string, newStatus: 'Backlog' | 'In Progress' | 'Done' | 'Blocked') => {
-    const numericStatus = newStatus === 'Backlog' ? 0 : newStatus === 'In Progress' ? 1 : newStatus === 'Done' ? 2 : 3;
-    onTaskUpdate(taskId, { status: numericStatus as any });
+  const cycleTaskStatus = (task: Task) => {
+    const sequence = [0, 1, 2, 3];
+    const current = Number((task as any).status ?? 0);
+    const currentIndex = sequence.indexOf(current);
+    const nextValue = sequence[(currentIndex + 1) % sequence.length];
+    onTaskUpdate(task.id, { status: nextValue as any });
   };
+
+  const cycleTaskPriority = (task: Task) => {
+    const sequence = [0, 1, 2, 3, 4];
+    const current = Number((task as any).priority ?? 0);
+    const currentIndex = sequence.indexOf(current);
+    const nextValue = sequence[(currentIndex + 1) % sequence.length];
+    onTaskPriorityChange(task.id, nextValue);
+  };
+
+  const showToast = (message: string, variant: 'success' | 'danger' | 'info' = 'info') => {
+    setFeedback({ show: true, message, variant });
+  };
+
+  const linkedScheduleStories = useMemo(() => {
+    if (!scheduleTask) return [] as Story[];
+    const linkedStory = getStoryForTask(scheduleTask);
+    return linkedStory ? [linkedStory] : [];
+  }, [scheduleTask, stories]);
+
+  const scheduleInitialValues = useMemo(() => {
+    if (!scheduleTask) return undefined;
+    const linkedStory = getStoryForTask(scheduleTask);
+    const estimateMin = Number((scheduleTask as any).estimateMin || 0) || (Number((scheduleTask as any).points || 0) * 60);
+    return buildCalendarComposerInitialValues({
+      title: scheduleTask.title || 'Task block',
+      rationale: 'Manual schedule from task card',
+      persona: ((scheduleTask as any).persona || (linkedStory as any)?.persona || currentPersona || 'personal') as 'personal' | 'work',
+      theme: String((linkedStory as any)?.theme || (scheduleTask as any)?.theme || 'General'),
+      category: (((scheduleTask as any).persona || currentPersona) === 'work' ? 'Work (Main Gig)' : 'Wellbeing') as any,
+      storyId: linkedStory?.id,
+      taskId: scheduleTask.id,
+      estimateMin,
+      aiScore: Number.isFinite(Number((scheduleTask as any).aiCriticalityScore)) ? Number((scheduleTask as any).aiCriticalityScore) : null,
+      aiReason: String((scheduleTask as any).aiReason || (scheduleTask as any).aiPriorityReason || '').trim() || null,
+    }) as Partial<BlockFormState>;
+  }, [currentPersona, scheduleTask, stories]);
 
   const toDate = (value: any) => {
     if (!value) return null;
@@ -282,12 +306,20 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
     return Number.isNaN(parsed.getTime()) ? null : parsed;
   };
 
-  const statusColors = {
-    Backlog: 'var(--muted)',
-    'In Progress': 'var(--green)',
-    Done: 'var(--brand)',
-    Blocked: 'var(--red)'
-  } as const;
+  const statusPillClass = (label: string) => {
+    const normalized = String(label).toLowerCase();
+    const base = 'kanban-card__meta-pill';
+    if (normalized.includes('done')) return `${base} kanban-card__meta-pill--success`;
+    if (normalized.includes('progress')) return `${base} kanban-card__meta-pill--orange`;
+    if (normalized.includes('block')) return `${base} kanban-card__meta-pill--danger`;
+    return base;
+  };
+
+  const formatDateChip = (value: any) => {
+    const date = toDate(value);
+    if (!date) return null;
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  };
 
   if (tasks.length === 0) {
     return (
@@ -328,14 +360,10 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
           const themeDef = resolveTheme(themeValue);
           const themeColor = themeDef.color || (themeVars.brand as string);
           const themeTextColor = themeDef.textColor || (themeVars.onAccent as string);
-          const gradientStart = lightenColor(themeColor, 0.45);
-          const gradientEnd = lightenColor(themeColor, 0.78);
-          const cardBackground = `linear-gradient(165deg, ${gradientStart} 0%, ${gradientEnd} 100%)`;
           const textColor = themeVars.text as string;
           const mutedTextColor = themeVars.muted as string;
           const statusLabel = taskStatusText(task.status);
           const priorityText = priorityLabel(task.priority, `P${task.priority ?? 2}`);
-          const priorityVariant = getPriorityColor(task.priority);
           const latestActivity = latestActivities[task.id];
           const showActivity = showUpdates && !!latestActivity;
           const showTaskDescription = showDescriptions && !!task.description;
@@ -345,6 +373,10 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
           const lastSyncedAt = toDate(lastSyncedRaw);
           const rowSpan = rowSpans[task.id];
           const nextBlock = nextBlocks[task.id];
+          const aiScore = Number((task as any).aiCriticalityScore ?? NaN);
+          const dueChip = formatDateChip(task.dueDate || (task as any).targetDate);
+          const isTop3 = Boolean((task as any).aiTop3ForDay);
+          const points = Number((task as any).points ?? 0);
 
           return (
             <div
@@ -364,13 +396,13 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
                   overflow: 'hidden',
                   transition: 'all 0.3s ease',
                   cursor: 'pointer',
-                  background: cardBackground,
+                  background: 'var(--bs-body-bg, #fff)',
                   color: textColor,
                   display: 'flex',
                   flexDirection: 'column'
                 }}
                 onClick={() => {
-                  try { showSidebar(task, 'task'); } catch { }
+                  onEditTask(task);
                 }}
                 onMouseEnter={(e) => {
                   e.currentTarget.style.transform = 'translateY(-2px)';
@@ -381,8 +413,7 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
                   e.currentTarget.style.boxShadow = '0 6px 12px var(--glass-shadow-color)';
                 }}
               >
-                <div style={{ height: '6px', backgroundColor: themeColor }} />
-                <Card.Body style={{ padding: '14px 12px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+                <Card.Body style={{ padding: '14px 12px', display: 'flex', flexDirection: 'column', gap: '10px', borderLeft: `4px solid ${themeColor}` }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
                     <div style={{ flex: 1, minWidth: 0 }}>
                       {task.ref && (
@@ -390,11 +421,24 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
                           {task.ref}
                         </div>
                       )}
-                      <h5 style={{ margin: '4px 0 0 0', fontSize: '16px', fontWeight: 600, lineHeight: '1.3', color: textColor }}>
+                      <h5 className="kanban-card__title" style={{ margin: '4px 0 0 0', fontSize: '16px', fontWeight: 600, lineHeight: '1.3', color: textColor }}>
                         {task.title}
                       </h5>
                     </div>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      <Button
+                        variant="link"
+                        size="sm"
+                        className="p-0"
+                        style={{ width: 24, height: 24, color: textColor }}
+                        title="Schedule task"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setScheduleTask(task);
+                        }}
+                      >
+                        <Calendar size={14} />
+                      </Button>
                       <Button
                         variant="link"
                         size="sm"
@@ -416,49 +460,44 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
                         title="Edit task"
                         onClick={(e) => {
                           e.stopPropagation();
-                          showSidebar(task, 'task');
+                          onEditTask(task);
                         }}
                       >
                         <Edit3 size={14} />
                       </Button>
-                      <Dropdown onClick={(e) => e.stopPropagation()}>
-                        <Dropdown.Toggle
-                          variant="outline-secondary"
-                          size="sm"
-                          style={{ border: 'none', padding: '4px 6px', color: textColor }}
-                        >
-                          <ChevronDown size={16} />
-                        </Dropdown.Toggle>
-                        <Dropdown.Menu style={{ zIndex: 2000 }} popperConfig={{ strategy: 'fixed' }}>
-                          <Dropdown.Header>Change Status</Dropdown.Header>
-                          <Dropdown.Item onClick={() => handleStatusChange(task.id, 'Backlog')}>Backlog</Dropdown.Item>
-                          <Dropdown.Item onClick={() => handleStatusChange(task.id, 'In Progress')}>In Progress</Dropdown.Item>
-                          <Dropdown.Item onClick={() => handleStatusChange(task.id, 'Done')}>Done</Dropdown.Item>
-                          <Dropdown.Item onClick={() => handleStatusChange(task.id, 'Blocked')}>Blocked</Dropdown.Item>
-                          <Dropdown.Divider />
-                          <Dropdown.Header>Change Priority</Dropdown.Header>
-                          <Dropdown.Item onClick={() => onTaskPriorityChange(task.id, 4)}>Critical (4)</Dropdown.Item>
-                          <Dropdown.Item onClick={() => onTaskPriorityChange(task.id, 3)}>High (3)</Dropdown.Item>
-                          <Dropdown.Item onClick={() => onTaskPriorityChange(task.id, 2)}>Medium (2)</Dropdown.Item>
-                          <Dropdown.Item onClick={() => onTaskPriorityChange(task.id, 1)}>Low (1)</Dropdown.Item>
-                          <Dropdown.Divider />
-                          <Dropdown.Item onClick={() => setDeferTask(task)}>
-                            Defer intelligently
-                          </Dropdown.Item>
-                          <Dropdown.Item
-                            className="text-danger"
-                            onClick={() => {
-                              if (window.confirm('Delete this task? This cannot be undone.')) {
-                                onTaskDelete(task.id);
-                              }
-                            }}
-                          >
-                            <Trash2 size={14} className="me-2" />
-                            Delete Task
-                          </Dropdown.Item>
-                        </Dropdown.Menu>
-                      </Dropdown>
                     </div>
+                  </div>
+
+                  <div className="d-flex align-items-center gap-2 flex-wrap">
+                    <Badge bg="primary">Task</Badge>
+                    <button
+                      type="button"
+                      className={statusPillClass(statusLabel)}
+                      style={{ appearance: 'none', backgroundClip: 'padding-box', cursor: 'pointer' }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        cycleTaskStatus(task);
+                      }}
+                      title="Tap to cycle status"
+                    >
+                      {statusLabel}
+                    </button>
+                    <button
+                      type="button"
+                      className={priorityPillClass(task.priority ?? null)}
+                      style={{ appearance: 'none', backgroundClip: 'padding-box', cursor: 'pointer' }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        cycleTaskPriority(task);
+                      }}
+                      title="Tap to cycle priority"
+                    >
+                      {priorityText}
+                    </button>
+                    {dueChip && <Badge bg="light" text="dark">Due {dueChip}</Badge>}
+                    {Number.isFinite(aiScore) && <Badge bg="secondary">AI {Math.round(aiScore)}/100</Badge>}
+                    {points > 0 && <Badge bg="dark">Pts {points}</Badge>}
+                    {isTop3 && <Badge bg="danger">Top 3</Badge>}
                   </div>
 
                   {(showTaskDescription || showActivity) && (
@@ -553,24 +592,6 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
                     </div>
                   )}
 
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
-                    <Badge style={{ backgroundColor: themeColor, color: themeTextColor, fontSize: '11px' }}>
-                      {themeDef.label}
-                    </Badge>
-                    <Badge
-                      style={{
-                        backgroundColor: statusColors[statusLabel as keyof typeof statusColors] || 'var(--muted)',
-                        color: 'var(--on-accent)',
-                        fontSize: '11px'
-                      }}
-                    >
-                      {statusLabel}
-                    </Badge>
-                    <Badge bg={priorityVariant} style={{ fontSize: '11px' }}>
-                      {priorityText}
-                    </Badge>
-                  </div>
-
                   {nextBlock && (
                     <div
                       style={{
@@ -596,6 +617,33 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
                       </span>
                     </div>
                   )}
+
+                  <div className="d-flex align-items-center gap-2 flex-wrap">
+                    <Button
+                      variant="outline-warning"
+                      size="sm"
+                      className="d-inline-flex align-items-center gap-1"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setDeferTask(task);
+                      }}
+                    >
+                      <Clock3 size={14} /> Defer
+                    </Button>
+                    <Button
+                      variant="outline-danger"
+                      size="sm"
+                      className="d-inline-flex align-items-center gap-1"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (window.confirm('Delete this task? This cannot be undone.')) {
+                          onTaskDelete(task.id);
+                        }
+                      }}
+                    >
+                      <Trash2 size={14} /> Delete
+                    </Button>
+                  </div>
 
                   <div
                     style={{
@@ -646,15 +694,45 @@ const TasksCardView: React.FC<TasksCardViewProps> = ({
         itemTitle={deferTask?.title || ''}
         onApply={async ({ dateMs, rationale, source }) => {
           if (!deferTask) return;
-          onTaskUpdate(deferTask.id, {
-            dueDate: dateMs,
-            deferredUntil: dateMs,
-            deferredReason: rationale,
-            deferredBy: source,
-          });
-          setDeferTask(null);
+          try {
+            await Promise.resolve(onTaskUpdate(deferTask.id, {
+              dueDate: dateMs,
+              deferredUntil: dateMs,
+              deferredReason: rationale,
+              deferredBy: source,
+            }));
+            showToast(`${deferTask.title} deferred to ${new Date(dateMs).toLocaleDateString()}.`, 'success');
+            setDeferTask(null);
+          } catch (error) {
+            console.error('TasksCardView: failed to defer task', error);
+            showToast('Failed to defer task.', 'danger');
+          }
         }}
       />
+      <NewCalendarEventModal
+        show={Boolean(scheduleTask)}
+        onHide={() => setScheduleTask(null)}
+        initialValues={scheduleInitialValues}
+        stories={linkedScheduleStories}
+        onSaved={() => {
+          const title = scheduleTask?.title || 'Task';
+          setScheduleTask(null);
+          showToast(`${title} added to your calendar.`, 'success');
+        }}
+      />
+      <ToastContainer position="bottom-end" className="p-3" style={{ zIndex: 1080 }}>
+        <Toast
+          bg={feedback.variant}
+          onClose={() => setFeedback((prev) => ({ ...prev, show: false }))}
+          show={feedback.show}
+          delay={3500}
+          autohide
+        >
+          <Toast.Body className={feedback.variant === 'info' ? '' : 'text-white'}>
+            {feedback.message}
+          </Toast.Body>
+        </Toast>
+      </ToastContainer>
     </div>
   );
 };

--- a/react-app/src/components/WorkoutsDashboard.tsx
+++ b/react-app/src/components/WorkoutsDashboard.tsx
@@ -5,6 +5,7 @@ import { collection, query, where, orderBy, limit, onSnapshot, doc, setDoc } fro
 import { useAuth } from '../contexts/AuthContext';
 import { useLocation } from 'react-router-dom';
 import { Line } from 'react-chartjs-2';
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip as RechartsTooltip } from 'recharts';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -79,6 +80,38 @@ interface HealthTrendPoint {
   readiness: number | null;
 }
 
+interface RecoveryTrendPoint {
+  dayKey: string;
+  label: string;
+  ms: number;
+  hrvMs: number | null;
+  vo2Max: number | null;
+}
+
+interface ComplianceCardSummary {
+  key: string;
+  label: string;
+  valueLabel: string;
+  targetLabel: string;
+  progressPct: number | null;
+  tone: 'success' | 'warning' | 'secondary';
+  labels: string[];
+  series: Array<number | null>;
+}
+
+const CARDIO_FITNESS_METRIC_KEYS = [
+  'healthkitVo2Max',
+  'healthkitVO2Max',
+  'healthkitCardioFitness',
+  'vo2Max',
+  'cardioFitness',
+  'cardioFitnessVo2Max',
+  'appleHealthCardioFitness',
+  'appleHealthVo2Max',
+];
+
+const clampPercent = (value: number): number => Math.max(0, Math.min(999, Math.round(value)));
+
 function fmtTime(sec?: number | null): string {
   const s = Math.floor(sec || 0);
   const h = Math.floor(s/3600), m = Math.floor((s%3600)/60), ss = s%60;
@@ -115,6 +148,16 @@ function resolveWorkoutStartMs(w: WorkoutDoc): number {
 
 type SportMode = 'run' | 'swim' | 'bike';
 
+type ActivityCompositionKey =
+  | 'run'
+  | 'swim'
+  | 'bike'
+  | 'walk'
+  | 'strength'
+  | 'crossfit'
+  | 'mobility'
+  | 'other';
+
 function getWorkoutSport(w: WorkoutDoc): SportMode | 'other' {
   if (w.provider === 'parkrun') return 'run';
   if (w.run === true) return 'run';
@@ -123,6 +166,19 @@ function getWorkoutSport(w: WorkoutDoc): SportMode | 'other' {
   if (type.includes('ride') || type.includes('bike') || type.includes('cycling')) return 'bike';
   if (type.includes('run') || type.includes('walk') || type.includes('hike')) return 'run';
   return 'other';
+}
+
+function classifyWorkoutActivityType(w: WorkoutDoc): ActivityCompositionKey {
+  if (w.provider === 'parkrun') return 'run';
+  const haystack = `${String(w.type || '')} ${String(w.sportType || '')} ${String(w.title || '')} ${String(w.name || '')} ${String(w.event || '')}`.toLowerCase();
+  if (haystack.includes('crossfit')) return 'crossfit';
+  if (haystack.includes('strength') || haystack.includes('weights') || haystack.includes('resistance') || haystack.includes('gym')) return 'strength';
+  if (haystack.includes('yoga') || haystack.includes('pilates') || haystack.includes('mobility') || haystack.includes('stretch')) return 'mobility';
+  if (haystack.includes('swim')) return 'swim';
+  if (haystack.includes('ride') || haystack.includes('bike') || haystack.includes('cycling')) return 'bike';
+  if (haystack.includes('walk') || haystack.includes('hike')) return 'walk';
+  if (haystack.includes('run')) return 'run';
+  return getWorkoutSport(w);
 }
 
 function workoutMatchesSport(w: WorkoutDoc, sportMode: SportMode): boolean {
@@ -159,6 +215,10 @@ function resolveMetricDateMs(metric: any): number {
     if (Number.isFinite(parsed)) return parsed;
   }
   return toMillis(metric?.updatedAt) || toMillis(metric?.createdAt) || 0;
+}
+
+function resolveObservedMetricMs(metric: any): number {
+  return Number(metric?.observedAt || 0) || toMillis(metric?.observedAt) || resolveMetricDateMs(metric);
 }
 
 function formatMetricLabel(ms: number): string {
@@ -210,6 +270,43 @@ function formatSignedSecDelta(deltaSec: number | null): string {
   return `${sign}${s}s`;
 }
 
+function formatMinutesCompact(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '—';
+  const minutes = Math.max(0, Math.round(value));
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (hours > 0 && mins > 0) return `${hours}h ${mins}m`;
+  if (hours > 0) return `${hours}h`;
+  return `${mins}m`;
+}
+
+function formatPercentCompact(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '—';
+  return `${Math.round(value)}%`;
+}
+
+const ACTIVITY_COMPOSITION_COLORS: Record<ActivityCompositionKey, string> = {
+  run: '#2563eb',
+  swim: '#0f766e',
+  bike: '#d97706',
+  walk: '#16a34a',
+  strength: '#7c3aed',
+  crossfit: '#dc2626',
+  mobility: '#0891b2',
+  other: '#6b7280',
+};
+
+const ACTIVITY_COMPOSITION_LABELS: Record<ActivityCompositionKey, string> = {
+  run: 'Run',
+  swim: 'Swim',
+  bike: 'Bike',
+  walk: 'Walk / Hike',
+  strength: 'Strength',
+  crossfit: 'CrossFit',
+  mobility: 'Mobility',
+  other: 'Other',
+};
+
 function trendArrow(delta: number | null, lowerIsBetter: boolean): JSX.Element {
   if (delta == null || !Number.isFinite(delta) || Math.abs(delta) < 0.001) {
     return <span className="text-muted ms-1">→</span>;
@@ -259,6 +356,7 @@ const WorkoutsDashboard: React.FC = () => {
   const [workouts, setWorkouts] = useState<WorkoutDoc[]>([]);
   const [healthProfile, setHealthProfile] = useState<any | null>(null);
   const [healthMetrics, setHealthMetrics] = useState<any[]>([]);
+  const [vo2Metrics, setVo2Metrics] = useState<any[]>([]);
   const [providerFilter, setProviderFilter] = useState<'all'|'strava'|'parkrun'>('all');
   const [settingsMsg, setSettingsMsg] = useState<string>('');
   const [zoneDisplayMode, setZoneDisplayMode] = useState<'time'|'percent'>('time');
@@ -391,6 +489,23 @@ const WorkoutsDashboard: React.FC = () => {
     return () => unsub();
   }, [currentUser]);
 
+  useEffect(() => {
+    if (!currentUser) {
+      setVo2Metrics([]);
+      return;
+    }
+    const qRef = query(
+      collection(db, 'metric_values'),
+      where('ownerUid', '==', currentUser.uid),
+      where('metricKey', 'in', CARDIO_FITNESS_METRIC_KEYS),
+      limit(180)
+    );
+    const unsub = onSnapshot(qRef, (snap) => {
+      setVo2Metrics(snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) })));
+    }, () => setVo2Metrics([]));
+    return () => unsub();
+  }, [currentUser]);
+
   const minWindowStartMs = useMemo(() => {
     if (lookbackWindow === 'all') return null;
     const now = new Date();
@@ -417,6 +532,17 @@ const WorkoutsDashboard: React.FC = () => {
       sourceLabel: ['authorized', 'synced'].includes(String(healthProfile.healthkitStatus || '').toLowerCase()) ? 'HealthKit' : 'Manual',
       weightKg: readNumericValue(healthProfile, 'healthkitWeightKg', 'manualWeightKg'),
       bodyFatPct: readNumericValue(healthProfile, 'healthkitBodyFatPct', 'manualBodyFatPct'),
+      vo2Max: readNumericValue(
+        healthProfile,
+        'healthkitVo2Max',
+        'healthkitVO2Max',
+        'healthkitCardioFitness',
+        'vo2Max',
+        'cardioFitness',
+        'cardioFitnessVo2Max',
+        'appleHealthCardioFitness',
+        'appleHealthVo2Max',
+      ),
       stepsToday: readNumericValue(healthProfile, 'healthkitStepsToday', 'manualStepsToday'),
       distanceKmToday: readNumericValue(healthProfile, 'healthkitDistanceKmToday', 'manualDistanceKmToday'),
       workoutMinutesToday: readNumericValue(healthProfile, 'healthkitWorkoutMinutesToday', 'manualWorkoutMinutesToday'),
@@ -502,10 +628,85 @@ const WorkoutsDashboard: React.FC = () => {
       byDay.set(dayKey, current);
     }
 
+    if (currentHealthSnapshot) {
+      const todayMs = Date.now();
+      const todayKey = new Date(todayMs).toISOString().slice(0, 10);
+      const current = byDay.get(todayKey) || {
+        dayKey: todayKey,
+        label: formatMetricLabel(todayMs),
+        ms: todayMs,
+        steps: null,
+        workoutMinutes: 0,
+        distanceKm: 0,
+      };
+      if (currentHealthSnapshot.stepsToday != null) current.steps = currentHealthSnapshot.stepsToday;
+      if (currentHealthSnapshot.workoutMinutesToday != null) current.workoutMinutes = Math.max(current.workoutMinutes, currentHealthSnapshot.workoutMinutesToday);
+      if (currentHealthSnapshot.distanceKmToday != null) current.distanceKm = Math.max(current.distanceKm, currentHealthSnapshot.distanceKmToday);
+      current.ms = Math.max(current.ms, todayMs);
+      current.label = formatMetricLabel(current.ms);
+      byDay.set(todayKey, current);
+    }
+
     return Array.from(byDay.values())
       .sort((a, b) => a.ms - b.ms)
       .slice(-30);
-  }, [healthTrendRows, workouts, excludeWithDadFromMetrics]);
+  }, [healthTrendRows, workouts, excludeWithDadFromMetrics, currentHealthSnapshot]);
+
+  const recoveryTrendRows = useMemo<RecoveryTrendPoint[]>(() => {
+    const byDay = new Map<string, RecoveryTrendPoint>();
+
+    for (const metric of healthMetrics) {
+      const metricMs = resolveMetricDateMs(metric);
+      if (!metricMs) continue;
+      const dayKey = new Date(metricMs).toISOString().slice(0, 10);
+      const hrvValue = readNumericValue(metric, 'value', 'rMSSD', 'hrv');
+      const current = byDay.get(dayKey) || {
+        dayKey,
+        label: formatMetricLabel(metricMs),
+        ms: metricMs,
+        hrvMs: null,
+        vo2Max: null,
+      };
+      if (hrvValue != null) current.hrvMs = hrvValue;
+      current.ms = Math.max(current.ms, metricMs);
+      current.label = formatMetricLabel(current.ms);
+      byDay.set(dayKey, current);
+    }
+
+    for (const metric of vo2Metrics) {
+      const metricMs = resolveObservedMetricMs(metric);
+      if (!metricMs) continue;
+      const dayKey = new Date(metricMs).toISOString().slice(0, 10);
+      const vo2Value = readNumericValue(
+        metric,
+        'value',
+        'vo2Max',
+        'healthkitVo2Max',
+        'healthkitVO2Max',
+        'healthkitCardioFitness',
+        'cardioFitness',
+        'cardioFitnessVo2Max',
+        'appleHealthCardioFitness',
+        'appleHealthVo2Max',
+      );
+      if (vo2Value == null) continue;
+      const current = byDay.get(dayKey) || {
+        dayKey,
+        label: formatMetricLabel(metricMs),
+        ms: metricMs,
+        hrvMs: null,
+        vo2Max: null,
+      };
+      current.vo2Max = vo2Value;
+      current.ms = Math.max(current.ms, metricMs);
+      current.label = formatMetricLabel(current.ms);
+      byDay.set(dayKey, current);
+    }
+
+    return Array.from(byDay.values())
+      .sort((a, b) => a.ms - b.ms)
+      .slice(-30);
+  }, [healthMetrics, vo2Metrics]);
 
   const bodyCompositionChartData = useMemo(() => ({
     labels: healthTrendRows.map((row) => row.label),
@@ -592,6 +793,47 @@ const WorkoutsDashboard: React.FC = () => {
         type: 'linear',
         position: 'right',
         title: { display: true, text: 'Minutes / km' },
+        grid: { drawOnChartArea: false },
+      },
+    },
+  }), []);
+
+  const recoveryChartData = useMemo(() => ({
+    labels: recoveryTrendRows.map((row) => row.label),
+    datasets: [
+      {
+        label: 'HRV (ms)',
+        data: recoveryTrendRows.map((row) => row.hrvMs),
+        borderColor: '#dc3545',
+        backgroundColor: 'rgba(220, 53, 69, 0.12)',
+        yAxisID: 'yHrv',
+        spanGaps: true,
+      },
+      {
+        label: 'Cardio Fitness (VO2 Max)',
+        data: recoveryTrendRows.map((row) => row.vo2Max),
+        borderColor: '#0d6efd',
+        backgroundColor: 'rgba(13, 110, 253, 0.12)',
+        yAxisID: 'yVo2',
+        spanGaps: true,
+      },
+    ],
+  }), [recoveryTrendRows]);
+
+  const recoveryChartOptions: any = useMemo(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    scales: {
+      yHrv: {
+        type: 'linear',
+        position: 'left',
+        title: { display: true, text: 'HRV (ms)' },
+      },
+      yVo2: {
+        type: 'linear',
+        position: 'right',
+        title: { display: true, text: 'Cardio Fitness' },
         grid: { drawOnChartArea: false },
       },
     },
@@ -1252,6 +1494,289 @@ const WorkoutsDashboard: React.FC = () => {
     ? sportCards.filter((card) => card.sport === 'run')
     : sportCards;
 
+  const workoutTargetModel = useMemo(() => {
+    const explicitTargetMinutes = readNumericValue(
+      healthProfile,
+      'weeklyWorkoutTargetMinutes',
+      'targetWorkoutMinutesPerWeek',
+      'workoutTargetMinutesWeekly',
+      'healthTargetWorkoutMinutesWeekly',
+      'targetExerciseMinutesWeekly',
+    );
+    const awakeHoursPerDay = Math.max(0, readNumericValue(
+      healthProfile,
+      'awakeHoursPerDay',
+      'targetAwakeHoursPerDay',
+      'healthAwakeHoursPerDay',
+    ) ?? 16);
+    const workHoursPerDay = Math.max(0, readNumericValue(
+      healthProfile,
+      'workHoursPerDay',
+      'targetWorkHoursPerDay',
+      'healthWorkHoursPerDay',
+    ) ?? 8);
+    const workoutPctOfFreeTime = Math.max(1, readNumericValue(
+      healthProfile,
+      'targetWorkoutPctOfFreeTime',
+      'weeklyWorkoutTargetPercent',
+      'weeklyExerciseTimePercent',
+      'trainingTimePercent',
+    ) ?? 20);
+    const discretionaryHoursPerWeek = Math.max(0, awakeHoursPerDay - workHoursPerDay) * 7;
+    const derivedTargetMinutes = Math.round(discretionaryHoursPerWeek * (workoutPctOfFreeTime / 100) * 60);
+    const hasDerivedConfig = readNumericValue(
+      healthProfile,
+      'awakeHoursPerDay',
+      'targetAwakeHoursPerDay',
+      'healthAwakeHoursPerDay',
+      'workHoursPerDay',
+      'targetWorkHoursPerDay',
+      'healthWorkHoursPerDay',
+      'targetWorkoutPctOfFreeTime',
+      'weeklyWorkoutTargetPercent',
+      'weeklyExerciseTimePercent',
+      'trainingTimePercent',
+    ) != null;
+    const treatExplicitAsLegacyFallback = explicitTargetMinutes === 240 && !hasDerivedConfig;
+    const usesDerivedTarget = explicitTargetMinutes == null || treatExplicitAsLegacyFallback;
+    return {
+      targetMinutes: usesDerivedTarget ? derivedTargetMinutes : Math.max(1, Math.round(explicitTargetMinutes)),
+      awakeHoursPerDay,
+      workHoursPerDay,
+      workoutPctOfFreeTime,
+      discretionaryHoursPerWeek,
+      usesDerivedTarget,
+    };
+  }, [healthProfile]);
+
+  const workoutTargetMinutesPerWeek = workoutTargetModel.targetMinutes;
+
+  const workoutTimeSummary = useMemo(() => {
+    const nowMs = Date.now();
+    const weekStartMs = nowMs - (7 * 24 * 60 * 60 * 1000);
+    const prevWeekStartMs = nowMs - (14 * 24 * 60 * 60 * 1000);
+    let currentMinutes = 0;
+    let previousMinutes = 0;
+    const byActivity = new Map<ActivityCompositionKey, number>();
+
+    workouts.forEach((workout) => {
+      if (activeProviderFilter !== 'all' && workout.provider !== activeProviderFilter) return;
+      if (excludeWithDadFromMetrics && workoutHasDadMarker(workout)) return;
+      const startMs = resolveWorkoutStartMs(workout);
+      if (!startMs) return;
+      const minutes = Number(workout.movingTime_s ?? workout.elapsedTime_s ?? 0) / 60;
+      if (!Number.isFinite(minutes) || minutes <= 0) return;
+      if (startMs >= weekStartMs && startMs <= nowMs) {
+        currentMinutes += minutes;
+        const key = classifyWorkoutActivityType(workout);
+        byActivity.set(key, (byActivity.get(key) || 0) + minutes);
+      } else if (startMs >= prevWeekStartMs && startMs < weekStartMs) {
+        previousMinutes += minutes;
+      }
+    });
+
+    const breakdown = Array.from(byActivity.entries())
+      .map(([key, minutes]) => ({
+        key,
+        label: ACTIVITY_COMPOSITION_LABELS[key],
+        minutes: Number(minutes.toFixed(1)),
+      }))
+      .sort((a, b) => b.minutes - a.minutes);
+
+    const pct = workoutTargetMinutesPerWeek > 0
+      ? Math.round((currentMinutes / workoutTargetMinutesPerWeek) * 100)
+      : null;
+
+    return {
+      currentMinutes: Number(currentMinutes.toFixed(1)),
+      previousMinutes: Number(previousMinutes.toFixed(1)),
+      deltaMinutes: Number((currentMinutes - previousMinutes).toFixed(1)),
+      progressPct: pct != null ? Math.max(0, Math.min(999, pct)) : null,
+      breakdown,
+    };
+  }, [workouts, activeProviderFilter, excludeWithDadFromMetrics, workoutTargetMinutesPerWeek]);
+
+  const healthTargets = useMemo(() => ({
+    stepTarget: readNumericValue(
+      healthProfile,
+      'targetStepsPerDay',
+      'dailyStepTarget',
+      'healthTargetStepsPerDay',
+      'stepTarget',
+    ) ?? 10000,
+    distanceTargetKm: readNumericValue(
+      healthProfile,
+      'targetDistanceKmPerDay',
+      'dailyDistanceTargetKm',
+      'healthTargetDistanceKmPerDay',
+      'distanceTargetKm',
+    ) ?? 5,
+    workoutTargetMinutesPerDay: Math.max(1, Math.round(workoutTargetMinutesPerWeek / 7)),
+    proteinTargetG: readNumericValue(healthProfile, 'targetProteinG', 'dailyProteinTargetG', 'healthTargetProteinG'),
+    fatTargetG: readNumericValue(healthProfile, 'targetFatG', 'dailyFatTargetG', 'healthTargetFatG'),
+    carbsTargetG: readNumericValue(healthProfile, 'targetCarbsG', 'dailyCarbsTargetG', 'healthTargetCarbsG'),
+    caloriesTargetKcal: readNumericValue(healthProfile, 'targetCaloriesKcal', 'dailyCaloriesTargetKcal', 'healthTargetCaloriesKcal'),
+  }), [healthProfile, workoutTargetMinutesPerWeek]);
+
+  const complianceSparklineOptions: any = useMemo(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (context: any) => {
+            const value = Number(context.parsed?.y);
+            return Number.isFinite(value) ? `${Math.round(value)}% of target` : 'No data';
+          },
+        },
+      },
+    },
+    scales: {
+      x: { display: false, grid: { display: false } },
+      y: { display: false, grid: { display: false }, min: 0, max: 100 },
+    },
+    elements: {
+      point: { radius: 0, hoverRadius: 3 },
+      line: { tension: 0.35, borderWidth: 2 },
+    },
+  }), []);
+
+  const complianceCards = useMemo<ComplianceCardSummary[]>(() => {
+    const last7Activity = activityTrendRows.slice(-7);
+    const last7Health = healthTrendRows.slice(-7);
+    const toTone = (pct: number | null): ComplianceCardSummary['tone'] => (
+      pct == null ? 'secondary' : pct >= 100 ? 'success' : pct >= 70 ? 'warning' : 'secondary'
+    );
+    const adherencePct = (actual: number | null, target: number | null): number | null => {
+      if (actual == null || target == null || target <= 0) return null;
+      return clampPercent((actual / target) * 100);
+    };
+    const macroTodayComponents = [
+      adherencePct(currentHealthSnapshot?.proteinTodayG ?? null, healthTargets.proteinTargetG),
+      adherencePct(currentHealthSnapshot?.fatTodayG ?? null, healthTargets.fatTargetG),
+      adherencePct(currentHealthSnapshot?.carbsTodayG ?? null, healthTargets.carbsTargetG),
+      adherencePct(currentHealthSnapshot?.caloriesTodayKcal ?? null, healthTargets.caloriesTargetKcal),
+    ].filter((value): value is number => value != null);
+    const macroTodayPct = macroTodayComponents.length
+      ? Math.round(macroTodayComponents.reduce((sum, value) => sum + value, 0) / macroTodayComponents.length)
+      : null;
+
+    const macroSeries = last7Health.map((row) => {
+      const parts = [
+        adherencePct(row.proteinG, healthTargets.proteinTargetG),
+        adherencePct(row.fatG, healthTargets.fatTargetG),
+        adherencePct(row.carbsG, healthTargets.carbsTargetG),
+        adherencePct(row.caloriesKcal, healthTargets.caloriesTargetKcal),
+      ].filter((value): value is number => value != null);
+      return parts.length ? Math.round(parts.reduce((sum, value) => sum + value, 0) / parts.length) : null;
+    });
+
+    return [
+      {
+        key: 'steps',
+        label: 'Steps Compliance',
+        valueLabel: currentHealthSnapshot?.stepsToday != null
+          ? `${Math.round(currentHealthSnapshot.stepsToday).toLocaleString()} steps`
+          : 'No steps today',
+        targetLabel: `${healthTargets.stepTarget.toLocaleString()} target`,
+        progressPct: currentHealthSnapshot?.stepsToday != null
+          ? clampPercent((currentHealthSnapshot.stepsToday / healthTargets.stepTarget) * 100)
+          : null,
+        tone: toTone(currentHealthSnapshot?.stepsToday != null
+          ? clampPercent((currentHealthSnapshot.stepsToday / healthTargets.stepTarget) * 100)
+          : null),
+        labels: last7Activity.map((row) => row.label),
+        series: last7Activity.map((row) => row.steps != null ? clampPercent((row.steps / healthTargets.stepTarget) * 100) : null),
+      },
+      {
+        key: 'distance',
+        label: 'Distance Compliance',
+        valueLabel: currentHealthSnapshot?.distanceKmToday != null
+          ? `${currentHealthSnapshot.distanceKmToday.toFixed(1)} km`
+          : 'No distance today',
+        targetLabel: `${healthTargets.distanceTargetKm.toFixed(1)} km target`,
+        progressPct: currentHealthSnapshot?.distanceKmToday != null
+          ? clampPercent((currentHealthSnapshot.distanceKmToday / healthTargets.distanceTargetKm) * 100)
+          : null,
+        tone: toTone(currentHealthSnapshot?.distanceKmToday != null
+          ? clampPercent((currentHealthSnapshot.distanceKmToday / healthTargets.distanceTargetKm) * 100)
+          : null),
+        labels: last7Activity.map((row) => row.label),
+        series: last7Activity.map((row) => row.distanceKm > 0 ? clampPercent((row.distanceKm / healthTargets.distanceTargetKm) * 100) : 0),
+      },
+      {
+        key: 'workout',
+        label: 'Workout Compliance',
+        valueLabel: currentHealthSnapshot?.workoutMinutesToday != null
+          ? `${Math.round(currentHealthSnapshot.workoutMinutesToday)} min`
+          : 'No workout today',
+        targetLabel: `${healthTargets.workoutTargetMinutesPerDay} min/day target`,
+        progressPct: currentHealthSnapshot?.workoutMinutesToday != null
+          ? clampPercent((currentHealthSnapshot.workoutMinutesToday / healthTargets.workoutTargetMinutesPerDay) * 100)
+          : null,
+        tone: toTone(currentHealthSnapshot?.workoutMinutesToday != null
+          ? clampPercent((currentHealthSnapshot.workoutMinutesToday / healthTargets.workoutTargetMinutesPerDay) * 100)
+          : null),
+        labels: last7Activity.map((row) => row.label),
+        series: last7Activity.map((row) => row.workoutMinutes > 0 ? clampPercent((row.workoutMinutes / healthTargets.workoutTargetMinutesPerDay) * 100) : 0),
+      },
+      {
+        key: 'macros',
+        label: 'Macro Compliance',
+        valueLabel: macroTodayPct != null ? `${macroTodayPct}% of plan` : 'No macro data today',
+        targetLabel: 'Protein, fat, carbs, calories',
+        progressPct: macroTodayPct,
+        tone: toTone(macroTodayPct),
+        labels: last7Health.map((row) => row.label),
+        series: macroSeries,
+      },
+    ];
+  }, [activityTrendRows, currentHealthSnapshot, healthTargets, healthTrendRows]);
+
+  const activityComposition30d = useMemo(() => {
+    const nowMs = Date.now();
+    const startMs = nowMs - (30 * 24 * 60 * 60 * 1000);
+    const byActivity = new Map<ActivityCompositionKey, { minutes: number; sessions: number }>();
+
+    workouts.forEach((workout) => {
+      if (activeProviderFilter !== 'all' && workout.provider !== activeProviderFilter) return;
+      if (excludeWithDadFromMetrics && workoutHasDadMarker(workout)) return;
+      const workoutStartMs = resolveWorkoutStartMs(workout);
+      if (!workoutStartMs || workoutStartMs < startMs || workoutStartMs > nowMs) return;
+      const minutes = Number(workout.movingTime_s ?? workout.elapsedTime_s ?? 0) / 60;
+      if (!Number.isFinite(minutes) || minutes <= 0) return;
+      const key = classifyWorkoutActivityType(workout);
+      const current = byActivity.get(key) || { minutes: 0, sessions: 0 };
+      current.minutes += minutes;
+      current.sessions += 1;
+      byActivity.set(key, current);
+    });
+
+    return Array.from(byActivity.entries())
+      .map(([key, value]) => ({
+        key,
+        name: ACTIVITY_COMPOSITION_LABELS[key],
+        value: Number(value.minutes.toFixed(1)),
+        sessions: value.sessions,
+        color: ACTIVITY_COMPOSITION_COLORS[key],
+      }))
+      .sort((a, b) => b.value - a.value);
+  }, [workouts, activeProviderFilter, excludeWithDadFromMetrics]);
+
+  const activityCompositionTotalMinutes = useMemo(
+    () => activityComposition30d.reduce((sum, entry) => sum + entry.value, 0),
+    [activityComposition30d]
+  );
+
+  const activityCompositionWithShare = useMemo(() => (
+    activityComposition30d.map((entry) => ({
+      ...entry,
+      pct: activityCompositionTotalMinutes > 0 ? Math.round((entry.value / activityCompositionTotalMinutes) * 100) : 0,
+    }))
+  ), [activityComposition30d, activityCompositionTotalMinutes]);
+
   return (
     <div className="container-fluid py-3">
       <Row className="mb-3">
@@ -1354,78 +1879,6 @@ const WorkoutsDashboard: React.FC = () => {
         </Card.Body>
       </Card>
 
-      {(currentHealthSnapshot || healthTrendRows.length > 0 || activityTrendRows.length > 0) && (
-        <>
-          <Card className="mb-3">
-            <Card.Header>
-              <strong>Health Snapshot</strong>
-            </Card.Header>
-            <Card.Body>
-              <div className="d-flex flex-wrap gap-3 small mb-2">
-                <span><strong>Source:</strong> {currentHealthSnapshot?.sourceLabel || '—'}</span>
-                <span><strong>Weight:</strong> {currentHealthSnapshot?.weightKg != null ? `${currentHealthSnapshot.weightKg.toFixed(1)} kg` : '—'}</span>
-                <span><strong>Body Fat:</strong> {currentHealthSnapshot?.bodyFatPct != null ? `${currentHealthSnapshot.bodyFatPct.toFixed(1)}%` : '—'}</span>
-                <span><strong>Target:</strong> {currentHealthSnapshot?.targetWeightKg != null ? `${currentHealthSnapshot.targetWeightKg.toFixed(1)} kg` : '—'} / {currentHealthSnapshot?.targetBodyFatPct != null ? `${currentHealthSnapshot.targetBodyFatPct.toFixed(1)}%` : '—'}</span>
-                <span><strong>Steps Today:</strong> {currentHealthSnapshot?.stepsToday != null ? Math.round(currentHealthSnapshot.stepsToday).toLocaleString() : '—'}</span>
-                <span><strong>Workout Today:</strong> {currentHealthSnapshot?.workoutMinutesToday != null ? `${Math.round(currentHealthSnapshot.workoutMinutesToday)} min` : '—'}</span>
-                <span><strong>Distance Today:</strong> {currentHealthSnapshot?.distanceKmToday != null ? `${currentHealthSnapshot.distanceKmToday.toFixed(2)} km` : '—'}</span>
-                <span><strong>Macros:</strong> {currentHealthSnapshot?.proteinTodayG != null ? `P ${Math.round(currentHealthSnapshot.proteinTodayG)}g` : 'P —'} · {currentHealthSnapshot?.fatTodayG != null ? `F ${Math.round(currentHealthSnapshot.fatTodayG)}g` : 'F —'} · {currentHealthSnapshot?.carbsTodayG != null ? `C ${Math.round(currentHealthSnapshot.carbsTodayG)}g` : 'C —'}</span>
-                <span><strong>Calories:</strong> {currentHealthSnapshot?.caloriesTodayKcal != null ? `${Math.round(currentHealthSnapshot.caloriesTodayKcal)} kcal` : '—'}</span>
-                <span><strong>ETA:</strong> {currentHealthSnapshot?.weeksToTargetBodyFat != null ? `${Math.round(currentHealthSnapshot.weeksToTargetBodyFat)} weeks to body-fat target` : '—'}</span>
-              </div>
-              <div className="text-muted" style={{ fontSize: '0.85rem' }}>
-                Health trends combine profile targets, HealthKit/manual metrics, and workout history so the drill-down shows body composition, daily activity, and nutrition in one place.
-              </div>
-            </Card.Body>
-          </Card>
-
-          <Row className="g-3 mb-3">
-            <Col xs={12} xl={4}>
-              <Card className="h-100">
-                <Card.Header>
-                  <strong>Body Composition Trend</strong>
-                </Card.Header>
-                <Card.Body style={{ height: '32vh', minHeight: 260 }}>
-                  {healthTrendRows.some((row) => row.weightKg != null || row.bodyFatPct != null) ? (
-                    <Line data={bodyCompositionChartData as any} options={bodyCompositionChartOptions as any} />
-                  ) : (
-                    <div className="text-muted small">No body-composition trend data yet.</div>
-                  )}
-                </Card.Body>
-              </Card>
-            </Col>
-            <Col xs={12} xl={4}>
-              <Card className="h-100">
-                <Card.Header>
-                  <strong>Daily Activity Trend</strong>
-                </Card.Header>
-                <Card.Body style={{ height: '32vh', minHeight: 260 }}>
-                  {activityTrendRows.some((row) => row.steps != null || row.workoutMinutes > 0 || row.distanceKm > 0) ? (
-                    <Line data={activityChartData as any} options={activityChartOptions as any} />
-                  ) : (
-                    <div className="text-muted small">No activity trend data yet.</div>
-                  )}
-                </Card.Body>
-              </Card>
-            </Col>
-            <Col xs={12} xl={4}>
-              <Card className="h-100">
-                <Card.Header>
-                  <strong>Nutrition Trend</strong>
-                </Card.Header>
-                <Card.Body style={{ height: '32vh', minHeight: 260 }}>
-                  {healthTrendRows.some((row) => row.caloriesKcal != null || row.proteinG != null || row.fatG != null || row.carbsG != null) ? (
-                    <Line data={nutritionChartData as any} options={nutritionChartOptions as any} />
-                  ) : (
-                    <div className="text-muted small">No nutrition trend data yet.</div>
-                  )}
-                </Card.Body>
-              </Card>
-            </Col>
-          </Row>
-        </>
-      )}
-
       <Row className="g-3 mb-3">
         {visibleSportCards.map((card) => (
           <Col key={card.sport} xs={12} md={6} xl={4}>
@@ -1464,6 +1917,262 @@ const WorkoutsDashboard: React.FC = () => {
           </Col>
         ))}
       </Row>
+
+      <Row className="g-3 mb-3">
+        <Col xs={12} lg={5}>
+          <Card className="h-100">
+            <Card.Header className="py-2">
+              <strong>Workout Time KPI</strong>
+            </Card.Header>
+            <Card.Body className="py-2">
+              <div className="d-flex align-items-start justify-content-between gap-3 flex-wrap mb-3">
+                <div>
+                  <div className="text-muted small">Last 7 days</div>
+                  <div className="fw-semibold" style={{ fontSize: '1.15rem', lineHeight: 1.2 }}>
+                    {formatMinutesCompact(workoutTimeSummary.currentMinutes)} / {formatMinutesCompact(workoutTargetMinutesPerWeek)}
+                  </div>
+                  <div className="text-muted small">
+                    {workoutTimeSummary.progressPct != null ? `${workoutTimeSummary.progressPct}% of target` : 'No target set'}
+                    {' · '}
+                    {workoutTimeSummary.deltaMinutes === 0
+                      ? 'Flat vs previous week'
+                      : `${workoutTimeSummary.deltaMinutes > 0 ? '+' : ''}${formatMinutesCompact(Math.abs(workoutTimeSummary.deltaMinutes))} vs previous week`}
+                  </div>
+                  <div className="text-muted small mt-1">
+                    {workoutTargetModel.usesDerivedTarget
+                      ? `${formatPercentCompact(workoutTargetModel.workoutPctOfFreeTime)} of ${formatMinutesCompact(workoutTargetModel.discretionaryHoursPerWeek * 60)} discretionary time/week`
+                      : 'Explicit weekly workout target'}
+                  </div>
+                </div>
+                <Badge bg={
+                  (workoutTimeSummary.progressPct || 0) >= 100
+                    ? 'success'
+                    : (workoutTimeSummary.progressPct || 0) >= 70
+                      ? 'warning'
+                      : 'secondary'
+                }>
+                  {(workoutTimeSummary.progressPct || 0) >= 100 ? 'On target' : (workoutTimeSummary.progressPct || 0) >= 70 ? 'Building' : 'Below target'}
+                </Badge>
+              </div>
+              <div
+                style={{
+                  height: 6,
+                  borderRadius: 999,
+                  background: 'rgba(15, 23, 42, 0.08)',
+                  overflow: 'hidden',
+                  marginBottom: 12,
+                }}
+              >
+                <div
+                  style={{
+                    width: `${Math.max(0, Math.min(100, workoutTimeSummary.progressPct || 0))}%`,
+                    height: '100%',
+                    background: (workoutTimeSummary.progressPct || 0) >= 100 ? '#198754' : (workoutTimeSummary.progressPct || 0) >= 70 ? '#fd7e14' : '#0d6efd',
+                  }}
+                />
+              </div>
+              <div className="d-flex flex-wrap gap-2">
+                {workoutTimeSummary.breakdown.length === 0 ? (
+                  <div className="text-muted small">No workout-time data recorded this week yet.</div>
+                ) : (
+                  workoutTimeSummary.breakdown.slice(0, 6).map((entry) => (
+                    <Badge key={entry.key} bg="light" text="dark" pill>
+                      {entry.label}: {formatMinutesCompact(entry.minutes)}
+                    </Badge>
+                  ))
+                )}
+              </div>
+            </Card.Body>
+          </Card>
+        </Col>
+        <Col xs={12} lg={7}>
+          <Card className="h-100">
+            <Card.Header className="py-2">
+              <strong>30-Day Training Composition</strong>
+            </Card.Header>
+            <Card.Body className="py-2">
+              {activityCompositionWithShare.length === 0 ? (
+                <div className="text-muted small">No recent workout composition data yet.</div>
+              ) : (
+                <Row className="g-3 align-items-center">
+                  <Col xs={12} md={5} style={{ height: 210 }}>
+                    <ResponsiveContainer width="100%" height="100%">
+                      <PieChart>
+                        <Pie
+                          data={activityCompositionWithShare}
+                          dataKey="value"
+                          nameKey="name"
+                          innerRadius={46}
+                          outerRadius={76}
+                          paddingAngle={3}
+                          labelLine={false}
+                          label={({ value, percent }: any) => {
+                            const pct = Math.round((Number(percent) || 0) * 100);
+                            if (pct < 9) return '';
+                            return `${pct}% · ${formatMinutesCompact(Number(value))}`;
+                          }}
+                        >
+                          {activityCompositionWithShare.map((entry) => (
+                            <Cell key={entry.key} fill={entry.color} />
+                          ))}
+                        </Pie>
+                        <RechartsTooltip formatter={(value: number, name: string, meta: any) => [`${formatMinutesCompact(value)} · ${meta?.payload?.pct || 0}%`, `${name}${meta?.payload?.sessions ? ` · ${meta.payload.sessions} sessions` : ''}`]} />
+                      </PieChart>
+                    </ResponsiveContainer>
+                  </Col>
+                  <Col xs={12} md={7}>
+                    <div className="d-flex flex-column gap-2">
+                      {activityCompositionWithShare.map((entry) => (
+                        <div key={entry.key} className="d-flex align-items-center justify-content-between gap-2">
+                          <div className="d-flex align-items-center gap-2">
+                            <span style={{ width: 10, height: 10, borderRadius: 999, background: entry.color, display: 'inline-block' }} />
+                            <span className="small fw-semibold">{entry.name}</span>
+                          </div>
+                          <div className="text-muted small">
+                            {entry.pct}% · {formatMinutesCompact(entry.value)} · {entry.sessions} sessions
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </Col>
+                </Row>
+              )}
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
+
+      <Row className="g-3 mb-3">
+        {complianceCards.map((card) => (
+          <Col key={card.key} xs={12} md={6} xl={3}>
+            <Card className="h-100">
+              <Card.Body>
+                <div className="d-flex align-items-start justify-content-between gap-3 mb-2">
+                  <div>
+                    <div className="text-muted small">{card.label}</div>
+                    <div className="fw-semibold">{card.valueLabel}</div>
+                    <div className="text-muted small">{card.targetLabel}</div>
+                  </div>
+                  <Badge bg={card.tone}>
+                    {card.progressPct != null ? `${card.progressPct}%` : 'Pending'}
+                  </Badge>
+                </div>
+                <div style={{ height: 54 }}>
+                  {card.series.some((value) => value != null) ? (
+                    <Line
+                      data={{
+                        labels: card.labels,
+                        datasets: [{
+                          data: card.series,
+                          borderColor: card.tone === 'success' ? '#198754' : card.tone === 'warning' ? '#fd7e14' : '#0d6efd',
+                          backgroundColor: 'transparent',
+                          fill: false,
+                          spanGaps: true,
+                        }],
+                      } as any}
+                      options={complianceSparklineOptions}
+                    />
+                  ) : (
+                    <div className="text-muted small">No recent data yet.</div>
+                  )}
+                </div>
+              </Card.Body>
+            </Card>
+          </Col>
+        ))}
+      </Row>
+
+      {(currentHealthSnapshot || healthTrendRows.length > 0 || activityTrendRows.length > 0) && (
+        <>
+          <Card className="mb-3">
+            <Card.Header>
+              <strong>Health Snapshot</strong>
+            </Card.Header>
+            <Card.Body>
+              <div className="d-flex flex-wrap gap-3 small mb-2">
+                <span><strong>Source:</strong> {currentHealthSnapshot?.sourceLabel || '—'}</span>
+                <span><strong>Weight:</strong> {currentHealthSnapshot?.weightKg != null ? `${currentHealthSnapshot.weightKg.toFixed(1)} kg` : '—'}</span>
+                <span><strong>Body Fat:</strong> {currentHealthSnapshot?.bodyFatPct != null ? `${currentHealthSnapshot.bodyFatPct.toFixed(1)}%` : '—'}</span>
+                <span><strong>Cardio Fitness:</strong> {currentHealthSnapshot?.vo2Max != null ? currentHealthSnapshot.vo2Max.toFixed(1) : '—'}</span>
+                <span><strong>Target:</strong> {currentHealthSnapshot?.targetWeightKg != null ? `${currentHealthSnapshot.targetWeightKg.toFixed(1)} kg` : '—'} / {currentHealthSnapshot?.targetBodyFatPct != null ? `${currentHealthSnapshot.targetBodyFatPct.toFixed(1)}%` : '—'}</span>
+                <span><strong>Steps Today:</strong> {currentHealthSnapshot?.stepsToday != null ? Math.round(currentHealthSnapshot.stepsToday).toLocaleString() : '—'}</span>
+                <span><strong>Workout Today:</strong> {currentHealthSnapshot?.workoutMinutesToday != null ? `${Math.round(currentHealthSnapshot.workoutMinutesToday)} min` : '—'}</span>
+                <span><strong>Distance Today:</strong> {currentHealthSnapshot?.distanceKmToday != null ? `${currentHealthSnapshot.distanceKmToday.toFixed(2)} km` : '—'}</span>
+                <span><strong>Macros:</strong> {currentHealthSnapshot?.proteinTodayG != null ? `P ${Math.round(currentHealthSnapshot.proteinTodayG)}g` : 'P —'} · {currentHealthSnapshot?.fatTodayG != null ? `F ${Math.round(currentHealthSnapshot.fatTodayG)}g` : 'F —'} · {currentHealthSnapshot?.carbsTodayG != null ? `C ${Math.round(currentHealthSnapshot.carbsTodayG)}g` : 'C —'}</span>
+                <span><strong>Calories:</strong> {currentHealthSnapshot?.caloriesTodayKcal != null ? `${Math.round(currentHealthSnapshot.caloriesTodayKcal)} kcal` : '—'}</span>
+                <span><strong>ETA:</strong> {currentHealthSnapshot?.weeksToTargetBodyFat != null ? `${Math.round(currentHealthSnapshot.weeksToTargetBodyFat)} weeks to body-fat target` : '—'}</span>
+              </div>
+              <div className="text-muted mt-1" style={{ fontSize: '0.8rem' }}>
+                Workout target basis: {workoutTargetModel.usesDerivedTarget
+                  ? `${workoutTargetModel.awakeHoursPerDay}h awake/day − ${workoutTargetModel.workHoursPerDay}h work/day = ${formatMinutesCompact(workoutTargetModel.discretionaryHoursPerWeek * 60)} discretionary time/week; target set to ${workoutTargetModel.workoutPctOfFreeTime}%`
+                  : `${formatMinutesCompact(workoutTargetMinutesPerWeek)} explicit weekly target`}
+              </div>
+              <div className="text-muted" style={{ fontSize: '0.85rem' }}>
+                Health trends combine profile targets, HealthKit/manual metrics, and workout history so the drill-down shows body composition, daily activity, and nutrition in one place.
+              </div>
+            </Card.Body>
+          </Card>
+
+          <Row className="g-3 mb-3">
+            <Col xs={12} xl={6}>
+              <Card className="h-100">
+                <Card.Header>
+                  <strong>Body Composition Trend</strong>
+                </Card.Header>
+                <Card.Body style={{ height: '32vh', minHeight: 260 }}>
+                  {healthTrendRows.some((row) => row.weightKg != null || row.bodyFatPct != null) ? (
+                    <Line data={bodyCompositionChartData as any} options={bodyCompositionChartOptions as any} />
+                  ) : (
+                    <div className="text-muted small">No body-composition trend data yet.</div>
+                  )}
+                </Card.Body>
+              </Card>
+            </Col>
+            <Col xs={12} xl={6}>
+              <Card className="h-100">
+                <Card.Header>
+                  <strong>Daily Activity Trend</strong>
+                </Card.Header>
+                <Card.Body style={{ height: '32vh', minHeight: 260 }}>
+                  {activityTrendRows.some((row) => row.steps != null || row.workoutMinutes > 0 || row.distanceKm > 0) ? (
+                    <Line data={activityChartData as any} options={activityChartOptions as any} />
+                  ) : (
+                    <div className="text-muted small">No activity trend data yet.</div>
+                  )}
+                </Card.Body>
+              </Card>
+            </Col>
+            <Col xs={12} xl={6}>
+              <Card className="h-100">
+                <Card.Header>
+                  <strong>Recovery + Cardio Fitness</strong>
+                </Card.Header>
+                <Card.Body style={{ height: '32vh', minHeight: 260 }}>
+                  {recoveryTrendRows.some((row) => row.hrvMs != null || row.vo2Max != null) ? (
+                    <Line data={recoveryChartData as any} options={recoveryChartOptions as any} />
+                  ) : (
+                    <div className="text-muted small">No HRV or Cardio Fitness trend data yet.</div>
+                  )}
+                </Card.Body>
+              </Card>
+            </Col>
+            <Col xs={12} xl={6}>
+              <Card className="h-100">
+                <Card.Header>
+                  <strong>Nutrition Trend</strong>
+                </Card.Header>
+                <Card.Body style={{ height: '32vh', minHeight: 260 }}>
+                  {healthTrendRows.some((row) => row.caloriesKcal != null || row.proteinG != null || row.fatG != null || row.carbsG != null) ? (
+                    <Line data={nutritionChartData as any} options={nutritionChartOptions as any} />
+                  ) : (
+                    <div className="text-muted small">No nutrition trend data yet.</div>
+                  )}
+                </Card.Body>
+              </Card>
+            </Col>
+          </Row>
+        </>
+      )}
 
       <Card className="mb-3">
         <Card.Header>

--- a/react-app/src/components/checkins/CheckInDaily.tsx
+++ b/react-app/src/components/checkins/CheckInDaily.tsx
@@ -11,10 +11,6 @@ import { ActivityStreamService } from '../../services/ActivityStreamService';
 import type { Goal, Story, Task } from '../../types';
 import EditTaskModal from '../EditTaskModal';
 import EditStoryModal from '../EditStoryModal';
-import { getSourceFreshnessLabel, isFreshTimestamp } from '../../utils/kpiFreshness';
-import { upsertMetricValue, toPeriodKey } from '../../utils/metricValues';
-import { persistResolvedGoalKpisForOwner } from '../../utils/kpiResolver';
-import { getGoalDisplayPath, resolveLeafGoalSelection } from '../../utils/goalHierarchy';
 
 type CheckInItemType = 'block' | 'instance' | 'habit' | 'task' | 'chore' | 'routine';
 
@@ -66,9 +62,6 @@ const DAY_FORMAT = 'yyyyMMdd';
 interface HealthSnapshot {
   // source flags
   healthkitStatus?: string;
-  healthkitLastSyncAt?: any;
-  healthDataSource?: string;
-  updatedAt?: any;
   // steps
   healthkitStepsToday?: number;
   healthkitStepGoal?: number;
@@ -124,10 +117,15 @@ function getDefaultDate(): Date {
   return new Date().getHours() < 20 ? getYesterday() : new Date();
 }
 
-const CheckInDaily: React.FC = () => {
+interface CheckInDailyProps {
+  embedded?: boolean;
+  fixedDate?: Date;
+}
+
+const CheckInDaily: React.FC<CheckInDailyProps> = ({ embedded = false, fixedDate }) => {
   const { currentUser } = useAuth();
   const { currentPersona } = usePersona();
-  const [date, setDate] = useState<Date>(getDefaultDate);
+  const [date, setDate] = useState<Date>(() => fixedDate || getDefaultDate());
   const [yesterdayWarning, setYesterdayWarning] = useState<string | null>(null);
   const [items, setItems] = useState<DailyCheckInItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -155,27 +153,6 @@ const CheckInDaily: React.FC = () => {
   const [quickEditTask, setQuickEditTask] = useState<Task | null>(null);
   const [quickEditStory, setQuickEditStory] = useState<Story | null>(null);
   const [goals, setGoals] = useState<Goal[]>([]);
-  const goalTitlesById = useMemo(() => {
-    const next = new Map<string, string>();
-    goals.forEach((goal) => {
-      if (!goal?.id) return;
-      next.set(String(goal.id), getGoalDisplayPath(String(goal.id), goals));
-    });
-    return next;
-  }, [goals]);
-
-  const refreshGoalKpis = useCallback(async (goalIds?: string[]) => {
-    if (!currentUser?.uid || goals.length === 0) return;
-    try {
-      await persistResolvedGoalKpisForOwner({
-        ownerUid: currentUser.uid,
-        goals,
-        goalIds,
-      });
-    } catch (err) {
-      console.warn('Failed to refresh goal KPI metrics from check-in', err);
-    }
-  }, [currentUser?.uid, goals]);
 
   const getEffectiveType = (item: DailyCheckInItem): string => String(item.taskType || item.sourceType || item.type || '').toLowerCase();
 
@@ -247,6 +224,12 @@ const CheckInDaily: React.FC = () => {
   const dateKey = useMemo(() => format(date, DAY_FORMAT), [date]);
   const dayStart = useMemo(() => startOfDay(date), [date]);
   const dayEnd = useMemo(() => endOfDay(date), [date]);
+
+  useEffect(() => {
+    if (fixedDate) {
+      setDate(fixedDate);
+    }
+  }, [fixedDate]);
 
   useEffect(() => {
     if (!currentUser?.uid) {
@@ -373,15 +356,6 @@ const CheckInDaily: React.FC = () => {
   const effectiveCarbs = health.healthkitCarbsTodayG ?? health.manualCarbsG;
   const effectiveWeightKg = health.healthkitWeightKg ?? health.manualWeightKg;
   const effectiveBodyFatPct = health.healthkitBodyFatPct ?? health.manualBodyFatPct;
-  const automatedHealthTimestamp = health.healthkitLastSyncAt || health.updatedAt || null;
-  const manualHealthTimestamp = health.healthDataSource === 'manual' ? (health.updatedAt || null) : null;
-  const staleAutomatedHealth = health.healthkitStatus === 'synced' && !isFreshTimestamp(automatedHealthTimestamp, 24);
-  const healthFreshnessLabel = getSourceFreshnessLabel({
-    source: 'healthkit',
-    automatedTimestamp: automatedHealthTimestamp,
-    manualObservedAt: manualHealthTimestamp,
-    freshnessWindowHours: 24,
-  });
 
   const saveHealthData = useCallback(async () => {
     if (!currentUser) return;
@@ -399,41 +373,12 @@ const CheckInDaily: React.FC = () => {
       if (manualInputs.weightKg) payload.manualWeightKg = parseFloat(manualInputs.weightKg);
       if (manualInputs.bodyFatPct) payload.manualBodyFatPct = parseFloat(manualInputs.bodyFatPct);
       await setDoc(doc(db, 'profiles', currentUser.uid), payload, { merge: true });
-      const observedAt = Date.now();
-      const periodKey = toPeriodKey('daily', new Date(observedAt));
-      const metricWrites: Array<Promise<unknown>> = [];
-      if (payload.manualSleepMinutes != null) {
-        metricWrites.push(upsertMetricValue({ ownerUid: currentUser.uid, metricKey: 'healthkitSleepMinutes', source: 'user_input', observedAt, periodKey, value: Number(payload.manualSleepMinutes), unit: 'minutes', dataType: 'duration', isManual: true, staleAfterAt: observedAt + (24 * 60 * 60 * 1000) }));
-      }
-      if (payload.manualStepsToday != null) {
-        metricWrites.push(upsertMetricValue({ ownerUid: currentUser.uid, metricKey: 'healthkitStepsToday', source: 'user_input', observedAt, periodKey, value: Number(payload.manualStepsToday), unit: 'steps', dataType: 'count', isManual: true, staleAfterAt: observedAt + (24 * 60 * 60 * 1000) }));
-      }
-      if (payload.manualDistanceKmToday != null) {
-        metricWrites.push(upsertMetricValue({ ownerUid: currentUser.uid, metricKey: 'healthkitDistanceKmToday', source: 'user_input', observedAt, periodKey, value: Number(payload.manualDistanceKmToday), unit: 'km', dataType: 'number', isManual: true, staleAfterAt: observedAt + (24 * 60 * 60 * 1000) }));
-      }
-      if (payload.manualWorkoutMinutesToday != null) {
-        metricWrites.push(upsertMetricValue({ ownerUid: currentUser.uid, metricKey: 'healthkitWorkoutMinutesToday', source: 'user_input', observedAt, periodKey, value: Number(payload.manualWorkoutMinutesToday), unit: 'minutes', dataType: 'duration', isManual: true, staleAfterAt: observedAt + (24 * 60 * 60 * 1000) }));
-      }
-      if (payload.manualCaloriesKcal != null) {
-        metricWrites.push(upsertMetricValue({ ownerUid: currentUser.uid, metricKey: 'healthkitCaloriesTodayKcal', source: 'user_input', observedAt, periodKey, value: Number(payload.manualCaloriesKcal), unit: 'kcal', dataType: 'number', isManual: true, staleAfterAt: observedAt + (24 * 60 * 60 * 1000) }));
-      }
-      if (payload.manualProteinG != null) {
-        metricWrites.push(upsertMetricValue({ ownerUid: currentUser.uid, metricKey: 'healthkitProteinTodayG', source: 'user_input', observedAt, periodKey, value: Number(payload.manualProteinG), unit: 'g', dataType: 'number', isManual: true, staleAfterAt: observedAt + (24 * 60 * 60 * 1000) }));
-      }
-      if (payload.manualWeightKg != null) {
-        metricWrites.push(upsertMetricValue({ ownerUid: currentUser.uid, metricKey: 'healthkitWeightKg', source: 'user_input', observedAt, periodKey, value: Number(payload.manualWeightKg), unit: 'kg', dataType: 'number', isManual: true, staleAfterAt: observedAt + (24 * 60 * 60 * 1000) }));
-      }
-      if (payload.manualBodyFatPct != null) {
-        metricWrites.push(upsertMetricValue({ ownerUid: currentUser.uid, metricKey: 'healthkitBodyFatPct', source: 'user_input', observedAt, periodKey, value: Number(payload.manualBodyFatPct), unit: '%', dataType: 'percentage', isManual: true, staleAfterAt: observedAt + (24 * 60 * 60 * 1000) }));
-      }
-      await Promise.all(metricWrites);
       setHealth((prev) => ({ ...prev, ...payload }));
       setHealthSaved(true);
       setTimeout(() => setHealthSaved(false), 3000);
-      await refreshGoalKpis();
     } catch { /* non-fatal */ }
     finally { setHealthSaving(false); }
-  }, [currentUser, manualInputs, refreshGoalKpis]);
+  }, [currentUser, manualInputs]);
 
   // Auto-mark routine/habit items as done when health data covers them
   const autoMarkHealthRoutines = useCallback((snapshot: HealthSnapshot) => {
@@ -466,10 +411,6 @@ const CheckInDaily: React.FC = () => {
     setError(null);
     try {
       const ownerUid = currentUser.uid;
-      const normalizeExecutionGoalId = (value: any): string | null => {
-        const resolved = resolveLeafGoalSelection(String(value || '').trim(), goals);
-        return resolved.goalId || null;
-      };
       const blockQuery = query(
         collection(db, 'calendar_blocks'),
         where('ownerUid', '==', ownerUid),
@@ -593,8 +534,7 @@ const CheckInDaily: React.FC = () => {
         return false;
       });
       dueHabits.forEach((habit) => {
-        const linkedLeafGoalId = normalizeExecutionGoalId(habit.linkedGoalId);
-        if (linkedLeafGoalId) goalIds.add(linkedLeafGoalId);
+        if (habit.linkedGoalId) goalIds.add(String(habit.linkedGoalId));
       });
 
       const habitCompletionMap = new Map<string, { completed: boolean; completedAt: number | null }>();
@@ -633,8 +573,7 @@ const CheckInDaily: React.FC = () => {
       blocks.forEach((block) => {
         if (block.taskId) taskIds.add(String(block.taskId));
         if (block.storyId) storyIds.add(String(block.storyId));
-        const linkedLeafGoalId = normalizeExecutionGoalId(block.goalId);
-        if (linkedLeafGoalId) goalIds.add(linkedLeafGoalId);
+        if (block.goalId) goalIds.add(String(block.goalId));
       });
 
       const taskRefs = new Map<string, string>();
@@ -659,13 +598,12 @@ const CheckInDaily: React.FC = () => {
               status: data.status,
               completedAtMs,
               lastDoneAtMs,
-              goalId: normalizeExecutionGoalId(data.goalId),
+              goalId: data.goalId ? String(data.goalId) : null,
               type: data.type ? String(data.type) : null,
               completedBy,
               points: data.points != null ? Number(data.points) || null : null,
             });
-            const linkedLeafGoalId = normalizeExecutionGoalId(data.goalId);
-            if (linkedLeafGoalId) goalIds.add(linkedLeafGoalId);
+            if (data.goalId) goalIds.add(String(data.goalId));
           } catch (err) {
             if (isPermissionDenied(err)) {
               console.warn('CheckInDaily: task read denied', id);
@@ -682,11 +620,10 @@ const CheckInDaily: React.FC = () => {
             const ref = data.ref || data.reference || data.referenceNumber || data.code || id.slice(-6).toUpperCase();
             storyRefs.set(id, String(ref));
             storyMeta.set(id, {
-              goalId: normalizeExecutionGoalId(data.goalId),
+              goalId: data.goalId ? String(data.goalId) : null,
               points: data.points != null ? Number(data.points) || null : null,
             });
-            const linkedLeafGoalId = normalizeExecutionGoalId(data.goalId);
-            if (linkedLeafGoalId) goalIds.add(linkedLeafGoalId);
+            if (data.goalId) goalIds.add(String(data.goalId));
           } catch (err) {
             if (isPermissionDenied(err)) {
               console.warn('CheckInDaily: story read denied', id);
@@ -700,10 +637,6 @@ const CheckInDaily: React.FC = () => {
       const goalTitles = new Map<string, string>();
       await Promise.all(
         Array.from(goalIds).map(async (id) => {
-          if (goalTitlesById.has(id)) {
-            goalTitles.set(id, goalTitlesById.get(id) || id);
-            return;
-          }
           try {
             const snap = await getDoc(doc(db, 'goals', id));
             if (!snap.exists()) return;
@@ -735,10 +668,9 @@ const CheckInDaily: React.FC = () => {
         const taskId = block.taskId ? String(block.taskId) : null;
         const taskInfo = taskId ? taskMeta.get(taskId) : null;
         const storyInfo = storyId ? storyMeta.get(storyId) : null;
-        const goalId = normalizeExecutionGoalId(block.goalId)
-          || taskInfo?.goalId
-          || storyInfo?.goalId
-          || null;
+        const goalId = block.goalId
+          ? String(block.goalId)
+          : (taskInfo?.goalId || storyInfo?.goalId || null);
         const goalTitle = goalId ? goalTitles.get(goalId) || null : null;
         const completedFromTask = taskInfo ? (isTaskDone(taskInfo.status) && wasCompletedToday(taskInfo.completedAtMs)) : false;
         const completedBy = completedFromTask ? (taskInfo?.completedBy || 'auto') : null;
@@ -814,8 +746,8 @@ const CheckInDaily: React.FC = () => {
           end,
           durationMin: start && end ? Math.round((end - start) / 60000) : null,
           habitId: habit.id,
-          goalId: normalizeExecutionGoalId(habit.linkedGoalId),
-          goalTitle: normalizeExecutionGoalId(habit.linkedGoalId) ? goalTitles.get(String(normalizeExecutionGoalId(habit.linkedGoalId))) || null : null,
+          goalId: habit.linkedGoalId || null,
+          goalTitle: habit.linkedGoalId ? goalTitles.get(String(habit.linkedGoalId)) || null : null,
           completed: habitState.completed,
           completedAt: habitState.completedAt,
           completedBy: habitState.completed ? 'user' : null,
@@ -906,8 +838,7 @@ const CheckInDaily: React.FC = () => {
         })
         .filter((task) => isRecurringDueToday(task));
       recurringTasks.forEach((task) => {
-        const linkedLeafGoalId = normalizeExecutionGoalId(task.goalId);
-        if (linkedLeafGoalId) goalIds.add(linkedLeafGoalId);
+        if (task.goalId) goalIds.add(String(task.goalId));
       });
 
       const missingGoalIds = Array.from(goalIds).filter((id) => !goalTitles.has(id));
@@ -953,8 +884,8 @@ const CheckInDaily: React.FC = () => {
           durationMin: start && end ? Math.round((end - start) / 60000) : null,
           taskId: task.id,
           taskRef: ref,
-          goalId: normalizeExecutionGoalId(task.goalId),
-          goalTitle: normalizeExecutionGoalId(task.goalId) ? goalTitles.get(String(normalizeExecutionGoalId(task.goalId))) || null : null,
+          goalId: task.goalId || null,
+          goalTitle: task.goalId ? goalTitles.get(String(task.goalId)) || null : null,
           taskType: task.type || null,
           completed,
           completedAt: completedAtMs,
@@ -1002,7 +933,7 @@ const CheckInDaily: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [currentUser, currentPersona, dateKey, dayEnd, dayStart, goalTitlesById, goals, hydrateLastComments]);
+  }, [currentUser, currentPersona, dateKey, dayEnd, dayStart, hydrateLastComments]);
 
   useEffect(() => {
     loadPlannedItems();
@@ -1063,10 +994,7 @@ const CheckInDaily: React.FC = () => {
         }
       }
     }
-    if (item.goalId) {
-      void refreshGoalKpis([item.goalId]);
-    }
-  }, [dateKey, dayStart, currentUser, refreshGoalKpis]);
+  }, [dateKey, dayStart, currentUser]);
 
   const handleNoteChange = useCallback((key: string, note: string) => {
     setItems((prev) =>
@@ -1217,20 +1145,6 @@ const CheckInDaily: React.FC = () => {
         });
       await Promise.all(progressWrites);
 
-      const changedGoalIds = new Set<string>();
-      itemsWithMeta.forEach((item) => {
-        const prev = prevMap.get(item.key);
-        const completedChanged = item.completed !== prev?.completed;
-        const progressChanged = (item.progressPct ?? null) !== (prev?.progressPct ?? null);
-        const noteChanged = (item.note || '') !== (prev?.note || '');
-        if ((completedChanged || progressChanged || noteChanged) && item.goalId) {
-          changedGoalIds.add(String(item.goalId));
-        }
-      });
-      if (changedGoalIds.size > 0) {
-        await refreshGoalKpis(Array.from(changedGoalIds));
-      }
-
       setItems(itemsWithMeta);
       initialItemsRef.current = new Map(itemsWithMeta.map((item) => [item.key, item]));
     } catch (err) {
@@ -1252,27 +1166,9 @@ const CheckInDaily: React.FC = () => {
       if (!prev) return;
       if ((item.note || '') !== (prev.note || '')) keys.add(item.key);
       if ((item.progressPct ?? null) !== (prev.progressPct ?? null)) keys.add(item.key);
-      if (item.completed !== prev.completed) keys.add(item.key);
     });
     return keys;
   }, [items]);
-
-  useEffect(() => {
-    if (loading || saving || dirtyKeys.size === 0) return;
-    const timer = window.setTimeout(() => {
-      void handleSave();
-    }, 700);
-    return () => window.clearTimeout(timer);
-  }, [dirtyKeys, handleSave, loading, saving]);
-
-  useEffect(() => {
-    const hasManualInput = Object.values(manualInputs).some((value) => String(value || '').trim().length > 0);
-    if (!hasManualInput || healthSaving) return;
-    const timer = window.setTimeout(() => {
-      void saveHealthData();
-    }, 700);
-    return () => window.clearTimeout(timer);
-  }, [healthSaving, manualInputs, saveHealthData]);
 
   const refreshComments = useCallback(async () => {
     setRefreshingComments(true);
@@ -1528,15 +1424,17 @@ const CheckInDaily: React.FC = () => {
   };
 
   return (
-    <div className="p-3">
-      <h3 className="mb-3">Daily Check-in</h3>
+    <div className={embedded ? 'p-0' : 'p-3'}>
+      {!embedded && <h3 className="mb-3">Daily Check-in</h3>}
       <div className="d-flex flex-wrap gap-2 align-items-center mb-3">
-        <Form.Control
-          type="date"
-          value={format(date, 'yyyy-MM-dd')}
-          onChange={(e) => setDate(new Date(e.target.value))}
-          style={{ maxWidth: 200 }}
-        />
+        {!fixedDate && (
+          <Form.Control
+            type="date"
+            value={format(date, 'yyyy-MM-dd')}
+            onChange={(e) => setDate(new Date(e.target.value))}
+            style={{ maxWidth: 200 }}
+          />
+        )}
         <Badge bg={completedCount === items.length && items.length > 0 ? 'success' : 'secondary'}>
           {completedCount}/{items.length} done
         </Badge>
@@ -1574,14 +1472,14 @@ const CheckInDaily: React.FC = () => {
           {refreshingComments ? <Spinner size="sm" animation="border" /> : '↺ Comments'}
         </Button>
         <Button variant="primary" onClick={handleSave} disabled={saving || loading} className="ms-auto">
-          {saving ? 'Saving…' : 'Sync now'}
+          {saving ? 'Saving…' : 'Submit check-in'}
         </Button>
       </div>
 
       {yesterdayWarning && (
         <Alert variant="danger" dismissible onClose={() => setYesterdayWarning(null)} className="mb-2">
           <strong>Incomplete check-in:</strong> {yesterdayWarning}
-          {format(date, DAY_FORMAT) !== format(getYesterday(), DAY_FORMAT) && (
+          {!fixedDate && format(date, DAY_FORMAT) !== format(getYesterday(), DAY_FORMAT) && (
             <Button
               size="sm"
               variant="outline-danger"
@@ -1600,15 +1498,10 @@ const CheckInDaily: React.FC = () => {
         <Card.Header className="py-2 d-flex justify-content-between align-items-center">
           <span className="fw-semibold small">Today's Health Data</span>
           <span className="text-muted small">
-            {healthFreshnessLabel}
+            {health.healthkitStatus === 'synced' ? '● HealthKit synced' : 'Manual entry'}
           </span>
         </Card.Header>
         <Card.Body className="py-2">
-          {staleAutomatedHealth && (
-            <Alert variant="warning" className="mb-2 py-2">
-              Stale Data: the latest automated health sync is older than 24 hours. Manual entries will be used for today where available.
-            </Alert>
-          )}
           <Row className="g-2">
             {/* Sleep */}
             <Col xs={6} md={4} xl={2}>

--- a/react-app/src/components/checkins/CheckInWeekly.tsx
+++ b/react-app/src/components/checkins/CheckInWeekly.tsx
@@ -8,6 +8,8 @@ import { db } from '../../firebase';
 import { useAuth } from '../../contexts/AuthContext';
 import type { FocusGoal, Goal } from '../../types';
 import { getGoalDisplayPath, getProtectedFocusGoalIds, isGoalInHierarchySet } from '../../utils/goalHierarchy';
+import { getKpiHealthRollupLabel, getKpiStateBadge } from '../../utils/kpiDisplay';
+import WeeklyPlannerSurface from '../planner/WeeklyPlannerSurface';
 
 interface GoalMetricDoc {
   goalId: string;
@@ -95,6 +97,7 @@ const toNumber = (value: any): number | null => {
 const CheckInWeekly: React.FC = () => {
   const { currentUser } = useAuth();
   const navigate = useNavigate();
+  const [mode, setMode] = useState<'reflect' | 'plan'>('reflect');
   const [weekStart, setWeekStart] = useState<Date>(() =>
     startOfWeek(addDays(new Date(), -7), { weekStartsOn: 1 }),
   );
@@ -143,11 +146,10 @@ const CheckInWeekly: React.FC = () => {
 
   const weekEnd = useMemo(() => endOfWeek(weekStart, { weekStartsOn: 1 }), [weekStart]);
   const weekKey = useMemo(() => format(weekStart, WEEK_FORMAT), [weekStart]);
-
-  const formatKpiHealthLabel = useCallback((healthy: number, total: number) => {
-    if (total === 0) return 'No KPIs';
-    if (healthy === total) return `${healthy}/${total} healthy`;
-    return `${healthy}/${total} healthy`;
+  const planningWeekStart = useMemo(() => startOfWeek(addDays(weekStart, 7), { weekStartsOn: 1 }), [weekStart]);
+  const showPlanningPrompt = useMemo(() => {
+    const day = new Date().getDay();
+    return day === 0 || day === 1;
   }, []);
 
   const loadWeeklyData = useCallback(async () => {
@@ -553,10 +555,29 @@ const CheckInWeekly: React.FC = () => {
         <Badge bg="secondary" className="py-2 px-3">
           {format(weekStart, 'dd MMM')} – {format(weekEnd, 'dd MMM yyyy')}
         </Badge>
+        <div className="ms-auto d-flex gap-2">
+          <Button size="sm" variant={mode === 'reflect' ? 'primary' : 'outline-primary'} onClick={() => setMode('reflect')}>
+            Reflect
+          </Button>
+          <Button size="sm" variant={mode === 'plan' ? 'primary' : 'outline-primary'} onClick={() => setMode('plan')}>
+            Plan next week
+          </Button>
+        </div>
       </div>
 
+      {showPlanningPrompt && mode === 'reflect' && (
+        <Alert variant="warning" className="py-2 mb-3 d-flex align-items-center justify-content-between gap-2 flex-wrap">
+          <div className="small">
+            Finish your reflection, then switch to <strong>Plan next week</strong> to move items across the next 7 days and accept defer proposals.
+          </div>
+          <Button size="sm" variant="outline-dark" onClick={() => setMode('plan')}>
+            Open planner
+          </Button>
+        </Alert>
+      )}
+
       {/* Capacity plan review reminder */}
-      {!capacityReviewed && !loading && (
+      {!capacityReviewed && !loading && mode === 'reflect' && (
         <Alert variant="warning" className="d-flex justify-content-between align-items-center py-2 mb-3">
           <span className="small">
             <BarChart2 size={13} className="me-1" />
@@ -578,7 +599,14 @@ const CheckInWeekly: React.FC = () => {
       )}
 
       {error && <Alert variant="danger">{error}</Alert>}
-      {loading || !metrics ? (
+      {mode === 'plan' ? (
+        <WeeklyPlannerSurface
+          weekStart={planningWeekStart}
+          embedded
+          title={`Plan week of ${format(planningWeekStart, 'dd MMM yyyy')}`}
+          storageScope="weekly_checkin"
+        />
+      ) : loading || !metrics ? (
         <div className="d-flex align-items-center gap-2 text-muted">
           <Spinner size="sm" animation="border" /> Loading weekly metrics…
         </div>
@@ -631,7 +659,7 @@ const CheckInWeekly: React.FC = () => {
                           <div className="small text-muted mb-2">
                             {rootGoal.completedLeafGoals}/{rootGoal.leafCount} leaf goals complete
                             {' · '}
-                            {formatKpiHealthLabel(rootGoal.healthyKpis, rootGoal.totalKpis)}
+                            {getKpiHealthRollupLabel(rootGoal.healthyKpis, rootGoal.totalKpis, rootGoal.staleKpis)}
                           </div>
                           <ProgressBar now={Math.max(0, Math.min(100, rootGoal.avgCompletionPct))} style={{ height: 8 }} />
                           <div className="small text-muted mt-2">
@@ -659,7 +687,7 @@ const CheckInWeekly: React.FC = () => {
                                   {' · '}
                                   {leafGoal.totalMinutes} min
                                   {' · '}
-                                  {formatKpiHealthLabel(leafGoal.healthyKpis, leafGoal.totalKpis)}
+                                  {getKpiHealthRollupLabel(leafGoal.healthyKpis, leafGoal.totalKpis, leafGoal.staleKpis)}
                                 </div>
                               </div>
                               <Badge bg={leafGoal.completionPct >= 100 ? 'success' : leafGoal.completionPct >= 60 ? 'warning' : 'secondary'}>
@@ -674,14 +702,20 @@ const CheckInWeekly: React.FC = () => {
                             </div>
                             {leafGoal.topKpis.length > 0 && (
                               <div className="mt-2">
-                                {leafGoal.topKpis.map((kpi) => (
-                                  <div key={kpi.id} className="d-flex justify-content-between align-items-center small py-1">
-                                    <span className="text-truncate pe-2">{kpi.name}</span>
-                                    <span className={kpi.healthy ? 'text-success' : 'text-muted'}>
-                                      {kpi.currentDisplay}{kpi.progressPct != null ? ` · ${Math.round(kpi.progressPct)}%` : ''}
-                                    </span>
-                                  </div>
-                                ))}
+                                {leafGoal.topKpis.map((kpi) => {
+                                  const stateBadge = getKpiStateBadge(kpi.healthy, !kpi.healthy);
+                                  return (
+                                    <div key={kpi.id} className="d-flex justify-content-between align-items-center small py-1 gap-2">
+                                      <span className="text-truncate pe-2 d-inline-flex align-items-center gap-1">
+                                        <span>{kpi.name}</span>
+                                        <Badge bg={stateBadge.bg}>{stateBadge.label}</Badge>
+                                      </span>
+                                      <span className={kpi.healthy ? 'text-success' : 'text-muted'}>
+                                        {kpi.currentDisplay}{kpi.progressPct != null ? ` · ${Math.round(kpi.progressPct)}%` : ''}
+                                      </span>
+                                    </div>
+                                  );
+                                })}
                               </div>
                             )}
                           </div>

--- a/react-app/src/components/planner/DailyPlanSummaryCard.tsx
+++ b/react-app/src/components/planner/DailyPlanSummaryCard.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Alert, Badge, Button, Card, Spinner } from 'react-bootstrap';
+import { collection, doc, limit, onSnapshot, orderBy, query, where } from 'firebase/firestore';
+import { useNavigate } from 'react-router-dom';
+import { db } from '../../firebase';
+import { useAuth } from '../../contexts/AuthContext';
+import { usePersona } from '../../contexts/PersonaContext';
+import { useSprint } from '../../contexts/SprintContext';
+import { useFocusGoals } from '../../hooks/useFocusGoals';
+import type { Goal, Story, Task } from '../../types';
+import { getActiveFocusLeafGoalIds } from '../../utils/goalHierarchy';
+import { buildPlannerItems, type PlannerCalendarBlockRow, type PlannerScheduledInstanceRow } from '../../utils/plannerItems';
+
+const DailyPlanSummaryCard: React.FC = () => {
+  const { currentUser } = useAuth();
+  const { currentPersona } = usePersona();
+  const { selectedSprintId } = useSprint();
+  const { activeFocusGoals } = useFocusGoals(currentUser?.uid);
+  const navigate = useNavigate();
+
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [stories, setStories] = useState<Story[]>([]);
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [calendarBlocks, setCalendarBlocks] = useState<PlannerCalendarBlockRow[]>([]);
+  const [scheduledInstances, setScheduledInstances] = useState<PlannerScheduledInstanceRow[]>([]);
+  const [reviewDone, setReviewDone] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const todayStartMs = useMemo(() => {
+    const date = new Date();
+    date.setHours(0, 0, 0, 0);
+    return date.getTime();
+  }, []);
+  const todayEndMs = useMemo(() => todayStartMs + (24 * 60 * 60 * 1000) - 1, [todayStartMs]);
+  const todayIso = useMemo(() => new Date(todayStartMs).toISOString().slice(0, 10), [todayStartMs]);
+  const activeFocusGoalIds = useMemo(() => getActiveFocusLeafGoalIds(activeFocusGoals), [activeFocusGoals]);
+  const reviewStateId = useMemo(
+    () => (currentUser?.uid ? `${currentUser.uid}_${currentPersona || 'personal'}_${todayIso}` : null),
+    [currentUser?.uid, currentPersona, todayIso],
+  );
+
+  useEffect(() => {
+    if (!currentUser?.uid) {
+      setLoading(false);
+      return;
+    }
+    const taskQuery = query(collection(db, 'tasks'), where('ownerUid', '==', currentUser.uid), orderBy('updatedAt', 'desc'), limit(200));
+    const storyQuery = query(collection(db, 'stories'), where('ownerUid', '==', currentUser.uid), orderBy('updatedAt', 'desc'), limit(200));
+    const goalQuery = query(collection(db, 'goals'), where('ownerUid', '==', currentUser.uid));
+    const blockQuery = query(
+      collection(db, 'calendar_blocks'),
+      where('ownerUid', '==', currentUser.uid),
+      where('start', '>=', todayStartMs),
+      where('start', '<=', todayEndMs),
+    );
+    const instanceQuery = query(
+      collection(db, 'scheduled_instances'),
+      where('ownerUid', '==', currentUser.uid),
+      where('occurrenceDate', '==', todayIso),
+    );
+
+    const unsubTasks = onSnapshot(taskQuery, (snap) => {
+      let rows = snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Task[];
+      rows = rows.filter((task: any) => currentPersona === 'work' ? task.persona === 'work' : task.persona == null || task.persona === 'personal');
+      setTasks(rows);
+      setLoading(false);
+    }, (error) => {
+      console.warn('DailyPlanSummaryCard: tasks listener denied/failed', error?.message || error);
+      setTasks([]);
+      setLoading(false);
+    });
+    const unsubStories = onSnapshot(storyQuery, (snap) => {
+      let rows = snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Story[];
+      rows = rows.filter((story: any) => currentPersona === 'work' ? story.persona === 'work' : story.persona == null || story.persona === 'personal');
+      setStories(rows);
+    }, (error) => {
+      console.warn('DailyPlanSummaryCard: stories listener denied/failed', error?.message || error);
+      setStories([]);
+    });
+    const unsubGoals = onSnapshot(goalQuery, (snap) => {
+      setGoals(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Goal[]);
+    }, (error) => {
+      console.warn('DailyPlanSummaryCard: goals listener denied/failed', error?.message || error);
+      setGoals([]);
+    });
+    const unsubBlocks = onSnapshot(blockQuery, (snap) => {
+      setCalendarBlocks(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as PlannerCalendarBlockRow[]);
+    }, (error) => {
+      console.warn('DailyPlanSummaryCard: calendar_blocks listener denied/failed', error?.message || error);
+      setCalendarBlocks([]);
+    });
+    const unsubInstances = onSnapshot(instanceQuery, (snap) => {
+      setScheduledInstances(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as PlannerScheduledInstanceRow[]);
+    }, (error) => {
+      console.warn('DailyPlanSummaryCard: scheduled_instances listener denied/failed', error?.message || error);
+      setScheduledInstances([]);
+    });
+    const unsubReview = reviewStateId
+      ? onSnapshot(doc(db, 'daily_plan_state', reviewStateId), (snap) => {
+          const data = snap.data() as any;
+          setReviewDone(!!(data?.reviewCompletedAt || data?.reviewCompletedAtMs));
+        }, (error) => {
+          console.warn('DailyPlanSummaryCard: review state listener denied/failed', error?.message || error);
+          setReviewDone(false);
+        })
+      : () => undefined;
+
+    return () => {
+      unsubTasks();
+      unsubStories();
+      unsubGoals();
+      unsubBlocks();
+      unsubInstances();
+      unsubReview();
+    };
+  }, [currentUser?.uid, currentPersona, todayEndMs, todayIso, todayStartMs, reviewStateId]);
+
+  const plannerItems = useMemo(
+    () =>
+      buildPlannerItems({
+        tasks,
+        stories,
+        goals,
+        calendarBlocks,
+        scheduledInstances,
+        activeFocusGoalIds,
+        rangeStartMs: todayStartMs,
+        rangeEndMs: todayEndMs,
+        selectedSprintId,
+        includeUnscheduledTasks: true,
+      }).filter((item) => item.kind !== 'event'),
+    [tasks, stories, goals, calendarBlocks, scheduledInstances, activeFocusGoalIds, todayStartMs, todayEndMs, selectedSprintId],
+  );
+
+  const summary = useMemo(() => {
+    const openItems = plannerItems.length;
+    const reviewItems = plannerItems.filter(
+      (item) =>
+        (item.kind === 'task' || item.kind === 'story')
+        && !item.isTop3
+        && !item.isFocusAligned
+        && !(item.deferredUntilMs && item.deferredUntilMs > Date.now()),
+    ).length;
+    const overdue = plannerItems.filter((item) => item.dueAt != null && item.dueAt < Date.now()).length;
+    const focusItems = plannerItems.filter((item) => item.isFocusAligned).length;
+    return { openItems, reviewItems, overdue, focusItems };
+  }, [plannerItems]);
+
+  const urgency = reviewDone
+    ? 'Morning review completed'
+    : summary.reviewItems > 0
+    ? 'Review queue waiting'
+    : summary.overdue > 0
+      ? 'Overdue items need attention'
+      : summary.focusItems === 0
+        ? 'Top 3 not scheduled'
+        : 'Daily plan is ready';
+
+  return (
+    <Card className="shadow-sm border-0 h-100">
+        <Card.Header className="d-flex align-items-center justify-content-between">
+        <div className="fw-semibold">Daily Plan</div>
+        <Badge
+          bg={!reviewDone && summary.reviewItems > 0 ? 'warning' : summary.openItems > 0 ? 'info' : 'secondary'}
+          text={!reviewDone && summary.reviewItems > 0 ? 'dark' : undefined}
+          pill
+        >
+          {!reviewDone && summary.reviewItems > 0 ? summary.reviewItems : summary.openItems}
+        </Badge>
+      </Card.Header>
+      <Card.Body>
+        {loading ? (
+          <div className="d-flex align-items-center gap-2 text-muted small">
+            <Spinner size="sm" animation="border" /> Loading today…
+          </div>
+        ) : (
+          <>
+            <Alert variant={!reviewDone && (summary.reviewItems > 0 || summary.overdue > 0) ? 'warning' : 'light'} className="py-2 px-3">
+              <div className="fw-semibold">{urgency}</div>
+              <div className="small text-muted mt-1">
+                {!reviewDone && summary.reviewItems > 0
+                  ? `${summary.reviewItems} review ${summary.reviewItems === 1 ? 'item' : 'items'} waiting · ${summary.openItems} open · ${summary.overdue} overdue · ${summary.focusItems} focus aligned`
+                  : `${summary.openItems} open · ${summary.reviewItems} review · ${summary.overdue} overdue · ${summary.focusItems} focus aligned`}
+              </div>
+            </Alert>
+            <div className="d-flex flex-wrap gap-2 mb-3">
+              <Badge bg="secondary">Open {summary.openItems}</Badge>
+              <Badge bg={reviewDone ? 'secondary' : 'warning'} text={reviewDone ? undefined : 'dark'}>
+                {reviewDone ? 'Reviewed' : 'Review'} {summary.reviewItems}
+              </Badge>
+              <Badge bg="danger">Overdue {summary.overdue}</Badge>
+              <Badge bg="success">Focus {summary.focusItems}</Badge>
+            </div>
+            <Button size="sm" variant="primary" onClick={() => navigate('/daily-plan')}>
+              Open Daily Plan
+            </Button>
+          </>
+        )}
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default DailyPlanSummaryCard;

--- a/react-app/src/components/planner/PlannerCapacityBanner.tsx
+++ b/react-app/src/components/planner/PlannerCapacityBanner.tsx
@@ -476,9 +476,9 @@ const PlannerCapacityBanner: React.FC = () => {
             <ArrowRightLeft size={14} className="me-1" />
             Priority matrix
           </Button>
-          <Button size="sm" variant="outline-dark" onClick={() => navigate('/calendar/planner')}>
+          <Button size="sm" variant="outline-dark" onClick={() => navigate('/planner/sprint-capacity')}>
             <Settings2 size={14} className="me-1" />
-            Weekly planner
+            Sprint capacity plan
           </Button>
           <Button size="sm" variant="outline-dark" onClick={() => navigate('/calendar')}>
             <CalendarClock size={14} className="me-1" />

--- a/react-app/src/components/planner/PlannerWorkCard.tsx
+++ b/react-app/src/components/planner/PlannerWorkCard.tsx
@@ -1,0 +1,460 @@
+import React from 'react';
+import { Button, Card, Form } from 'react-bootstrap';
+import { Activity, CalendarClock, CalendarPlus, Check, ChevronDown, ChevronUp, Clock3, Edit3, MoveRight, Sparkles, Target } from 'lucide-react';
+import type { PlannerItem } from '../../utils/plannerItems';
+import { priorityLabel as formatPriorityLabel, priorityPillClass, storyStatusText, taskStatusText } from '../../utils/storyCardFormatting';
+import { getManualPriorityLabel } from '../../utils/manualPriority';
+import '../../styles/KanbanCards.css';
+
+type PlannerCardContext = 'daily' | 'weekly';
+
+interface PlannerCardRecommendation {
+  label: string;
+  rationale: string;
+}
+
+interface PlannerWorkCardProps {
+  item: PlannerItem;
+  context: PlannerCardContext;
+  isMobileLayout: boolean;
+  applyingKey?: string | null;
+  showDoneControl?: boolean;
+  doneAsCheckbox?: boolean;
+  showInlineRecommendation?: boolean;
+  recommendation?: PlannerCardRecommendation | null;
+  canEditState?: boolean;
+  canShowActions?: boolean;
+  expanded?: boolean;
+  onToggleExpanded?: (item: PlannerItem) => void;
+  onToggleDone?: (item: PlannerItem) => void;
+  onOpenActivity?: (item: PlannerItem) => void;
+  onOpenEditor?: (item: PlannerItem) => void;
+  onSchedule?: (item: PlannerItem) => void;
+  onMove?: (item: PlannerItem) => void;
+  onDefer?: (item: PlannerItem) => void;
+  onAcceptRecommendation?: (item: PlannerItem) => void;
+  onCycleStatus?: (item: PlannerItem) => void;
+  onCyclePriority?: (item: PlannerItem) => void;
+  onStatusChange?: (item: PlannerItem, nextStatus: number) => void;
+  onPriorityChange?: (item: PlannerItem, nextPriority: number) => void;
+}
+
+const normalizeAiScore = (value: any): number | null => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  if (numeric <= 1) return Math.round(numeric * 100);
+  return Math.round(numeric);
+};
+
+const formatDateChip = (value?: number | null) => {
+  if (!value) return null;
+  return new Date(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+};
+
+const buildChildMeta = (child: PlannerItem) => {
+  const parts = [child.ref, child.timeLabel].filter(Boolean);
+  return parts.join(' · ');
+};
+
+const PlannerWorkCard: React.FC<PlannerWorkCardProps> = ({
+  item,
+  context,
+  isMobileLayout,
+  applyingKey = null,
+  showDoneControl = true,
+  doneAsCheckbox = false,
+  showInlineRecommendation = false,
+  recommendation = null,
+  canEditState = true,
+  canShowActions = true,
+  expanded = false,
+  onToggleExpanded,
+  onToggleDone,
+  onOpenActivity,
+  onOpenEditor,
+  onSchedule,
+  onMove,
+  onDefer,
+  onAcceptRecommendation,
+  onCycleStatus,
+  onCyclePriority,
+  onStatusChange,
+  onPriorityChange,
+}) => {
+  const isEvent = item.kind === 'event';
+  const isGroup = Array.isArray(item.childItems) && item.childItems.length > 0;
+  const itemKindLabel = item.kind === 'story' ? 'Story' : item.kind === 'chore' ? (isGroup ? 'Chore block' : 'Chore') : item.kind === 'event' ? 'Event' : 'Task';
+  const choiceTable = item.rawStory ? 'story' : 'task';
+  const statusValue = item.rawStory ? Number((item.rawStory as any)?.status ?? 0) : Number((item.rawTask as any)?.status ?? 0);
+  const priorityValue = Number((item.rawTask as any)?.priority ?? (item.rawStory as any)?.priority ?? 0);
+  const statusLabel = item.kind === 'event'
+    ? 'Event'
+    : choiceTable === 'story'
+      ? storyStatusText(statusValue)
+      : taskStatusText(statusValue);
+  const priorityLabel = formatPriorityLabel(priorityValue, 'No priority');
+  const manualPriorityLabel = getManualPriorityLabel(item.rawStory || item.rawTask);
+  const aiScore = normalizeAiScore(
+    (item.rawTask as any)?.aiCriticalityScore
+    ?? (item.rawTask as any)?.metadata?.aiScore
+    ?? (item.rawTask as any)?.metadata?.aiCriticalityScore
+    ?? (item.rawStory as any)?.metadata?.aiScore
+    ?? (item.rawStory as any)?.metadata?.aiCriticalityScore
+    ?? (item.rawStory as any)?.aiCriticalityScore
+    ?? null,
+  );
+  const dueValue = formatDateChip(item.dueAt);
+  const deferredLabel = item.deferredUntilMs
+    ? `Deferred to ${new Date(item.deferredUntilMs).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`
+    : null;
+  const scheduledBlockLabel = (() => {
+    if (!item.timeLabel) return null;
+    if (item.scheduledBlockStart && item.scheduledBlockEnd) {
+      const start = new Date(item.scheduledBlockStart);
+      const end = new Date(item.scheduledBlockEnd);
+      const dayLabel = start.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
+      const timeLabel = `${start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}-${end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+      return `Planned ${dayLabel} ${timeLabel}`;
+    }
+    if (item.scheduledBlockStart) {
+      const start = new Date(item.scheduledBlockStart);
+      const dayLabel = start.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
+      const timeLabel = start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      return `Planned ${dayLabel} ${timeLabel}`;
+    }
+    return item.timeLabel;
+  })();
+  const scheduledSourceClassName = String(item.scheduledSourceLabel || '').toLowerCase().includes('gcal')
+    ? 'kanban-card__source-note kanban-card__source-note--quiet'
+    : 'kanban-card__source-note';
+  const pointsValue = Number((item.rawTask as any)?.points ?? (item.rawStory as any)?.points ?? 0);
+  const actionButtons = canShowActions && !isEvent;
+  const color = item.kind === 'story' ? '#0dcaf0' : item.kind === 'chore' ? '#198754' : item.kind === 'event' ? '#6c757d' : '#0d6efd';
+
+  return (
+    <Card
+      key={item.id}
+      className="border shadow-sm"
+      style={{ borderLeft: `4px solid ${color}` }}
+    >
+      <Card.Body className={isMobileLayout ? 'p-2' : context === 'weekly' ? 'p-2' : 'p-3'}>
+        <div className="d-flex align-items-start gap-2">
+          {showDoneControl && !isEvent && !isGroup && onToggleDone && (
+            doneAsCheckbox ? (
+              <Form.Check
+                type="checkbox"
+                checked={false}
+                disabled={applyingKey === item.id}
+                onChange={() => onToggleDone(item)}
+                className="mt-1"
+              />
+            ) : (
+              <Button
+                size="sm"
+                variant="outline-success"
+                className="rounded-circle d-inline-flex align-items-center justify-content-center p-1 mt-1 flex-shrink-0"
+                onClick={() => onToggleDone(item)}
+                disabled={applyingKey === item.id}
+              >
+                <Check size={14} />
+              </Button>
+            )
+          )}
+
+          <div className="flex-grow-1 min-w-0">
+            <div className={`d-flex ${isMobileLayout ? 'flex-column' : 'align-items-start justify-content-between'} gap-2`}>
+              <div className="min-w-0">
+                <div className="fw-semibold small kanban-card__title mb-1" style={{ lineHeight: 1.25 }}>
+                    {item.title}
+                </div>
+                <div className="kanban-card__meta">
+                  {!isEvent && !isGroup && canEditState && (
+                    onPriorityChange ? (
+                      <Form.Select
+                        size="sm"
+                        aria-label="Priority"
+                        value={priorityValue}
+                        onChange={(event) => onPriorityChange(item, Number(event.target.value))}
+                        className={priorityPillClass(priorityValue > 0 ? priorityValue : null)}
+                        style={{ minWidth: isMobileLayout ? 110 : 120, backgroundClip: 'padding-box' }}
+                      >
+                        <option value={0}>No priority</option>
+                        <option value={1}>Low</option>
+                        <option value={2}>Medium</option>
+                        <option value={3}>High</option>
+                        <option value={4}>Critical</option>
+                      </Form.Select>
+                    ) : onCyclePriority ? (
+                      <button
+                        type="button"
+                        className={priorityPillClass(priorityValue > 0 ? priorityValue : null)}
+                        style={{ appearance: 'none', backgroundClip: 'padding-box', cursor: 'pointer' }}
+                        onClick={() => onCyclePriority(item)}
+                        title="Tap to cycle priority"
+                      >
+                        {priorityLabel}
+                      </button>
+                    ) : null
+                  )}
+                  {manualPriorityLabel && (
+                    <span
+                      className="kanban-card__meta-badge"
+                      style={{
+                        borderColor: 'rgba(220, 53, 69, 0.45)',
+                        backgroundColor: 'rgba(220, 53, 69, 0.12)',
+                        color: 'var(--bs-danger)',
+                      }}
+                      title="Manual priority"
+                    >
+                      {manualPriorityLabel}
+                    </span>
+                  )}
+                  {item.isTop3 && (
+                    <span className="kanban-card__meta-badge kanban-card__meta-badge--top3" title="Top 3 priority">
+                      Top 3
+                    </span>
+                  )}
+                  {isGroup && (
+                    <span className="kanban-card__meta-badge" title="Grouped recurring items">
+                      {item.childItems!.length} items
+                    </span>
+                  )}
+                  {pointsValue > 0 && (
+                    <span className="kanban-card__meta-badge" title="Estimated points">
+                      {pointsValue} pts
+                    </span>
+                  )}
+                  {item.progressPct != null && (item.kind === 'task' || item.kind === 'story') && (
+                    <span className="kanban-card__meta-badge" title="Progress">
+                      Progress {Math.round(item.progressPct)}%
+                    </span>
+                  )}
+                  {scheduledBlockLabel && (
+                    <span className="d-inline-flex flex-column" style={{ lineHeight: 1.2 }}>
+                      <span
+                        className="kanban-card__meta-badge"
+                        style={{
+                          borderColor: 'rgba(37, 99, 235, 0.45)',
+                          backgroundColor: 'rgba(37, 99, 235, 0.12)',
+                          color: '#2563eb',
+                        }}
+                        title={scheduledBlockLabel}
+                      >
+                        <CalendarClock size={11} style={{ marginRight: 4, marginTop: -1 }} />
+                        {scheduledBlockLabel}
+                      </span>
+                      {item.scheduledSourceLabel && (
+                        <span className={scheduledSourceClassName} style={{ marginTop: 2 }}>
+                          {item.scheduledSourceLabel}
+                        </span>
+                      )}
+                    </span>
+                  )}
+                  {deferredLabel && (
+                    <span
+                      className="kanban-card__meta-badge"
+                      style={{
+                        borderColor: 'rgba(245, 158, 11, 0.45)',
+                        backgroundColor: 'rgba(245, 158, 11, 0.12)',
+                        color: '#b45309',
+                      }}
+                      title={deferredLabel}
+                    >
+                      <Clock3 size={11} style={{ marginRight: 4, marginTop: -1 }} />
+                      Deferred
+                    </span>
+                  )}
+                  {dueValue && (
+                    <span className="kanban-card__meta-badge" title={`Due ${dueValue}`}>
+                      Due {dueValue}
+                    </span>
+                  )}
+                  {item.isFocusAligned && (
+                    <span className="kanban-card__meta-badge" style={{ borderColor: 'rgba(22, 163, 74, 0.35)', color: '#15803d', backgroundColor: 'rgba(34, 197, 94, 0.1)' }}>
+                      Focus
+                    </span>
+                  )}
+                  {itemKindLabel && (
+                    <span className="kanban-card__meta-badge" title="Item type">
+                      {itemKindLabel}
+                    </span>
+                  )}
+                  {aiScore != null && (
+                    <span className="kanban-card__meta-badge" title="AI score">
+                      AI {aiScore}/100
+                    </span>
+                  )}
+                  {!isEvent && !isGroup && canEditState && onStatusChange ? (
+                    <Form.Select
+                      size="sm"
+                      aria-label="Status"
+                      value={statusValue}
+                      onChange={(event) => onStatusChange(item, Number(event.target.value))}
+                      className="dashboard-chip-select"
+                      style={{ minWidth: isMobileLayout ? 118 : 132 }}
+                    >
+                      {choiceTable === 'story' ? (
+                        <>
+                          <option value={0}>Backlog</option>
+                          <option value={1}>Ready</option>
+                          <option value={2}>In Progress</option>
+                          <option value={3}>Review</option>
+                          <option value={4}>Done</option>
+                        </>
+                      ) : (
+                        <>
+                          <option value={0}>To do</option>
+                          <option value={1}>Doing</option>
+                          <option value={2}>Done</option>
+                        </>
+                      )}
+                    </Form.Select>
+                  ) : (
+                    <span className="kanban-card__meta-text" title="Status">
+                      {statusLabel}
+                    </span>
+                  )}
+                </div>
+                <div className="text-muted kanban-card__description" style={{ fontSize: '0.74rem' }}>
+                  {[item.ref, !scheduledBlockLabel ? item.timeLabel : null].filter(Boolean).join(' · ')}
+                </div>
+                {item.goalTitle && (
+                  <div className="kanban-card__goal mt-1">
+                    <Target size={12} />
+                    <span style={{ overflowWrap: 'anywhere' }}>{item.goalTitle}</span>
+                  </div>
+                )}
+                {showInlineRecommendation && recommendation && (
+                  <div className="mt-2 small">
+                    <div className="fw-semibold d-inline-flex align-items-center gap-1"><Sparkles size={13} /> {recommendation.label}</div>
+                    <div className="text-muted">{recommendation.rationale}</div>
+                  </div>
+                )}
+                {isGroup && item.childItems && item.childItems.length > 0 && (
+                  <div className="mt-2">
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      className="rounded-pill py-0 px-2"
+                      onClick={() => onToggleExpanded?.(item)}
+                    >
+                      {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />} {expanded ? 'Hide items' : 'Show items'}
+                    </Button>
+                    {expanded && (
+                      <div className="mt-2 d-flex flex-column gap-2">
+                        {item.childItems.map((child) => (
+                          <div key={child.id} className="border rounded px-2 py-1">
+                            <div className="d-flex align-items-start gap-2">
+                              {onToggleDone && (
+                                <Form.Check
+                                  type="checkbox"
+                                  checked={false}
+                                  disabled={applyingKey === child.id}
+                                  onChange={() => onToggleDone(child)}
+                                  className="mt-1"
+                                />
+                              )}
+                              <div className="min-w-0 flex-grow-1">
+                                <div className="fw-semibold small" style={{ overflowWrap: 'anywhere' }}>{child.title}</div>
+                                <div className="text-muted" style={{ fontSize: '0.72rem' }}>{buildChildMeta(child)}</div>
+                              </div>
+                              {onDefer && (
+                                <Button
+                                  size="sm"
+                                  variant="outline-warning"
+                                  className="p-1 d-inline-flex align-items-center justify-content-center"
+                                  onClick={() => onDefer(child)}
+                                >
+                                  <Clock3 size={14} />
+                                </Button>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {actionButtons && (
+                <div className="d-flex align-items-center gap-1 flex-wrap">
+                  {onOpenActivity && (item.rawTask || item.rawStory) && (
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      className={isMobileLayout ? 'px-2 py-1 d-inline-flex align-items-center justify-content-center' : 'p-1 d-inline-flex align-items-center justify-content-center'}
+                      onClick={() => onOpenActivity(item)}
+                    >
+                      <Activity size={14} className={isMobileLayout ? 'me-1' : undefined} />
+                      {isMobileLayout ? 'Note' : null}
+                    </Button>
+                  )}
+                  {onOpenEditor && (item.rawTask || item.rawStory) && (
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      className={isMobileLayout ? 'px-2 py-1 d-inline-flex align-items-center justify-content-center' : 'p-1 d-inline-flex align-items-center justify-content-center'}
+                      onClick={() => onOpenEditor(item)}
+                    >
+                      <Edit3 size={14} className={isMobileLayout ? 'me-1' : undefined} />
+                      {isMobileLayout ? 'Edit' : null}
+                    </Button>
+                  )}
+                  {onSchedule && !isGroup && (
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      className={isMobileLayout ? 'px-2 py-1 d-inline-flex align-items-center justify-content-center' : 'p-1 d-inline-flex align-items-center justify-content-center'}
+                      onClick={() => onSchedule(item)}
+                    >
+                      <CalendarPlus size={14} className={isMobileLayout ? 'me-1' : undefined} />
+                      {isMobileLayout ? 'Schedule' : null}
+                    </Button>
+                  )}
+                  {onMove && (
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      className={isMobileLayout ? 'px-2 py-1 d-inline-flex align-items-center justify-content-center' : 'p-1 d-inline-flex align-items-center justify-content-center'}
+                      onClick={() => onMove(item)}
+                    >
+                      <MoveRight size={14} className={isMobileLayout ? 'me-1' : undefined} />
+                      {isMobileLayout ? 'Move' : null}
+                    </Button>
+                  )}
+                  {showInlineRecommendation && recommendation && onAcceptRecommendation ? (
+                    <>
+                      <Button size="sm" variant="primary" disabled={applyingKey === item.id} onClick={() => onAcceptRecommendation(item)}>
+                        {applyingKey === item.id ? 'Applying…' : 'Accept'}
+                      </Button>
+                      {onDefer && !isGroup && (
+                        <Button size="sm" variant="outline-warning" onClick={() => onDefer(item)}>
+                          More
+                        </Button>
+                      )}
+                    </>
+                  ) : (
+                    onDefer && !isGroup && (
+                      <Button
+                        size="sm"
+                        variant="outline-warning"
+                        className={isMobileLayout ? 'px-2 py-1 d-inline-flex align-items-center justify-content-center' : 'p-1 d-inline-flex align-items-center justify-content-center'}
+                        onClick={() => onDefer(item)}
+                      >
+                        <Clock3 size={14} className={isMobileLayout ? 'me-1' : undefined} />
+                        {isMobileLayout ? 'Defer' : null}
+                      </Button>
+                    )
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default PlannerWorkCard;

--- a/react-app/src/components/planner/UnifiedPlannerPage.tsx
+++ b/react-app/src/components/planner/UnifiedPlannerPage.tsx
@@ -72,7 +72,6 @@ import { getBadgeVariant, getPriorityBadge, getStatusName } from '../../utils/st
 import { isRecurringDueOnDate, resolveRecurringDueMs } from '../../utils/recurringTaskDue';
 import EditTaskModal from '../EditTaskModal';
 import EditStoryModal from '../EditStoryModal';
-import NewCalendarEventModal, { BlockFormState, DEFAULT_BLOCK_FORM, toInputValue } from './NewCalendarEventModal';
 import DayCapacityWarningBanner from './DayCapacityWarningBanner';
 import { useSidebar } from '../../contexts/SidebarContext';
 
@@ -120,6 +119,49 @@ type ThemeOption = {
   textColor: string;
 };
 
+interface BlockFormState {
+  id?: string;
+  title: string;
+  theme?: CalendarBlock['theme'];
+  category?: CalendarBlock['category'];
+  flexibility?: CalendarBlock['flexibility'];
+  rationale: string;
+  start: string;
+  end: string;
+  syncToGoogle: boolean;
+  subTheme: string;
+  persona?: 'personal' | 'work' | null;
+  storyId?: string;
+  taskId?: string;
+  aiScore?: number | null;
+  aiReason?: string | null;
+  storyInput?: string;
+  recurrenceFreq: 'none' | 'daily' | 'weekly';
+  recurrenceDays: string[]; // BYDAY codes e.g. ['MO','WE']
+  recurrenceUntil: string; // date input string
+}
+
+const DEFAULT_BLOCK_FORM: BlockFormState = {
+  title: 'Calendar entry',
+  theme: 'General',
+  category: 'Wellbeing',
+  flexibility: 'soft',
+  rationale: '',
+  start: '',
+  end: '',
+  syncToGoogle: true,
+  subTheme: '',
+  persona: null,
+  storyId: undefined,
+  taskId: undefined,
+  aiScore: null,
+  aiReason: null,
+  storyInput: '',
+  recurrenceFreq: 'none',
+  recurrenceDays: [],
+  recurrenceUntil: '',
+};
+
 type ViewType = 'day' | 'week' | 'month';
 
 type PlanningMode = 'strict' | 'smart';
@@ -163,6 +205,8 @@ const getInitialRange = (): PlannerRange => {
   const end = addDays(start, 6);
   return { start, end };
 };
+
+const toInputValue = (date: Date) => format(date, "yyyy-MM-dd'T'HH:mm");
 
 const isTaskDoneState = (status: any): boolean => {
   if (typeof status === 'number') {
@@ -555,29 +599,6 @@ const UnifiedPlannerPage: React.FC = () => {
     return ref ? String(ref) : '';
   }, []);
 
-  const getPlannerEventSourceLabel = useCallback((event: PlannerCalendarEvent): 'auto-planned' | 'linked from gcal' | 'manual' => {
-    if (event.type === 'external') return 'linked from gcal';
-
-    const block: any = event.block || null;
-    const source = String(block?.source || '').toLowerCase();
-    const entryMethod = String(block?.entry_method || '').toLowerCase();
-    const hasGcalLink = !!(event.instance?.external?.gcalEventId || block?.googleEventId);
-
-    if (hasGcalLink || source === 'gcal' || entryMethod === 'google_calendar') {
-      return 'linked from gcal';
-    }
-    if (
-      entryMethod.includes('auto')
-      || source.includes('auto')
-      || source.includes('ai')
-      || source === 'planner'
-      || source === 'bob_auto'
-    ) {
-      return 'auto-planned';
-    }
-    return 'manual';
-  }, []);
-
   const unscheduledItems = useMemo(
     () => planner.instances.filter((instance) => instance.status === 'unscheduled'),
     [planner.instances],
@@ -816,118 +837,6 @@ const UnifiedPlannerPage: React.FC = () => {
     };
   }, [currentUser, currentPersona]);
 
-  useEffect(() => {
-    if (!currentUser || !currentPersona) {
-      setTop3Tasks([]);
-      setTop3Stories([]);
-      setTop3Loading(false);
-      return;
-    }
-    setTop3Loading(true);
-    const todayIso = new Date().toISOString().slice(0, 10);
-    let tasksReady = false;
-    let storiesReady = false;
-    const markReady = () => {
-      if (tasksReady && storiesReady) setTop3Loading(false);
-    };
-
-    const isTaskDone = (status: any) => {
-      if (typeof status === 'number') return status >= 2;
-      const s = String(status || '').toLowerCase();
-      return ['done', 'complete', 'completed', 'finished', 'closed'].includes(s);
-    };
-    const isStoryDone = (status: any) => {
-      if (typeof status === 'number') return status >= 4;
-      const s = String(status || '').toLowerCase();
-      return ['done', 'complete', 'completed', 'finished', 'closed'].includes(s);
-    };
-
-    const taskQuery = query(
-      collection(db, 'tasks'),
-      where('ownerUid', '==', currentUser.uid),
-      where('persona', '==', currentPersona),
-      where('aiTop3ForDay', '==', true),
-    );
-    const storyQuery = query(
-      collection(db, 'stories'),
-      where('ownerUid', '==', currentUser.uid),
-      where('persona', '==', currentPersona),
-      where('aiTop3ForDay', '==', true),
-    );
-
-    const unsubTasks = onSnapshot(
-      taskQuery,
-      (snap) => {
-        const rows = snap.docs
-          .map((doc) => ({ id: doc.id, ...(doc.data() as any) } as Task))
-          .filter((task) => !task.deleted)
-          .filter((task) => !isTaskDone(task.status))
-          .filter((task) => {
-            const aiDate = (task as any).aiTop3Date;
-            if (!aiDate) return true;
-            return String(aiDate).slice(0, 10) === todayIso;
-          })
-          .sort((a, b) => {
-            const ar = Number((a as any).aiPriorityRank || 0) || 99;
-            const br = Number((b as any).aiPriorityRank || 0) || 99;
-            if (ar !== br) return ar - br;
-            const as = Number((a as any).aiCriticalityScore ?? -1);
-            const bs = Number((b as any).aiCriticalityScore ?? -1);
-            if (as !== bs) return bs - as;
-            return String(a.title || '').localeCompare(String(b.title || ''));
-          })
-          .slice(0, 3);
-        setTop3Tasks(rows);
-        tasksReady = true;
-        markReady();
-      },
-      (err) => {
-        console.warn('Failed to load top 3 tasks', err);
-        setTop3Tasks([]);
-        tasksReady = true;
-        markReady();
-      },
-    );
-
-    const unsubStories = onSnapshot(
-      storyQuery,
-      (snap) => {
-        const rows = snap.docs
-          .map((doc) => ({ id: doc.id, ...(doc.data() as any) } as Story))
-          .filter((story) => !isStoryDone(story.status))
-          .filter((story) => {
-            const aiDate = (story as any).aiTop3Date;
-            if (!aiDate) return true;
-            return String(aiDate).slice(0, 10) === todayIso;
-          })
-          .sort((a, b) => {
-            const ar = Number((a as any).aiFocusStoryRank || 0) || 99;
-            const br = Number((b as any).aiFocusStoryRank || 0) || 99;
-            if (ar !== br) return ar - br;
-            const as = Number((a as any).aiCriticalityScore ?? -1);
-            const bs = Number((b as any).aiCriticalityScore ?? -1);
-            if (as !== bs) return bs - as;
-            return String(a.title || '').localeCompare(String(b.title || ''));
-          })
-          .slice(0, 3);
-        setTop3Stories(rows);
-        storiesReady = true;
-        markReady();
-      },
-      (err) => {
-        console.warn('Failed to load top 3 stories', err);
-        setTop3Stories([]);
-        storiesReady = true;
-        markReady();
-      },
-    );
-
-    return () => {
-      unsubTasks();
-      unsubStories();
-    };
-  }, [currentUser, currentPersona]);
-
   const topChores = useMemo(() => planner.chores.slice(0, 5), [planner.chores]);
   const topRoutines = useMemo(() => planner.routines.slice(0, 5), [planner.routines]);
 
@@ -937,6 +846,7 @@ const UnifiedPlannerPage: React.FC = () => {
       theme: blockDefaultTheme as CalendarBlock['theme'],
     });
     setComposerOpen(false);
+    setComposerSaving(false);
   }, [blockDefaultTheme]);
 
   const handleRangeChange = useCallback(
@@ -2558,14 +2468,6 @@ const UnifiedPlannerPage: React.FC = () => {
                 )}
                 {activeEvent.type === 'instance' && activeEvent.instance && (
                   <>
-                    <div className="text-muted small">
-                      Source{' '}
-                      {(() => {
-                        const sourceLabel = getPlannerEventSourceLabel(activeEvent);
-                        const variant = sourceLabel === 'auto-planned' ? 'success' : sourceLabel === 'linked from gcal' ? 'info' : 'secondary';
-                        return <Badge bg={variant}>{sourceLabel}</Badge>;
-                      })()}
-                    </div>
                     {['chore', 'routine', 'habit'].includes(
                       (activeEvent.instance.sourceType || '').toLowerCase(),
                     ) && (
@@ -2650,14 +2552,6 @@ const UnifiedPlannerPage: React.FC = () => {
                 )}
                 {activeEvent.type === 'block' && activeEvent.block && (
                   <>
-                    <div className="text-muted small">
-                      Source{' '}
-                      {(() => {
-                        const sourceLabel = getPlannerEventSourceLabel(activeEvent);
-                        const variant = sourceLabel === 'auto-planned' ? 'success' : sourceLabel === 'linked from gcal' ? 'info' : 'secondary';
-                        return <Badge bg={variant}>{sourceLabel}</Badge>;
-                      })()}
-                    </div>
                     <div className="text-muted small">
                       Theme{' '}
                       <Badge bg="light" text="dark">

--- a/react-app/src/components/planner/WeeklyPlannerPage.tsx
+++ b/react-app/src/components/planner/WeeklyPlannerPage.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Alert, Badge, Button, Card, Form } from 'react-bootstrap';
+import { addDays, addWeeks, format, startOfWeek } from 'date-fns';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useSprint } from '../../contexts/SprintContext';
+import WeeklyPlannerSurface from './WeeklyPlannerSurface';
+
+const WeeklyPlannerPage: React.FC = () => {
+  const { sprints, selectedSprintId } = useSprint();
+  const [weekStart, setWeekStart] = useState<Date>(() => startOfWeek(addDays(new Date(), 7), { weekStartsOn: 1 }));
+  const isPlanningPromptWeek = useMemo(() => {
+    const day = new Date().getDay();
+    return day === 0 || day === 1;
+  }, []);
+  const currentSprint = useMemo(() => {
+    const nowMs = Date.now();
+    const selected = sprints.find((sprint) => sprint.id === selectedSprintId);
+    if (selected) return selected;
+    const active = sprints.find((sprint) => {
+      const start = typeof sprint.startDate === 'number' ? sprint.startDate : 0;
+      const end = typeof sprint.endDate === 'number' ? sprint.endDate : 0;
+      return start > 0 && end > 0 && nowMs >= start && nowMs <= end;
+    });
+    if (active) return active;
+    return sprints[0] || null;
+  }, [selectedSprintId, sprints]);
+  const sprintWeekOptions = useMemo(() => {
+    if (!currentSprint?.startDate || !currentSprint?.endDate) return [];
+    const options: Array<{ key: string; start: Date; label: string }> = [];
+    let cursor = startOfWeek(new Date(currentSprint.startDate), { weekStartsOn: 1 });
+    const sprintEnd = new Date(currentSprint.endDate);
+    let index = 0;
+    while (cursor.getTime() <= sprintEnd.getTime()) {
+      options.push({
+        key: format(cursor, 'yyyy-MM-dd'),
+        start: cursor,
+        label: `Week ${index + 1}`,
+      });
+      cursor = addWeeks(cursor, 1);
+      index += 1;
+    }
+    return options;
+  }, [currentSprint]);
+  const sprintLabel = useMemo(() => {
+    if (!currentSprint) return 'Current sprint';
+    return String((currentSprint as any).name || (currentSprint as any).title || (currentSprint as any).label || 'Current sprint');
+  }, [currentSprint]);
+  const activeSprintWeekKey = format(weekStart, 'yyyy-MM-dd');
+
+  useEffect(() => {
+    if (!sprintWeekOptions.length) return;
+    const currentWeekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+    const currentWeekKey = format(currentWeekStart, 'yyyy-MM-dd');
+    const hasActiveWeek = sprintWeekOptions.some((option) => option.key === activeSprintWeekKey);
+    if (hasActiveWeek) return;
+    const currentSprintWeek = sprintWeekOptions.find((option) => option.key === currentWeekKey);
+    setWeekStart((currentSprintWeek || sprintWeekOptions[0]).start);
+  }, [activeSprintWeekKey, sprintWeekOptions]);
+
+  return (
+    <div className="p-3">
+      <div className="d-flex justify-content-between align-items-center gap-2 flex-wrap mb-3">
+        <div>
+          <h3 className="mb-1">Weekly Planner</h3>
+          <div className="text-muted small">Review story and task placement week by week and adjust the schedule without leaving the planner.</div>
+        </div>
+        <Badge bg="info">
+          {format(weekStart, 'dd MMM')} – {format(addDays(weekStart, 6), 'dd MMM yyyy')}
+        </Badge>
+      </div>
+
+      {isPlanningPromptWeek && (
+        <Alert variant="warning" className="py-2 d-flex align-items-center justify-content-between flex-wrap gap-2">
+          <div className="small">
+            Review the week ahead now so Daily Plan starts with realistic loads and clear defer decisions.
+          </div>
+          <Button size="sm" variant="outline-dark" onClick={() => setWeekStart(startOfWeek(addDays(new Date(), 7), { weekStartsOn: 1 }))}>
+            Jump to next week
+          </Button>
+        </Alert>
+      )}
+
+      <Card className="shadow-sm border-0 mb-3">
+        <Card.Body className="d-flex align-items-center gap-2 flex-wrap">
+          <Button size="sm" variant="outline-secondary" onClick={() => setWeekStart((prev) => startOfWeek(addDays(prev, -7), { weekStartsOn: 1 }))}>
+            <ChevronLeft size={14} />
+          </Button>
+          <Form.Control
+            type="date"
+            value={format(weekStart, 'yyyy-MM-dd')}
+            onChange={(e) => setWeekStart(startOfWeek(new Date(e.target.value), { weekStartsOn: 1 }))}
+            style={{ maxWidth: 180 }}
+          />
+          <Button size="sm" variant="outline-secondary" onClick={() => setWeekStart((prev) => startOfWeek(addDays(prev, 7), { weekStartsOn: 1 }))}>
+            <ChevronRight size={14} />
+          </Button>
+        </Card.Body>
+      </Card>
+
+      {sprintWeekOptions.length > 0 && (
+        <Card className="shadow-sm border-0 mb-3">
+          <Card.Body className="d-flex align-items-center justify-content-between gap-3 flex-wrap">
+            <div>
+              <div className="fw-semibold">{sprintLabel}</div>
+              <div className="text-muted small">Jump between sprint weeks and review capacity week by week.</div>
+            </div>
+            <div className="d-flex align-items-center gap-2 flex-wrap">
+              {sprintWeekOptions.map((option) => (
+                <Button
+                  key={option.key}
+                  size="sm"
+                  variant={option.key === activeSprintWeekKey ? 'primary' : 'outline-secondary'}
+                  onClick={() => setWeekStart(option.start)}
+                >
+                  {option.label}
+                </Button>
+              ))}
+            </div>
+          </Card.Body>
+        </Card>
+      )}
+
+      <WeeklyPlannerSurface weekStart={weekStart} title="Weekly Planner" />
+    </div>
+  );
+};
+
+export default WeeklyPlannerPage;

--- a/react-app/src/components/planner/WeeklyPlannerSummaryCard.tsx
+++ b/react-app/src/components/planner/WeeklyPlannerSummaryCard.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Alert, Badge, Button, Card, Spinner } from 'react-bootstrap';
+import { addDays, format, startOfWeek } from 'date-fns';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { useNavigate } from 'react-router-dom';
+import { db } from '../../firebase';
+import { useAuth } from '../../contexts/AuthContext';
+
+const WeeklyPlannerSummaryCard: React.FC = () => {
+  const { currentUser } = useAuth();
+  const navigate = useNavigate();
+  const [planningSummary, setPlanningSummary] = useState<{ acceptedMoves: number; acceptedDefers: number; completedAt?: any } | null>(null);
+
+  const weekStart = useMemo(() => startOfWeek(addDays(new Date(), 7), { weekStartsOn: 1 }), []);
+  const weekKey = useMemo(() => format(weekStart, "yyyy-'W'II"), [weekStart]);
+  const isPlanningPromptWeek = useMemo(() => {
+    const day = new Date().getDay();
+    return day === 0 || day === 1;
+  }, []);
+
+  useEffect(() => {
+    if (!currentUser?.uid) {
+      setPlanningSummary(null);
+      return;
+    }
+    return onSnapshot(doc(db, 'weekly_checkins', `${currentUser.uid}_${weekKey}`), (snap) => {
+      const data = snap.data() as any;
+      setPlanningSummary(data?.nextWeekPlanning || null);
+    });
+  }, [currentUser?.uid, weekKey]);
+
+  const statusLabel = planningSummary?.completedAt
+    ? 'Weekly plan reviewed'
+    : isPlanningPromptWeek
+      ? 'Weekly review due'
+      : 'Weekly plan available';
+
+  return (
+    <Card className="shadow-sm border-0 h-100">
+      <Card.Header className="d-flex align-items-center justify-content-between">
+        <div className="fw-semibold">Weekly Planner</div>
+        <Badge bg="info">
+          {format(weekStart, 'dd MMM')} – {format(addDays(weekStart, 6), 'dd MMM')}
+        </Badge>
+      </Card.Header>
+      <Card.Body>
+        {!currentUser?.uid ? (
+          <div className="d-flex align-items-center gap-2 text-muted small">
+            <Spinner size="sm" animation="border" /> Loading next week…
+          </div>
+        ) : (
+          <>
+            <Alert variant={planningSummary?.completedAt ? 'light' : 'warning'} className="py-2 px-3">
+              <div className="fw-semibold">{statusLabel}</div>
+              <div className="small text-muted mt-1">
+                {planningSummary?.completedAt
+                  ? `${Number(planningSummary.acceptedMoves || 0)} planned · ${Number(planningSummary.acceptedDefers || 0)} deferred`
+                  : 'Review the next 7 days from Overview before the week fills up.'}
+              </div>
+            </Alert>
+            <div className="d-flex flex-wrap gap-2 mb-3">
+              <Badge bg="secondary">Week {weekKey.split('W')[1]}</Badge>
+              <Badge bg="info">Planned {Number(planningSummary?.acceptedMoves || 0)}</Badge>
+              <Badge bg="warning" text="dark">Deferred {Number(planningSummary?.acceptedDefers || 0)}</Badge>
+            </div>
+            <Button size="sm" variant="outline-primary" onClick={() => navigate('/planner/weekly')}>
+              Open 7-day planner
+            </Button>
+          </>
+        )}
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default WeeklyPlannerSummaryCard;

--- a/react-app/src/components/planner/WeeklyPlannerSurface.tsx
+++ b/react-app/src/components/planner/WeeklyPlannerSurface.tsx
@@ -1,0 +1,1191 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Col,
+  Form,
+  Modal,
+  Row,
+  Spinner,
+  Table,
+} from 'react-bootstrap';
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+  where,
+} from 'firebase/firestore';
+import { addDays, format } from 'date-fns';
+import { Clock3, MoveRight, Sparkles } from 'lucide-react';
+import { db } from '../../firebase';
+import { useAuth } from '../../contexts/AuthContext';
+import { usePersona } from '../../contexts/PersonaContext';
+import { useSprint } from '../../contexts/SprintContext';
+import { useFocusGoals } from '../../hooks/useFocusGoals';
+import { useGlobalThemes } from '../../hooks/useGlobalThemes';
+import { GLOBAL_THEMES, type GlobalTheme } from '../../constants/globalThemes';
+import type { Goal, Sprint, Story, Task } from '../../types';
+import DeferItemModal from '../DeferItemModal';
+import PlannerWorkCard from './PlannerWorkCard';
+import {
+  buildPlannerItems,
+  type PlannerCalendarBlockRow,
+  type PlannerItem,
+  type PlannerScheduledInstanceRow,
+  toDayKey,
+} from '../../utils/plannerItems';
+import { bucketLabel, bucketOrder, type TimelineBucket } from '../../utils/timelineBuckets';
+import { getActiveFocusLeafGoalIds } from '../../utils/goalHierarchy';
+import { buildPlannerRecommendation, type PlannerRecommendation } from '../../utils/plannerRecommendations';
+import { buildDayCapacityMap, plannerItemPoints } from '../../utils/plannerCapacity';
+import { schedulePlannerItem as schedulePlannerItemMutation } from '../../utils/plannerScheduling';
+
+type WeeklyPlannerView = 'table' | 'planner';
+
+interface WeeklyPlannerSurfaceProps {
+  weekStart: Date;
+  embedded?: boolean;
+  title?: string;
+  storageScope?: 'weekly_checkin' | 'standalone';
+  onPlanningSaved?: (summary: {
+    acceptedMoves: number;
+    acceptedDefers: number;
+    weekKey: string;
+  }) => void;
+}
+
+type MoveTarget = {
+  item: PlannerItem;
+  recommendation: PlannerRecommendation | null;
+};
+
+type ThemeAllocation = {
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+  theme: string;
+  subTheme?: string | null;
+};
+
+const dayStartMs = (date: Date | number) => {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+  return next.getTime();
+};
+
+const nextSprintForDate = (sprints: Sprint[], afterMs: number) =>
+  [...sprints]
+    .filter((sprint) => Number(sprint.startDate || 0) > afterMs)
+    .sort((a, b) => Number(a.startDate || 0) - Number(b.startDate || 0))[0] || null;
+
+const formatOccurrenceKey = (existingValue: string | null | undefined, targetDateMs: number) => {
+  const target = new Date(targetDateMs);
+  if (/^\d{8}$/.test(String(existingValue || '').trim())) {
+    return format(target, 'yyyyMMdd');
+  }
+  return format(target, 'yyyy-MM-dd');
+};
+
+const buildTargetTiming = (targetDateMs: number, targetBucket: TimelineBucket, durationMinutes: number) => {
+  const startHour = targetBucket === 'morning' ? 9 : targetBucket === 'afternoon' ? 14 : targetBucket === 'evening' ? 19 : 12;
+  const startMs = dayStartMs(targetDateMs) + startHour * 60 * 60 * 1000;
+  return {
+    startMs,
+    endMs: startMs + Math.max(15, durationMinutes || 30) * 60 * 1000,
+  };
+};
+
+const allocationToMinutes = (value: string | null | undefined) => {
+  const [hours = '0', minutes = '0'] = String(value || '0:0').split(':');
+  return Number(hours) * 60 + Number(minutes);
+};
+
+const bucketForMinutes = (minutes: number): TimelineBucket => {
+  if (minutes < 12 * 60) return 'morning';
+  if (minutes < 17 * 60) return 'afternoon';
+  if (minutes < 21 * 60) return 'evening';
+  return 'anytime';
+};
+
+const normalizeThemeKey = (value: unknown, themes: GlobalTheme[]) => {
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+  const numeric = Number(raw);
+  if (Number.isFinite(numeric)) {
+    const theme = themes.find((entry) => Number(entry.id) === numeric);
+    if (theme) return String(theme.name || theme.label || theme.id).trim().toLowerCase();
+  }
+  const lower = raw.toLowerCase();
+  const direct = themes.find((entry) => {
+    const candidates = [
+      String(entry.id ?? '').trim().toLowerCase(),
+      String(entry.name || '').trim().toLowerCase(),
+      String(entry.label || '').trim().toLowerCase(),
+    ];
+    return candidates.includes(lower);
+  });
+  if (direct) return String(direct.name || direct.label || direct.id).trim().toLowerCase();
+  return lower;
+};
+
+const WeeklyPlannerSurface: React.FC<WeeklyPlannerSurfaceProps> = ({
+  weekStart,
+  embedded = false,
+  title = 'Weekly Planner',
+  storageScope = 'standalone',
+  onPlanningSaved,
+}) => {
+  const { currentUser } = useAuth();
+  const { currentPersona } = usePersona();
+  const { sprints } = useSprint();
+  const { activeFocusGoals } = useFocusGoals(currentUser?.uid);
+  const { themes: customThemes } = useGlobalThemes();
+  const themePalette = useMemo(() => (customThemes && customThemes.length ? customThemes : GLOBAL_THEMES), [customThemes]);
+
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [stories, setStories] = useState<Story[]>([]);
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [calendarBlocks, setCalendarBlocks] = useState<PlannerCalendarBlockRow[]>([]);
+  const [scheduledInstances, setScheduledInstances] = useState<PlannerScheduledInstanceRow[]>([]);
+  const [themeAllocations, setThemeAllocations] = useState<ThemeAllocation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [feedback, setFeedback] = useState<{ variant: 'success' | 'warning' | 'danger'; text: string } | null>(null);
+  const [activeView, setActiveView] = useState<WeeklyPlannerView>('table');
+  const [isMobileLayout, setIsMobileLayout] = useState<boolean>(typeof window !== 'undefined' ? window.innerWidth < 768 : false);
+  const [moveTarget, setMoveTarget] = useState<MoveTarget | null>(null);
+  const [deferTarget, setDeferTarget] = useState<PlannerItem | null>(null);
+  const [applyingKey, setApplyingKey] = useState<string | null>(null);
+  const [dragItemId, setDragItemId] = useState<string | null>(null);
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+  const [plannerFilter, setPlannerFilter] = useState<'all' | 'focus' | 'top3' | 'stories'>('all');
+  const [planningSummary, setPlanningSummary] = useState<{ acceptedMoves: number; acceptedDefers: number }>({
+    acceptedMoves: 0,
+    acceptedDefers: 0,
+  });
+
+  const weekStartMs = useMemo(() => dayStartMs(weekStart), [weekStart]);
+  const weekEndMs = useMemo(() => dayStartMs(addDays(weekStart, 6)) + (24 * 60 * 60 * 1000) - 1, [weekStart]);
+  const weekKey = useMemo(() => format(weekStart, "yyyy-'W'II"), [weekStart]);
+  const dayColumns = useMemo(
+    () => Array.from({ length: 7 }, (_, index) => new Date(dayStartMs(addDays(weekStart, index)))),
+    [weekStart],
+  );
+  const activeFocusGoalIds = useMemo(() => getActiveFocusLeafGoalIds(activeFocusGoals), [activeFocusGoals]);
+  const nextSprint = useMemo(() => nextSprintForDate(sprints as Sprint[], weekEndMs), [sprints, weekEndMs]);
+
+  useEffect(() => {
+    const update = () => setIsMobileLayout(window.innerWidth < 768);
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  useEffect(() => {
+    if (!currentUser?.uid) {
+      setTasks([]);
+      setStories([]);
+      setGoals([]);
+      return;
+    }
+
+    const taskQuery = query(collection(db, 'tasks'), where('ownerUid', '==', currentUser.uid), orderBy('updatedAt', 'desc'), limit(400));
+    const storyQuery = query(collection(db, 'stories'), where('ownerUid', '==', currentUser.uid), orderBy('updatedAt', 'desc'), limit(400));
+    const goalQuery = query(collection(db, 'goals'), where('ownerUid', '==', currentUser.uid));
+
+    const unsubTasks = onSnapshot(taskQuery, (snap) => {
+      let rows = snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Task[];
+      rows = rows.filter((task: any) => currentPersona === 'work' ? task.persona === 'work' : task.persona == null || task.persona === 'personal');
+      setTasks(rows);
+    });
+    const unsubStories = onSnapshot(storyQuery, (snap) => {
+      let rows = snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Story[];
+      rows = rows.filter((story: any) => currentPersona === 'work' ? story.persona === 'work' : story.persona == null || story.persona === 'personal');
+      setStories(rows);
+    });
+    const unsubGoals = onSnapshot(goalQuery, (snap) => {
+      setGoals(snap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) })) as Goal[]);
+    });
+
+    return () => {
+      unsubTasks();
+      unsubStories();
+      unsubGoals();
+    };
+  }, [currentUser?.uid, currentPersona]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadWeekData = async () => {
+      if (!currentUser?.uid) {
+        setCalendarBlocks([]);
+        setScheduledInstances([]);
+        setThemeAllocations([]);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      try {
+        const [blocksSnap, instancesSnap, themeAllocationsSnap] = await Promise.all([
+          getDocs(query(collection(db, 'calendar_blocks'), where('ownerUid', '==', currentUser.uid))),
+          getDocs(query(collection(db, 'scheduled_instances'), where('ownerUid', '==', currentUser.uid))),
+          getDoc(doc(db, 'theme_allocations', currentUser.uid)),
+        ]);
+        const blockRows = blocksSnap.docs
+          .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) }))
+          .filter((row: any) => {
+            const start = Number(row.start || 0);
+            return Number.isFinite(start) && start >= weekStartMs && start <= weekEndMs;
+          }) as PlannerCalendarBlockRow[];
+
+        const instanceRows = instancesSnap.docs
+          .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as any) }))
+          .filter((row: any) => {
+            const raw = String(row.occurrenceDate || '').trim();
+            if (!raw) return false;
+            const normalized = /^\d{8}$/.test(raw) ? `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}` : raw;
+            return normalized >= format(weekStart, 'yyyy-MM-dd') && normalized <= format(addDays(weekStart, 6), 'yyyy-MM-dd');
+          }) as PlannerScheduledInstanceRow[];
+
+        const themeAllocationsData = themeAllocationsSnap.exists() ? (themeAllocationsSnap.data() as any) : null;
+        const weeklyOverrides = (themeAllocationsData?.weeklyOverrides && typeof themeAllocationsData.weeklyOverrides === 'object')
+          ? themeAllocationsData.weeklyOverrides
+          : {};
+        const weekAllocations = Array.isArray(weeklyOverrides?.[format(weekStart, 'yyyy-MM-dd')])
+          ? weeklyOverrides[format(weekStart, 'yyyy-MM-dd')]
+          : Array.isArray(themeAllocationsData?.allocations)
+            ? themeAllocationsData.allocations
+            : [];
+
+        const checkinDoc = await getDoc(doc(db, 'weekly_checkins', `${currentUser.uid}_${weekKey}`));
+        const summary = (checkinDoc.data() as any)?.nextWeekPlanning || null;
+        if (!cancelled) {
+          setCalendarBlocks(blockRows);
+          setScheduledInstances(instanceRows);
+          setThemeAllocations(weekAllocations as ThemeAllocation[]);
+          if (summary) {
+            setPlanningSummary({
+              acceptedMoves: Number(summary.acceptedMoves || 0),
+              acceptedDefers: Number(summary.acceptedDefers || 0),
+            });
+            if (summary.view === 'planner' || summary.view === 'table') setActiveView(summary.view);
+          } else {
+            setPlanningSummary({ acceptedMoves: 0, acceptedDefers: 0 });
+          }
+        }
+      } catch (error: any) {
+        if (!cancelled) {
+          console.error('Failed to load weekly planner data', error);
+          setFeedback({ variant: 'danger', text: error?.message || 'Failed to load weekly planner data.' });
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    loadWeekData();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentUser?.uid, weekStart, weekStartMs, weekEndMs, weekKey]);
+
+  const weekAssignedItems = useMemo(
+    () =>
+      buildPlannerItems({
+        tasks,
+        stories,
+        goals,
+        calendarBlocks,
+        scheduledInstances,
+        activeFocusGoalIds,
+        rangeStartMs: weekStartMs,
+        rangeEndMs: weekEndMs,
+        includeUnscheduledTasks: false,
+      }).filter((item) => item.kind !== 'event'),
+    [tasks, stories, goals, calendarBlocks, scheduledInstances, activeFocusGoalIds, weekStartMs, weekEndMs],
+  );
+
+  const reviewCandidates = useMemo(
+    () =>
+      buildPlannerItems({
+        tasks,
+        stories,
+        goals,
+        calendarBlocks,
+        scheduledInstances,
+        activeFocusGoalIds,
+        rangeStartMs: weekStartMs,
+        rangeEndMs: weekEndMs,
+        includeUnscheduledTasks: true,
+      }).filter((item) => item.kind !== 'event'),
+    [tasks, stories, goals, calendarBlocks, scheduledInstances, activeFocusGoalIds, weekStartMs, weekEndMs],
+  );
+
+  const dailyLoadHours = useMemo(() => {
+    const map = new Map<string, number>();
+    weekAssignedItems.forEach((item) => {
+      const dayKey = item.dayKey;
+      map.set(dayKey, (map.get(dayKey) || 0) + plannerItemPoints(item));
+    });
+    return map;
+  }, [weekAssignedItems]);
+
+  const dayCapacityByKey = useMemo(
+    () => buildDayCapacityMap(dayColumns.map((date) => toDayKey(date)), weekAssignedItems, 8),
+    [dayColumns, weekAssignedItems],
+  );
+
+  const filteredPlannerItems = useMemo(() => {
+    return weekAssignedItems.filter((item) => {
+      if (plannerFilter === 'focus') return item.isFocusAligned;
+      if (plannerFilter === 'top3') return !!item.isTop3;
+      if (plannerFilter === 'stories') return item.kind === 'story';
+      return true;
+    });
+  }, [weekAssignedItems, plannerFilter]);
+
+  const groupedPlannerItems = useMemo(() => {
+    const grouped = new Map<string, Map<TimelineBucket, PlannerItem[]>>();
+    dayColumns.forEach((date) => {
+      grouped.set(toDayKey(date), new Map(bucketOrder.map((bucket) => [bucket, []])));
+    });
+    filteredPlannerItems.forEach((item) => {
+      const dayKey = item.dayKey;
+      if (!grouped.has(dayKey)) grouped.set(dayKey, new Map(bucketOrder.map((bucket) => [bucket, []])));
+      const bucketMap = grouped.get(dayKey)!;
+      const list = bucketMap.get(item.bucket) || [];
+      list.push(item);
+      bucketMap.set(item.bucket, list);
+    });
+    return grouped;
+  }, [dayColumns, filteredPlannerItems]);
+
+  const bucketLoadByDay = useMemo(() => {
+    const grouped = new Map<string, Map<TimelineBucket, number>>();
+    dayColumns.forEach((date) => grouped.set(toDayKey(date), new Map(bucketOrder.map((bucket) => [bucket, 0]))));
+    weekAssignedItems.forEach((item) => {
+      const dayKey = item.dayKey;
+      if (!grouped.has(dayKey)) grouped.set(dayKey, new Map(bucketOrder.map((bucket) => [bucket, 0])));
+      const bucketMap = grouped.get(dayKey)!;
+      bucketMap.set(item.bucket, Number(bucketMap.get(item.bucket) || 0) + plannerItemPoints(item));
+    });
+    return grouped;
+  }, [dayColumns, weekAssignedItems]);
+
+  const themeAllocationByDay = useMemo(() => {
+    const grouped = new Map<string, Map<string, Map<TimelineBucket, number>>>();
+    dayColumns.forEach((date) => grouped.set(toDayKey(date), new Map()));
+    themeAllocations.forEach((allocation) => {
+      const day = dayColumns.find((date) => date.getDay() === Number(allocation.dayOfWeek));
+      if (!day) return;
+      const dayKey = toDayKey(day);
+      const themeKey = normalizeThemeKey(allocation.theme, themePalette);
+      if (!themeKey) return;
+      const startMinutes = allocationToMinutes(allocation.startTime);
+      const endMinutes = Math.max(startMinutes + 30, allocationToMinutes(allocation.endTime));
+      const themeMap = grouped.get(dayKey) || new Map<string, Map<TimelineBucket, number>>();
+      const bucketMap = themeMap.get(themeKey) || new Map<TimelineBucket, number>(bucketOrder.map((bucket) => [bucket, 0]));
+      for (let cursor = startMinutes; cursor < endMinutes; cursor += 30) {
+        const bucket = bucketForMinutes(cursor);
+        bucketMap.set(bucket, Number(bucketMap.get(bucket) || 0) + 30);
+      }
+      themeMap.set(themeKey, bucketMap);
+      grouped.set(dayKey, themeMap);
+    });
+    return grouped;
+  }, [dayColumns, themeAllocations, themePalette]);
+
+  function resolveItemThemeKey(item: PlannerItem) {
+    return normalizeThemeKey(
+      item.goalTheme
+        ?? (item.rawStory as any)?.theme
+        ?? (item.rawStory as any)?.themeId
+        ?? (item.rawTask as any)?.theme
+        ?? (item.rawTask as any)?.themeId
+        ?? null,
+      themePalette,
+    );
+  }
+
+  function deriveAutoPlacement(item: PlannerItem, preferredDayMs?: number | null): PlannerRecommendation {
+    const baseRecommendation = buildPlannerRecommendation({
+      item,
+      weekStartMs,
+      weekEndMs,
+      dailyLoadHours,
+      nextSprint,
+    });
+    if (!preferredDayMs && (baseRecommendation.action === 'next_sprint' || baseRecommendation.action === 'next_recurrence')) {
+      return baseRecommendation;
+    }
+
+    const itemPoints = plannerItemPoints(item);
+    const itemThemeKey = resolveItemThemeKey(item);
+    const preferredDayKey = preferredDayMs != null ? toDayKey(preferredDayMs) : null;
+    const daysToInspect = preferredDayKey
+      ? dayColumns.filter((date) => toDayKey(date) === preferredDayKey)
+      : dayColumns;
+
+    let best: { dayMs: number; bucket: TimelineBucket; score: number; themeMinutes: number; remaining: number } | null = null;
+
+    daysToInspect.forEach((date, dayIndex) => {
+      const dayKey = toDayKey(date);
+      const dayCapacity = dayCapacityByKey.get(dayKey);
+      const bucketLoad = bucketLoadByDay.get(dayKey) || new Map<TimelineBucket, number>(bucketOrder.map((bucket) => [bucket, 0]));
+      const currentItemPoints = item.dayKey === dayKey ? itemPoints : 0;
+      const projectedPoints = (dayCapacity?.plannedPoints || 0) - currentItemPoints + itemPoints;
+      const remaining = (dayCapacity?.capacityPoints || 8) - projectedPoints;
+
+      let targetBucket: TimelineBucket = item.timeOfDay || 'morning';
+      let themeMinutes = 0;
+      if (itemThemeKey) {
+        const themeBuckets = themeAllocationByDay.get(dayKey)?.get(itemThemeKey) || null;
+        if (themeBuckets) {
+          let bestBucket: TimelineBucket | null = null;
+          let bestMinutes = -1;
+          bucketOrder.forEach((bucket) => {
+            const minutes = Number(themeBuckets.get(bucket) || 0);
+            if (minutes > bestMinutes) {
+              bestMinutes = minutes;
+              bestBucket = bucket;
+            }
+          });
+          if (bestBucket) {
+            targetBucket = bestBucket;
+            themeMinutes = Math.max(0, bestMinutes);
+          }
+        }
+      }
+      if (!themeMinutes) {
+        targetBucket = [...bucketOrder].sort((a, b) => Number(bucketLoad.get(a) || 0) - Number(bucketLoad.get(b) || 0))[0] || targetBucket;
+      }
+
+      const bucketLoadPoints = Number(bucketLoad.get(targetBucket) || 0) - (item.dayKey === dayKey && item.bucket === targetBucket ? itemPoints : 0);
+      let score = 0;
+      score += preferredDayKey ? 200 : Math.max(0, 40 - dayIndex * 4);
+      score += Math.min(themeMinutes, 180);
+      score += Math.max(0, 60 - bucketLoadPoints * 10);
+      score += remaining >= 0 ? Math.min(remaining * 12, 90) : -220 - Math.abs(remaining) * 40;
+      if (item.isFocusAligned) score += 15;
+
+      if (!best || score > best.score) {
+        best = {
+          dayMs: dayStartMs(date),
+          bucket: targetBucket,
+          score,
+          themeMinutes,
+          remaining,
+        };
+      }
+    });
+
+    if (!best) return baseRecommendation;
+
+    const dayLabel = format(new Date(best.dayMs), 'EEE d MMM');
+    const rationaleParts = [];
+    if (best.themeMinutes > 0 && itemThemeKey) rationaleParts.push(`closest ${itemThemeKey} allocation`);
+    if (best.remaining >= 0) rationaleParts.push(`${Math.max(0, best.remaining).toFixed(1)} pts free after placement`);
+    if (!rationaleParts.length) rationaleParts.push('best fit for day load');
+    return {
+      action: 'move_day' as const,
+      label: `Place on ${dayLabel} ${bucketLabel(best.bucket).toLowerCase()}`,
+      rationale: `Uses ${rationaleParts.join(' and ')}.`,
+      targetDateMs: best.dayMs,
+      targetBucket: best.bucket,
+    };
+  }
+
+  const recommendationByItemId = useMemo(() => {
+    const next = new Map<string, PlannerRecommendation>();
+    reviewCandidates.forEach((item) => {
+      next.set(item.id, deriveAutoPlacement(item));
+    });
+    return next;
+  }, [reviewCandidates, weekStartMs, weekEndMs, dailyLoadHours, nextSprint, dayCapacityByKey, bucketLoadByDay, themeAllocationByDay, themePalette, dayColumns]);
+
+  const persistPlanningSummary = async (updates?: Partial<{ acceptedMoves: number; acceptedDefers: number; view: WeeklyPlannerView }>) => {
+    if (!currentUser?.uid) return;
+    const acceptedMoves = updates?.acceptedMoves ?? planningSummary.acceptedMoves;
+    const acceptedDefers = updates?.acceptedDefers ?? planningSummary.acceptedDefers;
+    await setDoc(doc(db, 'weekly_checkins', `${currentUser.uid}_${weekKey}`), {
+      ownerUid: currentUser.uid,
+      weekKey,
+      nextWeekPlanning: {
+        completedAt: new Date(),
+        acceptedMoves,
+        acceptedDefers,
+        view: updates?.view || activeView,
+        storageScope,
+        updatedAt: new Date(),
+      },
+      updatedAt: new Date(),
+    }, { merge: true });
+    const summary = { acceptedMoves, acceptedDefers, weekKey };
+    setPlanningSummary({ acceptedMoves, acceptedDefers });
+    onPlanningSaved?.(summary);
+  };
+
+  const updateScheduledInstanceTiming = async (item: PlannerItem, targetDateMs: number, targetBucket: TimelineBucket) => {
+    if (!item.scheduledInstanceId) return;
+    const existingOccurrence = scheduledInstances.find((instance) => instance.id === item.scheduledInstanceId)?.occurrenceDate;
+    const durationMinutes = Math.max(
+      15,
+      Math.round((((item.scheduledBlockEnd || 0) - (item.scheduledBlockStart || 0)) / 60000) || Number((item.rawTask as any)?.estimateMin || 0) || 30),
+    );
+    const { startMs, endMs } = buildTargetTiming(targetDateMs, targetBucket, durationMinutes);
+    await updateDoc(doc(db, 'scheduled_instances', item.scheduledInstanceId), {
+      occurrenceDate: formatOccurrenceKey(existingOccurrence, targetDateMs),
+      dayKey: toDayKey(targetDateMs),
+      timeOfDay: targetBucket,
+      plannedStart: new Date(startMs).toISOString(),
+      plannedEnd: new Date(endMs).toISOString(),
+      updatedAt: Date.now(),
+    });
+  };
+
+  const updateGroupedTiming = async (item: PlannerItem, targetDateMs: number, targetBucket: TimelineBucket) => {
+    const children = Array.isArray(item.childItems) ? item.childItems : [];
+    await Promise.all(children.map((child) => updateScheduledInstanceTiming(child, targetDateMs, targetBucket)));
+  };
+
+  const shouldPromptIntelligentDefer = (item: PlannerItem, targetDateMs: number) => {
+    if (item.childItems?.length) return false;
+    if (!item.rawTask && !item.rawStory) return false;
+    const targetDayKey = toDayKey(targetDateMs);
+    const summary = dayCapacityByKey.get(targetDayKey);
+    const points = plannerItemPoints(item);
+    const currentPoints = item.dayKey === targetDayKey ? points : 0;
+    const projectedPoints = (summary?.plannedPoints || 0) - currentPoints + points;
+    const overCapacity = !!summary && projectedPoints > summary.capacityPoints + 0.01;
+    const outsideFocus = activeFocusGoalIds.size > 0 && !item.isFocusAligned;
+    if (!overCapacity && !outsideFocus) return false;
+    const reasons: string[] = [];
+    if (overCapacity && summary) {
+      reasons.push(`${targetDayKey} would be ${projectedPoints.toFixed(1)}/${summary.capacityPoints.toFixed(1)} pts`);
+    }
+    if (outsideFocus) {
+      reasons.push('this item is outside active focus goals');
+    }
+    setFeedback({
+      variant: 'warning',
+      text: `${item.title} should be deferred intelligently because ${reasons.join(' and ')}.`,
+    });
+    setMoveTarget(null);
+    setDeferTarget(item);
+    return true;
+  };
+
+  const applyMove = async (item: PlannerItem, targetDateMs: number, targetBucket: TimelineBucket, recommendation?: PlannerRecommendation | null) => {
+    if (!currentUser?.uid) return;
+    if ((recommendation?.action == null || recommendation.action === 'move_day') && shouldPromptIntelligentDefer(item, targetDateMs)) {
+      return;
+    }
+    setApplyingKey(item.id);
+    try {
+      if (item.childItems?.length) {
+        await updateGroupedTiming(item, targetDateMs, targetBucket);
+        const acceptedMoves = planningSummary.acceptedMoves + 1;
+        await persistPlanningSummary({ acceptedMoves });
+        setFeedback({
+          variant: 'success',
+          text: recommendation?.rationale
+            ? `${item.title} moved to ${new Date(targetDateMs).toLocaleDateString()} ${bucketLabel(targetBucket).toLowerCase()}. ${recommendation.rationale}`
+            : `${item.title} moved to ${new Date(targetDateMs).toLocaleDateString()} ${bucketLabel(targetBucket).toLowerCase()}.`,
+        });
+      } else if (item.scheduledInstanceId) {
+        await updateScheduledInstanceTiming(item, targetDateMs, targetBucket);
+        const acceptedMoves = planningSummary.acceptedMoves + 1;
+        await persistPlanningSummary({ acceptedMoves });
+        setFeedback({
+          variant: 'success',
+          text: recommendation?.rationale
+            ? `${item.title} moved to ${new Date(targetDateMs).toLocaleDateString()} ${bucketLabel(targetBucket).toLowerCase()}. ${recommendation.rationale}`
+            : `${item.title} moved to ${new Date(targetDateMs).toLocaleDateString()} ${bucketLabel(targetBucket).toLowerCase()}.`,
+        });
+      } else if (item.rawTask) {
+        const result = await schedulePlannerItemMutation({
+          itemType: 'task',
+          itemId: item.rawTask.id,
+          targetDateMs,
+          targetBucket,
+          intent: recommendation?.action === 'next_sprint' ? 'defer' : 'move',
+          source: 'weekly_planner',
+          rationale: recommendation?.rationale || null,
+          linkedBlockId: item.scheduledBlockId || null,
+          targetSprintId: recommendation?.action === 'next_sprint' ? (nextSprint?.id || null) : null,
+          durationMinutes: Math.max(
+            15,
+            Math.round((((item.scheduledBlockEnd || 0) - (item.scheduledBlockStart || 0)) / 60000) || Number((item.rawTask as any)?.estimateMin || 0) || 30),
+          ),
+        });
+        const acceptedMoves = planningSummary.acceptedMoves + 1;
+        await persistPlanningSummary({ acceptedMoves });
+        setFeedback({
+          variant: 'success',
+          text: recommendation?.rationale
+            ? `${item.title} moved to ${new Date(result.appliedStartMs).toLocaleDateString()} ${bucketLabel((result.appliedBucket || targetBucket) as TimelineBucket).toLowerCase()}. ${recommendation.rationale}`
+            : `${item.title} moved to ${new Date(result.appliedStartMs).toLocaleDateString()} ${bucketLabel((result.appliedBucket || targetBucket) as TimelineBucket).toLowerCase()}.`,
+        });
+      } else if (item.rawStory) {
+        const result = await schedulePlannerItemMutation({
+          itemType: 'story',
+          itemId: item.rawStory.id,
+          targetDateMs,
+          targetBucket,
+          intent: recommendation?.action === 'next_sprint' ? 'defer' : 'move',
+          source: 'weekly_planner',
+          rationale: recommendation?.rationale || null,
+          linkedBlockId: item.scheduledBlockId || null,
+          targetSprintId: recommendation?.action === 'next_sprint' ? (nextSprint?.id || null) : null,
+          durationMinutes: Math.max(
+            15,
+            Math.round((((item.scheduledBlockEnd || 0) - (item.scheduledBlockStart || 0)) / 60000) || Number((item.rawStory as any)?.estimateMin || 0) || 60),
+          ),
+        });
+        const acceptedMoves = planningSummary.acceptedMoves + 1;
+        await persistPlanningSummary({ acceptedMoves });
+        setFeedback({
+          variant: 'success',
+          text: recommendation?.rationale
+            ? `${item.title} moved to ${new Date(result.appliedStartMs).toLocaleDateString()} ${bucketLabel((result.appliedBucket || targetBucket) as TimelineBucket).toLowerCase()}. ${recommendation.rationale}`
+            : `${item.title} moved to ${new Date(result.appliedStartMs).toLocaleDateString()} ${bucketLabel((result.appliedBucket || targetBucket) as TimelineBucket).toLowerCase()}.`,
+        });
+      } else {
+        const acceptedMoves = planningSummary.acceptedMoves + 1;
+        await persistPlanningSummary({ acceptedMoves });
+        setFeedback({
+          variant: 'success',
+          text: recommendation?.rationale
+            ? `${item.title} moved to ${new Date(targetDateMs).toLocaleDateString()} ${bucketLabel(targetBucket).toLowerCase()}. ${recommendation.rationale}`
+            : `${item.title} moved to ${new Date(targetDateMs).toLocaleDateString()} ${bucketLabel(targetBucket).toLowerCase()}.`,
+        });
+      }
+      setMoveTarget(null);
+    } catch (error: any) {
+      console.error('Failed to move planner item', error);
+      setFeedback({ variant: 'danger', text: error?.message || 'Failed to move planner item.' });
+    } finally {
+      setApplyingKey(null);
+    }
+  };
+
+  const applyDayAutoMove = async (item: PlannerItem, targetDateMs: number) => {
+    const recommendation = deriveAutoPlacement(item, targetDateMs);
+    if (recommendation.targetDateMs == null || recommendation.targetBucket == null) {
+      setFeedback({ variant: 'warning', text: `No suitable placement was available for ${item.title}.` });
+      return;
+    }
+    await applyMove(item, recommendation.targetDateMs, recommendation.targetBucket, recommendation);
+  };
+
+  const applyRecommendation = async (item: PlannerItem, recommendation: PlannerRecommendation) => {
+    if (recommendation.action === 'keep_week') {
+      const acceptedMoves = planningSummary.acceptedMoves + 1;
+      await persistPlanningSummary({ acceptedMoves });
+      setFeedback({ variant: 'success', text: `${item.title} kept in this week.` });
+      return;
+    }
+    if (recommendation.targetDateMs == null || recommendation.targetBucket == null) {
+      setFeedback({ variant: 'warning', text: 'No actionable recommendation was available.' });
+      return;
+    }
+    if (recommendation.action === 'next_recurrence') {
+      setApplyingKey(item.id);
+      try {
+        if (item.childItems?.length) {
+          await updateGroupedTiming(item, recommendation.targetDateMs, recommendation.targetBucket || item.timeOfDay);
+        } else if (item.scheduledInstanceId) {
+          await updateScheduledInstanceTiming(item, recommendation.targetDateMs, recommendation.targetBucket || item.timeOfDay);
+        } else if (item.rawTask) {
+          await updateDoc(doc(db, 'tasks', item.rawTask.id), {
+            deferredUntil: recommendation.targetDateMs,
+            deferredReason: recommendation.rationale,
+            deferredBy: 'weekly_planner',
+            deferredAt: serverTimestamp(),
+            updatedAt: serverTimestamp(),
+          });
+        }
+        const acceptedDefers = planningSummary.acceptedDefers + 1;
+        await persistPlanningSummary({ acceptedDefers });
+        setFeedback({ variant: 'success', text: `${item.title} deferred to its next sensible recurrence.` });
+      } catch (error: any) {
+        console.error('Failed to apply recurring defer', error);
+        setFeedback({ variant: 'danger', text: error?.message || 'Failed to defer recurring item.' });
+      } finally {
+        setApplyingKey(null);
+      }
+      return;
+    }
+    await applyMove(item, recommendation.targetDateMs, recommendation.targetBucket, recommendation);
+  };
+
+  const renderPlannerCard = (item: PlannerItem) => {
+    const recommendation = recommendationByItemId.get(item.id) || null;
+    const plannerMode = activeView === 'planner';
+    return (
+      <div
+        key={item.id}
+        draggable={!isMobileLayout && item.kind !== 'event'}
+        onDragStart={() => setDragItemId(item.id)}
+        onDragEnd={() => setDragItemId(null)}
+      >
+        <PlannerWorkCard
+          item={item}
+          context="weekly"
+          isMobileLayout={isMobileLayout}
+          applyingKey={applyingKey}
+          showDoneControl={false}
+          canEditState={false}
+          showInlineRecommendation={!plannerMode && !!recommendation}
+          recommendation={recommendation}
+          canShowActions={!plannerMode || isMobileLayout}
+          expanded={!!expandedGroups[item.id]}
+          onToggleExpanded={(nextItem) => setExpandedGroups((prev) => ({ ...prev, [nextItem.id]: !prev[nextItem.id] }))}
+          onMove={(nextItem) => setMoveTarget({ item: nextItem, recommendation: deriveAutoPlacement(nextItem) })}
+          onDefer={(nextItem) => {
+            if (nextItem.childItems?.length) return;
+            const recurringRecommendation = nextItem.kind === 'chore'
+              ? deriveAutoPlacement(nextItem)
+              : null;
+            if (recurringRecommendation?.action === 'next_recurrence') {
+              void applyRecommendation(nextItem, recurringRecommendation);
+              return;
+            }
+            setDeferTarget(nextItem);
+          }}
+          onAcceptRecommendation={(nextItem) => {
+            const nextRecommendation = recommendationByItemId.get(nextItem.id);
+            if (nextRecommendation) void applyRecommendation(nextItem, nextRecommendation);
+          }}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div>
+      <div className="d-flex align-items-center justify-content-between gap-2 flex-wrap mb-3">
+        <div>
+          <div className="fw-semibold">{title}</div>
+          <div className="text-muted small">
+            {format(weekStart, 'dd MMM')} – {format(addDays(weekStart, 6), 'dd MMM yyyy')}
+          </div>
+        </div>
+        <div className="d-flex align-items-center gap-2 flex-wrap">
+          <Badge bg="secondary">{reviewCandidates.length} items</Badge>
+          <Badge bg="info">{planningSummary.acceptedMoves} planned</Badge>
+          <Badge bg="warning" text="dark">{planningSummary.acceptedDefers} deferred</Badge>
+        </div>
+      </div>
+
+      {feedback && (
+        <Alert variant={feedback.variant} dismissible onClose={() => setFeedback(null)} className="py-2">
+          {feedback.text}
+        </Alert>
+      )}
+
+      <div className="d-flex align-items-center gap-2 flex-wrap mb-3">
+        <Button
+          size="sm"
+          variant={activeView === 'table' ? 'primary' : 'outline-primary'}
+          onClick={() => {
+            setActiveView('table');
+            void persistPlanningSummary({ view: 'table' });
+          }}
+        >
+          Table
+        </Button>
+        <Button
+          size="sm"
+          variant={activeView === 'planner' ? 'primary' : 'outline-primary'}
+          onClick={() => {
+            setActiveView('planner');
+            void persistPlanningSummary({ view: 'planner' });
+          }}
+        >
+          Planner
+        </Button>
+        {activeView === 'planner' && (
+          <>
+            <Button size="sm" variant={plannerFilter === 'all' ? 'dark' : 'outline-dark'} onClick={() => setPlannerFilter('all')}>
+              All
+            </Button>
+            <Button size="sm" variant={plannerFilter === 'focus' ? 'success' : 'outline-success'} onClick={() => setPlannerFilter('focus')}>
+              Focus
+            </Button>
+            <Button size="sm" variant={plannerFilter === 'top3' ? 'danger' : 'outline-danger'} onClick={() => setPlannerFilter('top3')}>
+              Top 3
+            </Button>
+            <Button size="sm" variant={plannerFilter === 'stories' ? 'info' : 'outline-info'} onClick={() => setPlannerFilter('stories')}>
+              Stories
+            </Button>
+          </>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="d-flex align-items-center gap-2 text-muted">
+          <Spinner size="sm" animation="border" /> Loading weekly planner…
+        </div>
+      ) : activeView === 'table' ? (
+        isMobileLayout ? (
+          <div className="d-flex flex-column gap-2">
+            {reviewCandidates.map((item) => {
+              const recommendation = recommendationByItemId.get(item.id) || null;
+              return (
+                <Card key={item.id} className="shadow-sm border">
+                  <Card.Body className="p-3">
+                    <div className="fw-semibold">{item.title}</div>
+                    <div className="text-muted small mb-2">
+                      {[item.ref, item.statusLabel, item.goalTitle || 'No linked goal'].filter(Boolean).join(' · ')}
+                    </div>
+                    {recommendation && (
+                      <div className="small mb-2">
+                        <div className="fw-semibold d-inline-flex align-items-center gap-1"><Sparkles size={13} /> {recommendation.label}</div>
+                        <div className="text-muted">{recommendation.rationale}</div>
+                      </div>
+                    )}
+                    <div className="d-flex gap-2 flex-wrap">
+                      {recommendation && (
+                        <Button
+                          size="sm"
+                          variant="primary"
+                          disabled={applyingKey === item.id}
+                          onClick={() => void applyRecommendation(item, recommendation)}
+                        >
+                          {applyingKey === item.id ? 'Applying…' : 'Accept'}
+                        </Button>
+                      )}
+                      <Button size="sm" variant="outline-secondary" onClick={() => setMoveTarget({ item, recommendation: deriveAutoPlacement(item) })}>
+                        Move
+                      </Button>
+                      <Button size="sm" variant="outline-warning" onClick={() => setDeferTarget(item)}>
+                        More options
+                      </Button>
+                    </div>
+                  </Card.Body>
+                </Card>
+              );
+            })}
+          </div>
+        ) : (
+          <Table hover size="sm" className="align-middle">
+            <thead>
+              <tr>
+                <th>Item</th>
+                <th>Current</th>
+                <th>Goal</th>
+                <th>Recommendation</th>
+                <th className="text-end">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {reviewCandidates.map((item) => {
+                const recommendation = recommendationByItemId.get(item.id) || null;
+                return (
+                  <tr key={item.id}>
+                    <td>
+                      <div className="fw-semibold small">{item.title}</div>
+                      <div className="text-muted" style={{ fontSize: '0.74rem' }}>
+                        {[item.ref, item.statusLabel].filter(Boolean).join(' · ')}
+                      </div>
+                    </td>
+                    <td className="small text-muted">{item.timeLabel}</td>
+                    <td className="small text-muted">{item.goalTitle || 'No linked goal'}</td>
+                    <td>
+                      {recommendation ? (
+                        <>
+                          <div className="fw-semibold small">{recommendation.label}</div>
+                          <div className="text-muted" style={{ fontSize: '0.72rem' }}>{recommendation.rationale}</div>
+                        </>
+                      ) : (
+                        <span className="text-muted small">No recommendation</span>
+                      )}
+                    </td>
+                    <td className="text-end">
+                      <div className="d-inline-flex gap-1">
+                        {recommendation && (
+                          <Button
+                            size="sm"
+                            variant="primary"
+                            disabled={applyingKey === item.id}
+                            onClick={() => void applyRecommendation(item, recommendation)}
+                          >
+                            {applyingKey === item.id ? 'Applying…' : 'Accept'}
+                          </Button>
+                        )}
+                        <Button size="sm" variant="outline-secondary" onClick={() => setMoveTarget({ item, recommendation: deriveAutoPlacement(item) })}>
+                          <MoveRight size={14} />
+                        </Button>
+                        <Button size="sm" variant="outline-warning" onClick={() => setDeferTarget(item)}>
+                          <Clock3 size={14} />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </Table>
+        )
+      ) : (
+        isMobileLayout ? (
+          <div className="d-flex flex-column gap-3">
+            {dayColumns.map((date) => {
+              const dayKey = toDayKey(date);
+              const bucketMap = groupedPlannerItems.get(dayKey);
+              const items = bucketOrder.flatMap((bucket) => bucketMap?.get(bucket) || []);
+              const capacity = dayCapacityByKey.get(dayKey);
+              return (
+                <Card key={dayKey} className="shadow-sm border">
+                  <Card.Header className="d-flex align-items-center justify-content-between gap-2">
+                    <span className="fw-semibold">{format(date, 'EEEE d MMM')}</span>
+                    {capacity && (
+                      <Badge bg={capacity.overCapacity ? 'danger' : capacity.remainingPoints <= 2 ? 'warning' : 'success'} text={capacity.remainingPoints <= 2 && !capacity.overCapacity ? 'dark' : undefined}>
+                        {capacity.remainingPoints.toFixed(1)} pts free
+                      </Badge>
+                    )}
+                  </Card.Header>
+                  <Card.Body className="d-flex flex-column gap-2">
+                    {items.length === 0 ? (
+                      <div className="text-muted small">No items planned.</div>
+                    ) : (
+                      items.map((item) => renderPlannerCard(item))
+                    )}
+                  </Card.Body>
+                </Card>
+              );
+            })}
+          </div>
+        ) : (
+          <Row className="g-2">
+            {dayColumns.map((date) => {
+              const dayKey = toDayKey(date);
+              const bucketMap = groupedPlannerItems.get(dayKey);
+              const capacity = dayCapacityByKey.get(dayKey);
+              const dayItems = bucketOrder.flatMap((bucket) => bucketMap?.get(bucket) || []);
+              return (
+                <Col key={dayKey}>
+                  <Card className="shadow-sm border h-100">
+                    <Card.Header className="d-flex flex-column gap-1">
+                      <div className="d-flex align-items-start justify-content-between gap-2">
+                        <div>
+                          <div className="fw-semibold small">{format(date, 'EEE d MMM')}</div>
+                          <div className="text-muted" style={{ fontSize: '0.68rem' }}>
+                            {dayItems.length} items planned · drop on day to auto-place
+                          </div>
+                        </div>
+                        {capacity && (
+                          <div className="text-end" style={{ lineHeight: 1.1 }}>
+                            <div className={`small fw-semibold text-${capacity.overCapacity ? 'danger' : capacity.remainingPoints <= 2 ? 'warning' : 'success'}`}>
+                              {capacity.remainingPoints.toFixed(1)} pts free
+                            </div>
+                            <div className="text-muted" style={{ fontSize: '0.68rem' }}>
+                              {capacity.plannedPoints.toFixed(1)}/{capacity.capacityPoints.toFixed(1)} pts
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </Card.Header>
+                    <Card.Body
+                      className="p-2 d-flex flex-column gap-2"
+                      onDragOver={(event) => {
+                        event.preventDefault();
+                      }}
+                      onDrop={(event) => {
+                        event.preventDefault();
+                        const item = weekAssignedItems.find((row) => row.id === dragItemId);
+                        if (item) {
+                          void applyDayAutoMove(item, dayStartMs(date));
+                        }
+                        setDragItemId(null);
+                      }}
+                    >
+                      {bucketOrder.map((bucket) => {
+                        const items = bucketMap?.get(bucket) || [];
+                        return (
+                          <div
+                            key={`${dayKey}-${bucket}`}
+                            className="border rounded p-2"
+                            onDragOver={(event) => {
+                              event.preventDefault();
+                            }}
+                            onDrop={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              const item = weekAssignedItems.find((row) => row.id === dragItemId);
+                              if (item) {
+                                void applyMove(item, dayStartMs(date), bucket, null);
+                              }
+                              setDragItemId(null);
+                            }}
+                          >
+                            <div className="text-uppercase text-muted fw-semibold mb-1" style={{ fontSize: '0.68rem' }}>
+                              {bucketLabel(bucket)}
+                            </div>
+                            <div className="d-flex flex-column gap-1">
+                              {items.length === 0 ? (
+                                <div className="text-muted" style={{ fontSize: '0.72rem' }}>Drop here</div>
+                              ) : (
+                                items.map((item) => renderPlannerCard(item))
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </Card.Body>
+                  </Card>
+                </Col>
+              );
+            })}
+          </Row>
+        )
+      )}
+
+      <Modal show={!!moveTarget} onHide={() => setMoveTarget(null)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title style={{ fontSize: 16 }}>Move planner item</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="fw-semibold mb-2">{moveTarget?.item.title}</div>
+          <div className="text-muted small mb-3">
+            {moveTarget?.recommendation?.rationale || 'Pick a day and time bucket for this item.'}
+          </div>
+          <Form.Group className="mb-3">
+            <Form.Label className="small text-muted">Day</Form.Label>
+            <Form.Select
+              value={moveTarget?.recommendation?.targetDateMs != null ? format(new Date(moveTarget.recommendation.targetDateMs), 'yyyy-MM-dd') : format(weekStart, 'yyyy-MM-dd')}
+              onChange={(e) => {
+                if (!moveTarget) return;
+                const parsed = Date.parse(`${e.target.value}T12:00:00`);
+                const nextRecommendation = deriveAutoPlacement(moveTarget.item, parsed);
+                setMoveTarget({
+                  ...moveTarget,
+                  recommendation: {
+                    ...(moveTarget.recommendation || { action: 'move_day', label: 'Move day', rationale: '' }),
+                    ...nextRecommendation,
+                    targetDateMs: parsed,
+                    targetBucket: nextRecommendation.targetBucket || moveTarget.recommendation?.targetBucket || 'morning',
+                  },
+                });
+              }}
+            >
+              {dayColumns.map((date) => (
+                <option key={toDayKey(date)} value={format(date, 'yyyy-MM-dd')}>
+                  {format(date, 'EEEE d MMM')}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+          <Form.Group>
+            <Form.Label className="small text-muted">Time of day</Form.Label>
+            <Form.Select
+              value={moveTarget?.recommendation?.targetBucket || 'morning'}
+              onChange={(e) => {
+                if (!moveTarget) return;
+                setMoveTarget({
+                  ...moveTarget,
+                  recommendation: {
+                    ...(moveTarget.recommendation || { action: 'move_day', label: 'Move day', rationale: '' }),
+                    targetDateMs: moveTarget.recommendation?.targetDateMs || dayStartMs(weekStart),
+                    targetBucket: e.target.value as TimelineBucket,
+                  },
+                });
+              }}
+            >
+              {bucketOrder.map((bucket) => (
+                <option key={bucket} value={bucket}>{bucketLabel(bucket)}</option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setMoveTarget(null)}>Cancel</Button>
+          <Button
+            variant="primary"
+            disabled={!moveTarget?.recommendation?.targetDateMs || !moveTarget?.recommendation?.targetBucket || applyingKey === moveTarget?.item.id}
+            onClick={() => moveTarget && moveTarget.recommendation?.targetDateMs != null && moveTarget.recommendation?.targetBucket != null
+              ? void applyMove(moveTarget.item, moveTarget.recommendation.targetDateMs, moveTarget.recommendation.targetBucket, moveTarget.recommendation)
+              : undefined}
+          >
+            {applyingKey === moveTarget?.item.id ? 'Moving…' : 'Save move'}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      {deferTarget && (
+        <DeferItemModal
+          show={!!deferTarget}
+          onHide={() => setDeferTarget(null)}
+          itemType={deferTarget.kind === 'story' ? 'story' : 'task'}
+          itemId={deferTarget.sourceId || ''}
+          itemTitle={deferTarget.title}
+          focusContext={{
+            isFocusAligned: deferTarget.isFocusAligned,
+            activeFocusGoals: activeFocusGoals.map((focusGoal) => ({
+              id: focusGoal.id,
+              title: focusGoal.title || null,
+              focusRootGoalIds: Array.isArray(focusGoal.focusRootGoalIds) ? focusGoal.focusRootGoalIds : [],
+              focusLeafGoalIds: Array.isArray(focusGoal.focusLeafGoalIds) ? focusGoal.focusLeafGoalIds : [],
+              goalIds: Array.isArray(focusGoal.goalIds) ? focusGoal.goalIds : [],
+            })),
+          }}
+          onApply={async (payload) => {
+            if (!deferTarget) return;
+            setApplyingKey(deferTarget.id);
+            try {
+              const durationMinutes = Math.max(
+                15,
+                Math.round((((deferTarget.scheduledBlockEnd || 0) - (deferTarget.scheduledBlockStart || 0)) / 60000)
+                  || Number((deferTarget.rawTask as any)?.estimateMin || (deferTarget.rawStory as any)?.estimateMin || 0)
+                  || 30),
+              );
+              if (deferTarget.rawTask) {
+                await schedulePlannerItemMutation({
+                  itemType: 'task',
+                  itemId: deferTarget.rawTask.id,
+                  targetDateMs: payload.dateMs,
+                  targetBucket: deferTarget.timeOfDay || null,
+                  intent: 'defer',
+                  source: payload.source || 'weekly_planner',
+                  rationale: payload.rationale,
+                  linkedBlockId: deferTarget.scheduledBlockId || null,
+                  durationMinutes,
+                });
+              } else if (deferTarget.rawStory) {
+                await schedulePlannerItemMutation({
+                  itemType: 'story',
+                  itemId: deferTarget.rawStory.id,
+                  targetDateMs: payload.dateMs,
+                  targetBucket: deferTarget.timeOfDay || null,
+                  intent: 'defer',
+                  source: payload.source || 'weekly_planner',
+                  rationale: payload.rationale,
+                  linkedBlockId: deferTarget.scheduledBlockId || null,
+                  durationMinutes,
+                });
+              }
+              const acceptedDefers = planningSummary.acceptedDefers + 1;
+              await persistPlanningSummary({ acceptedDefers });
+              setFeedback({ variant: 'success', text: `${deferTarget.title} deferred.` });
+            } finally {
+              setApplyingKey(null);
+              setDeferTarget(null);
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default WeeklyPlannerSurface;

--- a/react-app/src/components/stories/SortableStoryCard.tsx
+++ b/react-app/src/components/stories/SortableStoryCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from 'react-bootstrap';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Activity, Wand2, Edit3, Trash2, Target, CalendarPlus, CalendarClock, Clock3 } from 'lucide-react';
+import { GripVertical, Activity, Wand2, Edit3, Trash2, Target, CalendarPlus, Clock3 } from 'lucide-react';
 import { httpsCallable } from 'firebase/functions';
 
 import { Story, Goal } from '../../types';
@@ -13,6 +13,7 @@ import { storyStatusText, priorityLabel as formatPriorityLabel, priorityPillClas
 import { colorWithAlpha, goalThemeColor } from '../../utils/storyCardFormatting';
 import { themeVars } from '../../utils/themeVars';
 import type { GlobalTheme } from '../../constants/globalThemes';
+import { getManualPriorityLabel, getManualPriorityRank } from '../../utils/manualPriority';
 
 interface SortableStoryCardProps {
   story: Story;
@@ -96,14 +97,17 @@ const SortableStoryCard: React.FC<SortableStoryCardProps> = ({
   })();
 
   const statusLabel = storyStatusText((story as any).status);
+  const manualPriorityRank = getManualPriorityRank(story);
+  const manualPriorityLabel = getManualPriorityLabel(story);
   const isTop3 = (() => {
+    if (manualPriorityRank) return true;
     if ((story as any).aiTop3ForDay !== true) return false;
     const top3Date = (story as any).aiTop3Date;
     if (!top3Date) return true;
     return String(top3Date).slice(0, 10) === new Date().toISOString().slice(0, 10);
   })();
-  const priorityClass = isTop3 ? priorityPillClass(4) : priorityPillClass(story.priority);
-  const priorityLabel = isTop3 ? 'Critical' : formatPriorityLabel(story.priority);
+  const priorityClass = isTop3 && !manualPriorityRank ? priorityPillClass(4) : priorityPillClass(story.priority);
+  const priorityLabel = isTop3 && !manualPriorityRank ? 'Critical' : formatPriorityLabel(story.priority);
   const handleStyle: React.CSSProperties = {
     color: resolvedThemeColor,
     borderColor: colorWithAlpha(resolvedThemeColor, 0.45),
@@ -129,39 +133,10 @@ const SortableStoryCard: React.FC<SortableStoryCardProps> = ({
     const source = String(scheduledBlock?.source || '').toLowerCase();
     const entryMethod = String(scheduledBlock?.entryMethod || '').toLowerCase();
     const fromGcal = source === 'gcal' || !!scheduledBlock?.googleEventId;
-    if (fromGcal && (scheduledBlock?.linkedStoryId || scheduledBlock?.googleEventId)) return 'linked from gcal';
-    if (scheduledBlock?.isAiGenerated) return 'auto-planned';
-    if (entryMethod.includes('manual') || source === 'manual' || source === 'bob') return 'manual';
-    return 'manual';
-  })();
-  const scheduledBlockSourceClassName = scheduledBlockSourceLabel === 'linked from gcal'
-    ? 'kanban-card__source-note kanban-card__source-note--quiet'
-    : 'kanban-card__source-note';
-  const deferredUntilMs = (() => {
-    const raw = (story as any).deferredUntil ?? null;
-    if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
-    if (raw?.toDate) return raw.toDate().getTime();
-    const parsed = raw ? Date.parse(String(raw)) : NaN;
-    return Number.isNaN(parsed) ? null : parsed;
-  })();
-  const isDeferred = Number.isFinite(deferredUntilMs as number) && (deferredUntilMs as number) > Date.now();
-  const deferredLabel = isDeferred
-    ? `Deferred to ${new Date(deferredUntilMs as number).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`
-    : null;
-  const storyProgressPct = (() => {
-    const raw = (story as any).progressPct ?? (story as any).progress ?? null;
-    const value = Number(raw);
-    if (!Number.isFinite(value)) return null;
-    return Math.max(0, Math.min(100, Math.round(value)));
-  })();
-  const storyLastComment = (() => {
-    const raw = (story as any).lastComment
-      ?? (story as any).latestComment
-      ?? (story as any).lastNote
-      ?? '';
-    const text = String(raw || '').replace(/\s+/g, ' ').trim();
-    if (!text) return null;
-    return text.length > 140 ? `${text.slice(0, 140)}...` : text;
+    if (fromGcal && (scheduledBlock?.linkedStoryId || scheduledBlock?.googleEventId)) return 'Linked from Google Calendar';
+    if (scheduledBlock?.isAiGenerated) return 'Auto planned';
+    if (entryMethod.includes('manual') || source === 'manual' || source === 'bob') return 'Manually planned';
+    return 'Planned';
   })();
 
   const safeTaskCount = Number.isFinite(taskCount) ? Number(taskCount) : 0;
@@ -308,12 +283,6 @@ const SortableStoryCard: React.FC<SortableStoryCardProps> = ({
               {story.description}
             </div>
           )}
-          {storyLastComment && (
-            <div className="kanban-card__note">
-              <span className="kanban-card__note-label">Last comment:</span>{' '}
-              {storyLastComment}
-            </div>
-          )}
 
           {resolvedShowTags && visibleTags.length > 0 && (
             <div className="kanban-card__tags">
@@ -334,7 +303,7 @@ const SortableStoryCard: React.FC<SortableStoryCardProps> = ({
             <span className={priorityClass} title={`Priority: ${priorityLabel}`}>
               {priorityLabel}
             </span>
-            {(story as any).userPriorityFlag && (
+            {manualPriorityRank && manualPriorityLabel && (
               <span
                 className="kanban-card__meta-badge"
                 style={{
@@ -342,9 +311,9 @@ const SortableStoryCard: React.FC<SortableStoryCardProps> = ({
                   backgroundColor: 'rgba(220, 53, 69, 0.12)',
                   color: 'var(--bs-danger)',
                 }}
-                title="User #1 priority flag"
+                title={manualPriorityLabel}
               >
-                <span style={{ fontWeight: 800 }}>1</span>&nbsp;Priority
+                {manualPriorityLabel}
               </span>
             )}
             {isTop3 && (
@@ -355,11 +324,6 @@ const SortableStoryCard: React.FC<SortableStoryCardProps> = ({
             <span className="kanban-card__meta-badge" title="Story points">
               {(story.points ?? 0)} pts
             </span>
-            {storyProgressPct != null && (
-              <span className="kanban-card__meta-badge" title="Story progress percentage">
-                Progress {storyProgressPct}%
-              </span>
-            )}
             {scheduledBlockLabel && (
               <span className="d-inline-flex flex-column" style={{ lineHeight: 1.2 }}>
                 <span
@@ -371,28 +335,13 @@ const SortableStoryCard: React.FC<SortableStoryCardProps> = ({
                   }}
                   title={scheduledBlock?.title || 'Planned calendar block'}
                 >
-                  <CalendarClock size={11} style={{ marginRight: 4, marginTop: -1 }} />
                   {scheduledBlockLabel}
                 </span>
                 {scheduledBlockSourceLabel && (
-                  <span className={scheduledBlockSourceClassName} style={{ marginTop: 2 }}>
+                  <span className="text-muted" style={{ fontSize: '0.65rem', marginTop: 2 }}>
                     {scheduledBlockSourceLabel}
                   </span>
                 )}
-              </span>
-            )}
-            {deferredLabel && (
-              <span
-                className="kanban-card__meta-badge"
-                style={{
-                  borderColor: 'rgba(245, 158, 11, 0.45)',
-                  backgroundColor: 'rgba(245, 158, 11, 0.12)',
-                  color: '#b45309',
-                }}
-                title={deferredLabel}
-              >
-                <Clock3 size={11} style={{ marginRight: 4, marginTop: -1 }} />
-                Deferred
               </span>
             )}
             <span className="kanban-card__meta-text" title="Status">

--- a/react-app/src/components/visualization/ConfirmSprintChangesModal.tsx
+++ b/react-app/src/components/visualization/ConfirmSprintChangesModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AlertTriangle, X } from 'lucide-react';
+import type { GoalTimelineAffectedStory } from './goalTimelineImpact';
 
 interface Props {
   visible: boolean;
@@ -7,16 +8,7 @@ interface Props {
     goalId: string;
     startDate: number;
     endDate: number;
-    affectedStories: Array<{
-      id: string;
-      ref: string;
-      title: string;
-      plannedSprintId?: string;
-      plannedSprintName?: string;
-      recommendedSprintId?: string;
-      recommendedSprintName?: string;
-      impactedTaskCount?: number;
-    }>;
+    affectedStories: GoalTimelineAffectedStory[];
   } | null;
   onConfirm: () => void;
   onCancel: () => void;
@@ -33,6 +25,11 @@ const ConfirmSprintChangesModal: React.FC<Props> = ({
   const formatDate = (timestamp: number) => {
     return new Date(timestamp).toLocaleDateString();
   };
+
+  const movableStories = pendingChanges.affectedStories.filter(
+    (story) => story.recommendedSprintId && story.recommendedSprintId !== story.plannedSprintId,
+  );
+  const manualReviewStories = pendingChanges.affectedStories.length - movableStories.length;
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
@@ -54,7 +51,7 @@ const ConfirmSprintChangesModal: React.FC<Props> = ({
           <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
             <p className="text-sm text-amber-800">
               <strong>Warning:</strong> Changing this goal's timeline will affect {pendingChanges.affectedStories.length} stories 
-              and may require updating their planned sprints.
+              and will move the stories below to the sprint closest to the new start date when a recommendation is available.
             </p>
           </div>
           
@@ -110,7 +107,8 @@ const ConfirmSprintChangesModal: React.FC<Props> = ({
           
           <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
             <p className="text-sm text-blue-800">
-              <strong>Next Steps:</strong> After confirming, review the recommended sprint mapping and reassign each affected story if needed.
+              <strong>What happens on confirm:</strong> {movableStories.length} stor{movableStories.length === 1 ? 'y' : 'ies'} will be reassigned automatically.
+              {manualReviewStories > 0 ? ` ${manualReviewStories} stor${manualReviewStories === 1 ? 'y has' : 'ies have'} no safe recommendation and will stay where they are for manual review.` : ''}
             </p>
           </div>
         </div>
@@ -126,7 +124,7 @@ const ConfirmSprintChangesModal: React.FC<Props> = ({
             onClick={onConfirm}
             className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700"
           >
-            Confirm Changes
+            Confirm and Move Stories
           </button>
         </div>
       </div>

--- a/react-app/src/components/visualization/GoalRoadmapV3.tsx
+++ b/react-app/src/components/visualization/GoalRoadmapV3.tsx
@@ -18,7 +18,7 @@ import ConfirmSprintChangesModal from './ConfirmSprintChangesModal';
 import './GoalRoadmapV3.css';
 import { useGlobalThemes } from '../../hooks/useGlobalThemes';
 import GLOBAL_THEMES, { migrateThemeValue, type GlobalTheme } from '../../constants/globalThemes';
-import { buildGoalTimelineImpactPlan, snapPlannerGoalMoveRange } from './goalTimelineImpact';
+import { buildGoalTimelineImpactPlan, snapPlannerGoalMoveRange, type GoalTimelineAffectedStory } from './goalTimelineImpact';
 
 type Zoom = 'weeks' | 'months' | 'quarters' | 'years';
 type AxisLabel = { label: string; subLabel?: string; x: number; width: number };
@@ -90,16 +90,7 @@ const GoalRoadmapV3: React.FC = () => {
     originalStart: number;
     originalEnd: number;
     themeId?: number | null;
-    affectedStories: Array<{
-      id: string;
-      ref: string;
-      title: string;
-      plannedSprintId?: string;
-      plannedSprintName?: string;
-      recommendedSprintId?: string;
-      recommendedSprintName?: string;
-      impactedTaskCount?: number;
-    }>;
+    affectedStories: GoalTimelineAffectedStory[];
   } | null>(null);
   const [showSprints, setShowSprints] = useState(true);
   const [snapEnabled, setSnapEnabled] = useState(true);

--- a/react-app/src/components/visualization/GoalRoadmapV6.tsx
+++ b/react-app/src/components/visualization/GoalRoadmapV6.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { collection, doc, onSnapshot, query, serverTimestamp, updateDoc, where } from 'firebase/firestore';
 import { Star, Search, Edit3, Wand2, CalendarClock, Activity, Maximize2, Minimize2 } from 'lucide-react';
+import { useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { usePersona } from '../../contexts/PersonaContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -14,9 +15,12 @@ import { useSidebar } from '../../contexts/SidebarContext';
 import { httpsCallable } from 'firebase/functions';
 import EditGoalModal from '../EditGoalModal';
 import ConfirmSprintChangesModal from './ConfirmSprintChangesModal';
+import type { GoalTimelineAffectedStory } from './goalTimelineImpact';
 import SprintSelector from '../SprintSelector';
 import './GoalRoadmapV6.css';
 import { buildGoalTimelineImpactPlan } from './goalTimelineImpact';
+import { applyGoalTimelineChanges } from '../../utils/goalTimelineChanges';
+import { parseBooleanParam, parseIdListParam, parseNumberListParam } from '../../utils/planningQuery';
 import { getGoalAncestors, getGoalDisplayPath, isGoalInHierarchySet } from '../../utils/goalHierarchy';
 
 interface GanttTask {
@@ -408,9 +412,22 @@ const GoalRoadmapV6: React.FC = () => {
   const { currentUser } = useAuth();
   const { currentPersona } = usePersona();
   const { theme } = useTheme();
+  const [searchParams] = useSearchParams();
   const { themes: globalThemes } = useGlobalThemes();
   const { sprints, selectedSprintId } = useSprint();
   const { showSidebar } = useSidebar();
+  const embedded = parseBooleanParam(searchParams.get('embed'));
+  const queryGoalIds = useMemo(
+    () => parseIdListParam(searchParams.get('goalIds') || searchParams.get('goalId')),
+    [searchParams],
+  );
+  const queryGoalIdSet = useMemo(() => new Set(queryGoalIds), [queryGoalIds]);
+  const queryThemeIds = useMemo(
+    () => parseNumberListParam(searchParams.get('themeIds') || searchParams.get('themeId')),
+    [searchParams],
+  );
+  const queryThemeIdSet = useMemo(() => new Set(queryThemeIds), [queryThemeIds]);
+  const queryFocusOnly = parseBooleanParam(searchParams.get('focusOnly'));
   const [goals, setGoals] = useState<Goal[]>([]);
   const goalsById = useMemo(
     () => goals.reduce<Record<string, Goal>>((acc, goal) => {
@@ -441,20 +458,13 @@ const GoalRoadmapV6: React.FC = () => {
   const [respectSprintScope, setRespectSprintScope] = useState(true);
   const [editGoal, setEditGoal] = useState<Goal | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [timelineNotice, setTimelineNotice] = useState<string | null>(null);
+  const [timelineError, setTimelineError] = useState<string | null>(null);
   const [pendingSprintChanges, setPendingSprintChanges] = useState<{
     goalId: string;
     startDate: number;
     endDate: number;
-    affectedStories: Array<{
-      id: string;
-      ref: string;
-      title: string;
-      plannedSprintId?: string;
-      plannedSprintName?: string;
-      recommendedSprintId?: string;
-      recommendedSprintName?: string;
-      impactedTaskCount?: number;
-    }>;
+    affectedStories: GoalTimelineAffectedStory[];
   } | null>(null);
   const boardRef = useRef<HTMLDivElement | null>(null);
   const dragOperationRef = useRef<GoalDragOperation | null>(null);
@@ -468,6 +478,19 @@ const GoalRoadmapV6: React.FC = () => {
   const pointerUpHandlerRef = useRef<(event: PointerEvent) => void>(() => {});
 
   const ENABLE_MONZO_POTS = process.env.REACT_APP_ENABLE_MONZO_POTS === 'true';
+
+  useEffect(() => {
+    if (queryThemeIds.length === 1) {
+      setThemeFilter(queryThemeIds[0]);
+    }
+  }, [queryThemeIds]);
+
+  useEffect(() => {
+    if (queryFocusOnly) {
+      setShowFocusGoalsOnly(true);
+      setFocusToggleTouched(true);
+    }
+  }, [queryFocusOnly]);
 
   const handleGenerateStories = useCallback(async (goal: Goal) => {
     try {
@@ -692,6 +715,8 @@ const GoalRoadmapV6: React.FC = () => {
     return goals.filter(g => {
       const themeId = migrateThemeValue((g as any).theme);
       if (themeFilter !== 'all' && themeId !== themeFilter) return false;
+      if (queryThemeIdSet.size > 0 && !queryThemeIdSet.has(Number(themeId))) return false;
+      if (queryGoalIdSet.size > 0 && !isGoalInHierarchySet(g.id, goals, queryGoalIdSet)) return false;
       if (showStoryGoalsOnly && !(storyPoints[g.id] > 0)) return false;
       if (showFocusGoalsOnly && activeFocusGoalIds.size > 0 && !isGoalInHierarchySet(g.id, goals, activeFocusGoalIds)) return false;
       if (respectSprintScope && selectedSprint) {
@@ -709,7 +734,7 @@ const GoalRoadmapV6: React.FC = () => {
       if (!term) return true;
       return (g.title || '').toLowerCase().includes(term);
     });
-  }, [goals, search, themeFilter, showStoryGoalsOnly, showFocusGoalsOnly, activeFocusGoalIds, storyPoints, respectSprintScope, selectedSprint, storySprintMap]);
+  }, [goals, search, themeFilter, queryThemeIdSet, queryGoalIdSet, showStoryGoalsOnly, showFocusGoalsOnly, activeFocusGoalIds, storyPoints, respectSprintScope, selectedSprint, storySprintMap]);
 
   const sortedGoals = useMemo(() => {
     const enriched = filteredGoals.map(goal => {
@@ -1250,14 +1275,28 @@ const GoalRoadmapV6: React.FC = () => {
   }, []);
 
   const confirmSprintChanges = useCallback(async () => {
-    if (!pendingSprintChanges) return;
-    await persistGoalDates(
-      pendingSprintChanges.goalId,
-      pendingSprintChanges.startDate,
-      pendingSprintChanges.endDate
-    );
-    setPendingSprintChanges(null);
-  }, [pendingSprintChanges, persistGoalDates]);
+    if (!pendingSprintChanges || !currentUser?.uid || !currentPersona) return;
+    try {
+      const result = await applyGoalTimelineChanges({
+        goalId: pendingSprintChanges.goalId,
+        startDateMs: pendingSprintChanges.startDate,
+        endDateMs: pendingSprintChanges.endDate,
+        ownerUid: currentUser.uid,
+        persona: currentPersona,
+        affectedStories: pendingSprintChanges.affectedStories,
+      });
+      setTimelineError(null);
+      setTimelineNotice(
+        `Goal timeline updated. ${result.movedStoryCount} stor${result.movedStoryCount === 1 ? 'y was' : 'ies were'} moved to the nearest sprint start${result.reviewStoryCount > 0 ? `, and ${result.reviewStoryCount} still need manual review.` : '.'}`
+      );
+    } catch (error: any) {
+      console.error('[RoadmapV6] Failed to apply goal timeline changes', error);
+      setTimelineNotice(null);
+      setTimelineError(error?.message || 'Failed to update the goal timeline.');
+    } finally {
+      setPendingSprintChanges(null);
+    }
+  }, [currentPersona, currentUser?.uid, pendingSprintChanges]);
 
   useEffect(() => {
     pointerMoveHandlerRef.current = (event: PointerEvent) => {
@@ -1740,14 +1779,26 @@ const GoalRoadmapV6: React.FC = () => {
       ref={boardRef}
       className={`grv6-container theme-${theme} ${isFullscreen ? 'grv6-in-fullscreen' : ''}`}
     >
-      <div className="grv6-header">
-        <div className="grv6-title-stack">
-          <h1 className="grv6-title">Goal Roadmap V6</h1>
+      {!embedded && (
+        <div className="grv6-header">
+          <div className="grv6-title-stack">
+            <h1 className="grv6-title">Goal Roadmap V6</h1>
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="grv6-body">
         <div className="grv6-main">
+          {timelineError && (
+            <div className="mb-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {timelineError}
+            </div>
+          )}
+          {timelineNotice && (
+            <div className="mb-3 rounded border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700">
+              {timelineNotice}
+            </div>
+          )}
           {renderTopbar()}
           {renderGanttContent()}
         </div>

--- a/react-app/src/hooks/useFocusGoals.ts
+++ b/react-app/src/hooks/useFocusGoals.ts
@@ -3,6 +3,15 @@ import { collection, query, where, onSnapshot, doc, updateDoc, serverTimestamp }
 import { db } from '../firebase';
 import { FocusGoal } from '../types';
 
+const toMillis = (value: any): number => {
+  if (!value) return Number.NaN;
+  if (typeof value?.toMillis === 'function') return value.toMillis();
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'number') return value;
+  const parsed = Date.parse(String(value));
+  return Number.isNaN(parsed) ? Number.NaN : parsed;
+};
+
 export const useFocusGoals = (userId: string | undefined) => {
   const [focusGoals, setFocusGoals] = useState<FocusGoal[]>([]);
   const [loading, setLoading] = useState(true);
@@ -27,11 +36,14 @@ export const useFocusGoals = (userId: string | undefined) => {
 
       // Calculate daysRemaining for each
       const withDaysRemaining = focusGoalsData.map(fg => {
-        const endDate = new Date(fg.endDate);
+        const endDateMs = toMillis(fg.endDate);
         const daysRemaining = Math.ceil(
-          (endDate.getTime() - Date.now()) / (24 * 60 * 60 * 1000)
+          (endDateMs - Date.now()) / (24 * 60 * 60 * 1000)
         );
-        return { ...fg, daysRemaining };
+        return {
+          ...fg,
+          daysRemaining: Number.isFinite(daysRemaining) ? daysRemaining : 0,
+        };
       });
 
       setFocusGoals(withDaysRemaining);

--- a/react-app/src/services/focusGoalsService.ts
+++ b/react-app/src/services/focusGoalsService.ts
@@ -1,18 +1,23 @@
 import { db } from '../firebase';
-import { collection, addDoc, serverTimestamp, query, where, getDocs, updateDoc, doc, writeBatch, deleteField } from 'firebase/firestore';
-import { Goal } from '../types';
+import { collection, addDoc, serverTimestamp, query, where, getDocs, updateDoc, doc, writeBatch, deleteField, deleteDoc } from 'firebase/firestore';
+import { FocusGoal, Goal } from '../types';
 import { httpsCallable } from 'firebase/functions';
 import { functions } from '../firebase';
 import { generateRef } from '../utils/referenceGenerator';
-import { expandFocusGoalIdsToLeafGoalIds } from '../utils/goalHierarchy';
 
 export const FOCUS_WIZARD_PREFILL_KEY = 'bob_focus_wizard_prefill_v1';
 
 export interface FocusWizardPrefill {
+  title?: string;
   visionText?: string;
   timeframe?: 'sprint' | 'quarter' | 'year';
   searchTerm?: string;
   autoRunMatch?: boolean;
+  endDateMs?: number;
+  autoSelectGoalIds?: string[];
+  queuedLeafMilestones?: string[];
+  goalTypeMap?: { [goalId: string]: 'story' | 'calendar' };
+  sprintPlanByGoalId?: { [goalId: string]: number[] };
   source?: string;
   createdAt?: number;
 }
@@ -215,7 +220,7 @@ export async function createFocusGoal(
   potIdsCreatedFor?: { [goalId: string]: string },
   goalTypeMap?: { [goalId: string]: 'story' | 'calendar' },
   monzoPotGoalRefs?: { [goalId: string]: string },
-  focusRootGoalIds?: string[]
+  focusGoalInput?: Partial<FocusGoal>
 ) {
   try {
     const now = new Date();
@@ -224,32 +229,42 @@ export async function createFocusGoal(
       quarter: 91 * 24 * 60 * 60 * 1000,
       year: 365 * 24 * 60 * 60 * 1000
     };
-    const endDate = new Date(now.getTime() + daysInMs[timeframe]);
-    const daysRemaining = Math.ceil((endDate.getTime() - now.getTime()) / (24 * 60 * 60 * 1000));
-
-    const allGoalsSnap = await getDocs(query(collection(db, 'goals'), where('ownerUid', '==', userId)));
-    const allGoals = allGoalsSnap.docs.map((goalDoc) => ({ id: goalDoc.id, ...(goalDoc.data() as Goal) })) as Goal[];
-    const rootGoalIds = (focusRootGoalIds && focusRootGoalIds.length > 0 ? focusRootGoalIds : goalIds)
-      .map((goalId) => String(goalId || '').trim())
-      .filter(Boolean);
-    const focusLeafGoalIds = expandFocusGoalIdsToLeafGoalIds(rootGoalIds, allGoals);
+    const requestedEndDate = focusGoalInput?.endDate
+      ? new Date((focusGoalInput.endDate as any)?.toDate?.() || focusGoalInput.endDate as any)
+      : null;
+    const endDate = requestedEndDate && !Number.isNaN(requestedEndDate.getTime())
+      ? requestedEndDate
+      : new Date(now.getTime() + daysInMs[timeframe]);
+    const daysRemaining = Math.max(0, Math.ceil((endDate.getTime() - now.getTime()) / (24 * 60 * 60 * 1000)));
 
     const focusRef = collection(db, 'focusGoals');
     const docRef = await addDoc(focusRef, {
       ownerUid: userId,
-      persona: 'personal',
-      goalIds: focusLeafGoalIds,
-      focusRootGoalIds: rootGoalIds,
-      focusLeafGoalIds,
+      persona: focusGoalInput?.persona || 'personal',
+      title: focusGoalInput?.title || null,
+      description: focusGoalInput?.description || null,
+      goalIds,
+      focusRootGoalIds: Array.isArray(focusGoalInput?.focusRootGoalIds) ? focusGoalInput?.focusRootGoalIds : goalIds,
+      focusLeafGoalIds: Array.isArray(focusGoalInput?.focusLeafGoalIds) ? focusGoalInput?.focusLeafGoalIds : goalIds,
       goalTypeMap: goalTypeMap || {},
       timeframe,
-      startDate: serverTimestamp(),
+      startDate: focusGoalInput?.startDate || serverTimestamp(),
       endDate,
       daysRemaining,
       isActive: true,
       storiesCreatedFor: storiesCreatedFor || [],
       potIdsCreatedFor: potIdsCreatedFor || {},
+      visionText: focusGoalInput?.visionText || null,
+      intentBrokerIntakeId: focusGoalInput?.intentBrokerIntakeId || null,
+      intentMatches: focusGoalInput?.intentMatches || [],
+      intentProposals: focusGoalInput?.intentProposals || [],
+      storyTableHandoff: focusGoalInput?.storyTableHandoff !== false,
+      autoCreatedSprintIds: focusGoalInput?.autoCreatedSprintIds || [],
+      deferredNonFocusCount: Number(focusGoalInput?.deferredNonFocusCount || 0) || 0,
       monzoPotGoalRefs: monzoPotGoalRefs || {},
+      sprintPlanByGoalId: focusGoalInput?.sprintPlanByGoalId || {},
+      sprintPlanSegments: focusGoalInput?.sprintPlanSegments || [],
+      pendingLeafGoalsToCreate: focusGoalInput?.pendingLeafGoalsToCreate || [],
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp()
     });
@@ -259,6 +274,48 @@ export async function createFocusGoal(
     console.error('Failed to create focus goal:', error);
     throw error;
   }
+}
+
+const normalizeFocusGoalUpdate = (focusGoal: Partial<FocusGoal>) => {
+  const payload: Record<string, any> = {
+    updatedAt: serverTimestamp(),
+  };
+
+  if ('title' in focusGoal) payload.title = focusGoal.title || null;
+  if ('description' in focusGoal) payload.description = focusGoal.description || null;
+  if ('persona' in focusGoal) payload.persona = focusGoal.persona || 'personal';
+  if (Array.isArray(focusGoal.goalIds)) payload.goalIds = focusGoal.goalIds;
+  if (Array.isArray(focusGoal.focusRootGoalIds)) payload.focusRootGoalIds = focusGoal.focusRootGoalIds;
+  if (Array.isArray(focusGoal.focusLeafGoalIds)) payload.focusLeafGoalIds = focusGoal.focusLeafGoalIds;
+  if ('goalTypeMap' in focusGoal) payload.goalTypeMap = focusGoal.goalTypeMap || {};
+  if ('timeframe' in focusGoal) payload.timeframe = focusGoal.timeframe;
+  if ('endDate' in focusGoal) payload.endDate = focusGoal.endDate || null;
+  if ('daysRemaining' in focusGoal) payload.daysRemaining = Number(focusGoal.daysRemaining || 0) || 0;
+  if ('isActive' in focusGoal) payload.isActive = focusGoal.isActive !== false;
+  if ('visionText' in focusGoal) payload.visionText = focusGoal.visionText || null;
+  if ('intentBrokerIntakeId' in focusGoal) payload.intentBrokerIntakeId = focusGoal.intentBrokerIntakeId || null;
+  if ('intentMatches' in focusGoal) payload.intentMatches = focusGoal.intentMatches || [];
+  if ('intentProposals' in focusGoal) payload.intentProposals = focusGoal.intentProposals || [];
+  if ('storyTableHandoff' in focusGoal) payload.storyTableHandoff = focusGoal.storyTableHandoff !== false;
+  if ('storiesCreatedFor' in focusGoal) payload.storiesCreatedFor = focusGoal.storiesCreatedFor || [];
+  if ('potIdsCreatedFor' in focusGoal) payload.potIdsCreatedFor = focusGoal.potIdsCreatedFor || {};
+  if ('monzoPotGoalRefs' in focusGoal) payload.monzoPotGoalRefs = focusGoal.monzoPotGoalRefs || {};
+  if ('sprintPlanByGoalId' in focusGoal) payload.sprintPlanByGoalId = focusGoal.sprintPlanByGoalId || {};
+  if ('sprintPlanSegments' in focusGoal) payload.sprintPlanSegments = focusGoal.sprintPlanSegments || [];
+  if ('pendingLeafGoalsToCreate' in focusGoal) payload.pendingLeafGoalsToCreate = focusGoal.pendingLeafGoalsToCreate || [];
+  if ('autoCreatedSprintIds' in focusGoal) payload.autoCreatedSprintIds = focusGoal.autoCreatedSprintIds || [];
+  if ('deferredNonFocusCount' in focusGoal) payload.deferredNonFocusCount = Number(focusGoal.deferredNonFocusCount || 0) || 0;
+
+  return payload;
+};
+
+export async function updateFocusGoal(focusGoalId: string, focusGoal: Partial<FocusGoal>) {
+  const focusGoalRef = doc(db, 'focusGoals', focusGoalId);
+  await updateDoc(focusGoalRef, normalizeFocusGoalUpdate(focusGoal));
+}
+
+export async function deleteFocusGoal(focusGoalId: string) {
+  await deleteDoc(doc(db, 'focusGoals', focusGoalId));
 }
 
 export async function persistMonzoGoalRefs(options: {

--- a/react-app/src/styles/Dashboard.css
+++ b/react-app/src/styles/Dashboard.css
@@ -127,6 +127,15 @@
   overflow: auto;
 }
 
+.dashboard-summary-stack > .card {
+  flex: 1 1 0;
+  min-height: 0;
+}
+
+.dashboard-summary-stack > .card .card-body {
+  min-height: 0;
+}
+
 .dashboard-widget-resize-handle {
   position: absolute;
   right: 10px;

--- a/react-app/src/styles/KanbanCards.css
+++ b/react-app/src/styles/KanbanCards.css
@@ -372,6 +372,13 @@
   flex-direction: column;
   gap: 6px;
   margin-bottom: 12px;
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  margin: -14px -14px 12px;
+  padding: 14px 14px 12px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
 }
 
 .sprint-column__header-top {

--- a/react-app/src/types.ts
+++ b/react-app/src/types.ts
@@ -3,8 +3,8 @@ export interface FocusGoal {
   ownerUid: string;
   persona: 'personal' | 'work';
   goalIds: string[]; // IDs of goals selected for focus
-  focusRootGoalIds?: string[]; // Strategic goals the user explicitly selected
-  focusLeafGoalIds?: string[]; // Execution goals expanded from root selections
+  focusRootGoalIds?: string[];
+  focusLeafGoalIds?: string[];
   goalTypeMap?: { [goalId: string]: 'story' | 'calendar' };
   timeframe: 'sprint' | 'quarter' | 'year'; // Duration of focus
   startDate: any; // Firebase Timestamp
@@ -37,10 +37,10 @@ export interface FocusGoal {
     tempId: string;
     parentGoalId: string;
     title: string;
-    theme?: number;
-    persona?: 'personal' | 'work';
-    goalKind?: 'milestone' | 'execution';
-    timeHorizon?: 'sprint' | 'quarter' | 'year';
+    theme: number;
+    persona: 'personal' | 'work';
+    goalKind: string;
+    timeHorizon: string;
   }>;
 }
 
@@ -134,6 +134,7 @@ export interface Story {
   aiTop3Reason?: string;
   // User-set #1 priority flag for gcal override
   userPriorityFlag?: boolean;
+  userPriorityRank?: 1 | 2 | 3 | null;
   userPriorityFlagAt?: string;
   deferredUntil?: any;
   deferredReason?: string;
@@ -311,6 +312,8 @@ export interface Task {
   aiTop3Date?: string;
   aiPriorityLabel?: string;
   aiTop3Reason?: string;
+  userPriorityFlag?: boolean;
+  userPriorityRank?: 1 | 2 | 3 | null;
   iosPriority?: string;
   type?: 'task' | 'chore' | 'routine' | 'habit' | 'read' | 'watch' | string;
   repeatFrequency?: 'daily' | 'weekly' | 'monthly' | 'yearly' | null;

--- a/react-app/src/utils/goalTimelineChanges.ts
+++ b/react-app/src/utils/goalTimelineChanges.ts
@@ -1,0 +1,62 @@
+import { doc, serverTimestamp, writeBatch } from 'firebase/firestore';
+import { db } from '../firebase';
+import type { GoalTimelineAffectedStory } from '../components/visualization/goalTimelineImpact';
+
+interface ApplyGoalTimelineChangesArgs {
+  goalId: string;
+  startDateMs: number;
+  endDateMs: number;
+  targetYear?: number | null;
+  ownerUid: string;
+  persona: 'personal' | 'work';
+  affectedStories?: GoalTimelineAffectedStory[];
+}
+
+export async function applyGoalTimelineChanges({
+  goalId,
+  startDateMs,
+  endDateMs,
+  targetYear,
+  ownerUid,
+  persona,
+  affectedStories = [],
+}: ApplyGoalTimelineChangesArgs) {
+  const batch = writeBatch(db);
+  const goalRef = doc(db, 'goals', goalId);
+  const goalPatch: Record<string, any> = {
+    startDate: startDateMs,
+    endDate: endDateMs,
+    updatedAt: serverTimestamp(),
+  };
+
+  if (targetYear !== undefined) {
+    goalPatch.targetYear = targetYear ?? null;
+  }
+
+  batch.update(goalRef, goalPatch);
+
+  let movedStoryCount = 0;
+  let reviewStoryCount = 0;
+
+  affectedStories.forEach((story) => {
+    if (!story?.id) return;
+    if (!story.recommendedSprintId || story.recommendedSprintId === story.plannedSprintId) {
+      reviewStoryCount += 1;
+      return;
+    }
+    batch.update(doc(db, 'stories', story.id), {
+      sprintId: story.recommendedSprintId,
+      ownerUid,
+      persona,
+      updatedAt: serverTimestamp(),
+    });
+    movedStoryCount += 1;
+  });
+
+  await batch.commit();
+
+  return {
+    movedStoryCount,
+    reviewStoryCount,
+  };
+}

--- a/react-app/src/utils/kpiDisplay.ts
+++ b/react-app/src/utils/kpiDisplay.ts
@@ -1,0 +1,44 @@
+export const toKpiNumber = (value: any): number | null => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const formatKpiValue = (value: number | null, unit: string): string => {
+  if (value == null) return '—';
+  if (unit === 'GBP') return `£${Math.round(value).toLocaleString()}`;
+  if (unit === '%') return `${Math.round(value)}%`;
+  if (unit === 'km' || unit === 'hours') return `${Number(value.toFixed(1))}`;
+  return `${Math.round(value)}`;
+};
+
+export const getKpiStateLabel = (
+  progressPct: number | null,
+  healthy?: boolean | null,
+  stale?: boolean | null,
+): string => {
+  if (stale === true || healthy === false) {
+    return progressPct != null ? `Stale data · ${Math.round(progressPct)}% of target` : 'Stale data';
+  }
+  if (healthy === true) {
+    return progressPct != null ? `Healthy · ${Math.round(progressPct)}% of target` : 'Healthy';
+  }
+  if (progressPct != null) {
+    return `${Math.round(progressPct)}% of target`;
+  }
+  return 'Waiting for synced KPI metrics';
+};
+
+export const getKpiHealthRollupLabel = (healthy: number, total: number, stale = 0): string => {
+  if (total === 0) return 'No KPIs';
+  if (stale > 0) return `${healthy}/${total} healthy · ${stale} stale`;
+  return `${healthy}/${total} healthy`;
+};
+
+export const getKpiStateBadge = (
+  healthy?: boolean | null,
+  stale?: boolean | null,
+): { bg: 'success' | 'warning' | 'secondary'; label: string } => {
+  if (stale === true || healthy === false) return { bg: 'warning', label: 'Stale' };
+  if (healthy === true) return { bg: 'success', label: 'Healthy' };
+  return { bg: 'secondary', label: 'Pending' };
+};

--- a/react-app/src/utils/manualPriority.ts
+++ b/react-app/src/utils/manualPriority.ts
@@ -1,0 +1,40 @@
+export type ManualPriorityRank = 1 | 2 | 3 | null;
+
+export function getManualPriorityRank(entity: any): ManualPriorityRank {
+  const explicit = Number(entity?.userPriorityRank);
+  if (explicit === 1 || explicit === 2 || explicit === 3) return explicit;
+  return entity?.userPriorityFlag === true ? 1 : null;
+}
+
+export function getManualPriorityLabel(entity: any): string | null {
+  const rank = getManualPriorityRank(entity);
+  return rank ? `#${rank} Priority` : null;
+}
+
+export function getNextManualPriorityRank(items: any[], persona: string, excludeId?: string): 1 | 2 | 3 {
+  const normalizedPersona = String(persona || 'personal');
+  const used = new Set<number>();
+  (items || []).forEach((item) => {
+    if (!item || item.id === excludeId) return;
+    if (String(item.persona || 'personal') !== normalizedPersona) return;
+    const rank = getManualPriorityRank(item);
+    if (rank) used.add(rank);
+  });
+  if (!used.has(1)) return 1;
+  if (!used.has(2)) return 2;
+  return 3;
+}
+
+export function findItemWithManualPriorityRank<T extends { id?: string; persona?: string }>(
+  items: T[],
+  persona: string,
+  rank: 1 | 2 | 3,
+  excludeId?: string,
+): T | null {
+  const normalizedPersona = String(persona || 'personal');
+  return (items || []).find((item) => {
+    if (!item || item.id === excludeId) return false;
+    if (String(item.persona || 'personal') !== normalizedPersona) return false;
+    return getManualPriorityRank(item) === rank;
+  }) || null;
+}

--- a/react-app/src/utils/plannerCapacity.ts
+++ b/react-app/src/utils/plannerCapacity.ts
@@ -1,0 +1,147 @@
+import type { Goal, Sprint, Story, Task } from '../types';
+import type { PlannerItem } from './plannerItems';
+import { isGoalInHierarchySet } from './goalHierarchy';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface CapacitySummary {
+  capacityPoints: number;
+  plannedPoints: number;
+  remainingPoints: number;
+  utilizationPct: number;
+  overCapacity: boolean;
+  focusAlignedPoints: number;
+  nonFocusPoints: number;
+}
+
+const clampCapacity = (value: number, fallback: number) => {
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  return Math.max(1, Number(value));
+};
+
+export const taskPoints = (task: Task | any): number => {
+  const direct = Number(task?.points || 0);
+  if (Number.isFinite(direct) && direct > 0) return direct;
+  const mins = Number(task?.estimateMin || 0);
+  if (Number.isFinite(mins) && mins > 0) return Math.max(0.25, mins / 60);
+  return 1;
+};
+
+export const storyPoints = (story: Story | any): number => {
+  const direct = Number(story?.points || 0);
+  if (Number.isFinite(direct) && direct > 0) return direct;
+  return 1;
+};
+
+export const plannerItemPoints = (item: PlannerItem): number => {
+  if (Array.isArray(item.childItems) && item.childItems.length > 0) {
+    return item.childItems.reduce((sum, child) => sum + plannerItemPoints(child), 0);
+  }
+  if (item.scheduledBlockStart && item.scheduledBlockEnd && item.scheduledBlockEnd > item.scheduledBlockStart) {
+    return Math.max(0.25, (item.scheduledBlockEnd - item.scheduledBlockStart) / (60 * 60 * 1000));
+  }
+  if (item.rawTask) return taskPoints(item.rawTask);
+  if (item.rawStory) return storyPoints(item.rawStory);
+  return item.kind === 'story' ? 2 : 1;
+};
+
+export const summarizeCapacity = (
+  points: number[],
+  capacityPoints: number,
+  focusPoints: number[] = [],
+): CapacitySummary => {
+  const plannedPoints = points.reduce((sum, value) => sum + value, 0);
+  const focusAlignedPoints = focusPoints.reduce((sum, value) => sum + value, 0);
+  const safeCapacity = clampCapacity(capacityPoints, 1);
+  const remainingPoints = safeCapacity - plannedPoints;
+  const utilizationPct = Math.round((plannedPoints / safeCapacity) * 100);
+  return {
+    capacityPoints: safeCapacity,
+    plannedPoints,
+    remainingPoints,
+    utilizationPct,
+    overCapacity: remainingPoints < 0,
+    focusAlignedPoints,
+    nonFocusPoints: Math.max(0, plannedPoints - focusAlignedPoints),
+  };
+};
+
+export const buildDayCapacityMap = (
+  dayKeys: string[],
+  items: PlannerItem[],
+  capacityPointsPerDay = 8,
+) => {
+  const grouped = new Map<string, PlannerItem[]>();
+  dayKeys.forEach((dayKey) => grouped.set(dayKey, []));
+  items.forEach((item) => {
+    const existing = grouped.get(item.dayKey) || [];
+    existing.push(item);
+    grouped.set(item.dayKey, existing);
+  });
+  const summary = new Map<string, CapacitySummary>();
+  dayKeys.forEach((dayKey) => {
+    const dayItems = grouped.get(dayKey) || [];
+    summary.set(
+      dayKey,
+      summarizeCapacity(
+        dayItems.map((item) => plannerItemPoints(item)),
+        capacityPointsPerDay,
+        dayItems.filter((item) => item.isFocusAligned).map((item) => plannerItemPoints(item)),
+      ),
+    );
+  });
+  return summary;
+};
+
+export const deriveSprintCapacityPoints = (
+  sprint: Sprint | null | undefined,
+  weeklyCapacityPoints = 20,
+) => {
+  const explicit = Number((sprint as any)?.capacityPoints || 0);
+  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+  const startMs = Number((sprint as any)?.startDate || 0);
+  const endMs = Number((sprint as any)?.endDate || 0);
+  if (Number.isFinite(startMs) && Number.isFinite(endMs) && endMs >= startMs) {
+    const sprintWeeks = Math.max(1, Math.ceil((endMs - startMs + DAY_MS) / (7 * DAY_MS)));
+    return sprintWeeks * weeklyCapacityPoints;
+  }
+  return weeklyCapacityPoints;
+};
+
+export const buildSprintCapacitySummary = ({
+  sprint,
+  stories,
+  goals,
+  activeFocusGoalIds,
+  weeklyCapacityPoints = 20,
+}: {
+  sprint: Sprint | null | undefined;
+  stories: Story[];
+  goals: Goal[];
+  activeFocusGoalIds: Set<string>;
+  weeklyCapacityPoints?: number;
+}) => {
+  const focusPoints = stories
+    .filter((story) => {
+      const goalId = String(story.goalId || '').trim();
+      return !!goalId && isGoalInHierarchySet(goalId, goals, activeFocusGoalIds);
+    })
+    .map((story) => storyPoints(story));
+  return summarizeCapacity(
+    stories.map((story) => storyPoints(story)),
+    deriveSprintCapacityPoints(sprint, weeklyCapacityPoints),
+    focusPoints,
+  );
+};
+
+export const findSprintForDate = (sprints: Sprint[], dateMs: number): Sprint | null => {
+  const exact = sprints.find((sprint) => {
+    const startMs = Number((sprint as any)?.startDate || 0);
+    const endMs = Number((sprint as any)?.endDate || 0);
+    return Number.isFinite(startMs) && Number.isFinite(endMs) && dateMs >= startMs && dateMs <= endMs;
+  });
+  if (exact) return exact;
+  return [...sprints]
+    .filter((sprint) => Number((sprint as any)?.startDate || 0) >= dateMs)
+    .sort((a, b) => Number((a as any)?.startDate || 0) - Number((b as any)?.startDate || 0))[0] || null;
+};

--- a/react-app/src/utils/plannerItems.ts
+++ b/react-app/src/utils/plannerItems.ts
@@ -1,0 +1,616 @@
+import type { Goal, Story, Task } from '../types';
+import { getGoalAncestors, getGoalDisplayPath } from './goalHierarchy';
+import { isRecurringDueOnDate, resolveTaskDueMs } from './recurringTaskDue';
+import { storyStatusText, taskStatusText } from './storyCardFormatting';
+import {
+  bucketFromTime,
+  bucketPseudoTime,
+  formatBucketBackfillLabel,
+  type TimelineBucket,
+} from './timelineBuckets';
+
+export type PlannerItemKind = 'task' | 'story' | 'chore' | 'event';
+
+export interface PlannerCalendarBlockRow {
+  id: string;
+  title?: string;
+  start?: number;
+  end?: number;
+  taskId?: string | null;
+  storyId?: string | null;
+  linkedStoryId?: string | null;
+  source?: string | null;
+  entry_method?: string | null;
+  entityType?: string | null;
+  category?: string | null;
+  sourceInstanceId?: string | null;
+  sourceInstanceIds?: string[] | null;
+  choreId?: string | null;
+  routineId?: string | null;
+  habitId?: string | null;
+  items?: Array<Record<string, any>> | null;
+  itemCount?: number | null;
+}
+
+export interface PlannerScheduledInstanceRow {
+  id: string;
+  ownerUid: string;
+  sourceType?: string | null;
+  sourceId?: string | null;
+  occurrenceDate?: string | null;
+  status?: string | null;
+  updatedAt?: number | null;
+  dayKey?: string | null;
+  blockId?: string | null;
+  plannedStart?: string | null;
+  plannedEnd?: string | null;
+  timeOfDay?: string | null;
+  durationMinutes?: number | null;
+  title?: string | null;
+  goalId?: string | null;
+  storyId?: string | null;
+}
+
+export interface PlannerSummaryEvent {
+  id: string;
+  title: string;
+  startMs: number | null;
+  endMs: number | null;
+}
+
+export interface PlannerItem {
+  id: string;
+  kind: PlannerItemKind;
+  title: string;
+  ref: string | null;
+  dayKey: string;
+  timeOfDay: TimelineBucket;
+  timeLabel: string;
+  sortMs: number | null;
+  bucket: TimelineBucket;
+  sourceId?: string;
+  isTop3?: boolean;
+  deferredUntilMs?: number | null;
+  dueAt?: number | null;
+  statusLabel?: string | null;
+  progressPct?: number | null;
+  scheduledSourceLabel?: string | null;
+  goalId?: string | null;
+  goalTitle: string | null;
+  goalTheme: string | null;
+  isFocusAligned: boolean;
+  rawTask: Task | null;
+  rawStory: Story | null;
+  scheduledBlockStart: number | null;
+  scheduledBlockEnd: number | null;
+  scheduledBlockId?: string | null;
+  scheduledInstanceId?: string | null;
+  childItems?: PlannerItem[];
+}
+
+interface PlannerBuildParams {
+  tasks: Task[];
+  stories: Story[];
+  goals: Goal[];
+  calendarBlocks: PlannerCalendarBlockRow[];
+  scheduledInstances: PlannerScheduledInstanceRow[];
+  activeFocusGoalIds: Set<string>;
+  rangeStartMs: number;
+  rangeEndMs: number;
+  selectedSprintId?: string | null;
+  summaryEvents?: PlannerSummaryEvent[];
+  includeUnscheduledTasks?: boolean;
+}
+
+export const toMs = (value: any): number | null => {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value?.toDate === 'function') {
+    try {
+      return value.toDate().getTime();
+    } catch {
+      return null;
+    }
+  }
+  const parsed = Date.parse(String(value));
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+const startOfDayMs = (value: number) => {
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+};
+
+export const toDayKey = (value: number | Date) => {
+  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+  date.setHours(0, 0, 0, 0);
+  return date.toISOString().slice(0, 10);
+};
+
+export const isDoneStatus = (value: any): boolean => {
+  if (typeof value === 'number') return value >= 2;
+  const raw = String(value || '').trim().toLowerCase();
+  return raw === 'done' || raw === 'complete' || raw === 'completed' || raw === 'archived';
+};
+
+export const normalizeStoryStatus = (value: any): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  const raw = String(value || '').trim().toLowerCase();
+  if (raw === 'done' || raw === 'complete' || raw === 'completed') return 4;
+  if (raw === 'testing' || raw === 'qa' || raw === 'review') return 3;
+  if (raw === 'in progress' || raw === 'in-progress' || raw === 'active' || raw === 'doing' || raw === 'blocked') return 2;
+  if (raw === 'planned' || raw === 'ready') return 1;
+  return 0;
+};
+
+const isTop3ForToday = (value: any): boolean => {
+  if (value?.aiTop3ForDay !== true) return false;
+  const top3Date = String(value?.aiTop3Date || '').trim();
+  if (!top3Date) return true;
+  return top3Date.slice(0, 10) === new Date().toISOString().slice(0, 10);
+};
+
+export const getChoreKind = (task: Task): 'chore' | 'routine' | 'habit' | null => {
+  const raw = String((task as any)?.type || (task as any)?.task_type || '').trim().toLowerCase();
+  const normalized = raw === 'habitual' ? 'habit' : raw;
+  if (normalized === 'chore' || normalized === 'routine' || normalized === 'habit') return normalized;
+  return null;
+};
+
+export const resolveTaskRef = (task: Task) => task.ref || `TK-${task.id.slice(-6).toUpperCase()}`;
+export const resolveStoryRef = (story: Story) => ((story as any).referenceNumber || story.ref || `ST-${story.id.slice(-6).toUpperCase()}`);
+
+const scheduledSourceLabelForBlock = (block: PlannerCalendarBlockRow | null): string | null => {
+  const source = String(block?.source || '').toLowerCase();
+  const entryMethod = String(block?.entry_method || '').toLowerCase();
+  const fromGcal = source === 'gcal' || entryMethod === 'google_calendar';
+  if (fromGcal) return 'linked from gcal';
+  if (source === 'bob' || source === 'manual' || entryMethod.includes('manual')) return 'manual';
+  if (source.includes('ai') || entryMethod.includes('auto')) return 'auto-planned';
+  return null;
+};
+
+const isGoalAlignedToFocus = (goalId: string | null | undefined, goals: Goal[], activeFocusGoalIds: Set<string>) => {
+  const normalized = String(goalId || '').trim();
+  if (!normalized) return false;
+  if (activeFocusGoalIds.has(normalized)) return true;
+  return getGoalAncestors(normalized, goals).some((goal) => activeFocusGoalIds.has(goal.id));
+};
+
+const instanceDayKey = (value: string | null | undefined) => {
+  const raw = String(value || '').trim();
+  if (!raw) return null;
+  if (/^\d{8}$/.test(raw)) {
+    return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`;
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+  return null;
+};
+
+const dayKeyToMs = (dayKey: string) => {
+  const parsed = Date.parse(`${dayKey}T12:00:00`);
+  return Number.isNaN(parsed) ? null : startOfDayMs(parsed);
+};
+
+export const buildPlannerItems = ({
+  tasks,
+  stories,
+  goals,
+  calendarBlocks,
+  scheduledInstances,
+  activeFocusGoalIds,
+  rangeStartMs,
+  rangeEndMs,
+  selectedSprintId,
+  summaryEvents = [],
+  includeUnscheduledTasks = false,
+}: PlannerBuildParams): PlannerItem[] => {
+  const rows: PlannerItem[] = [];
+  const seen = new Set<string>();
+  const storyMap = new Map(stories.map((story) => [story.id, story]));
+  const goalMap = new Map(goals.map((goal) => [goal.id, goal]));
+  const taskMap = new Map(tasks.map((task) => [task.id, task]));
+  const blockByTaskId = new Map<string, PlannerCalendarBlockRow>();
+  const blockByStoryId = new Map<string, PlannerCalendarBlockRow>();
+  const calendarBlockById = new Map<string, PlannerCalendarBlockRow>();
+  const blockByInstanceId = new Map<string, PlannerCalendarBlockRow>();
+  const instanceMap = new Map<string, PlannerScheduledInstanceRow[]>();
+  const instanceById = new Map<string, PlannerScheduledInstanceRow>();
+  const groupedRecurringBlockIds = new Set<string>();
+  const groupedRecurringInstanceIds = new Set<string>();
+  const rangeEndDayMs = startOfDayMs(rangeEndMs);
+  const isSingleDayRange = startOfDayMs(rangeStartMs) === startOfDayMs(rangeEndMs);
+
+  calendarBlocks.forEach((block) => {
+    const blockStart = toMs(block.start);
+    calendarBlockById.set(block.id, block);
+    if (blockStart == null || blockStart < rangeStartMs || blockStart > rangeEndMs) return;
+    const taskId = String(block.taskId || '').trim();
+    const storyId = String(block.storyId || block.linkedStoryId || '').trim();
+    if (taskId) blockByTaskId.set(taskId, block);
+    if (storyId) blockByStoryId.set(storyId, block);
+    const sourceInstanceId = String(block.sourceInstanceId || '').trim();
+    if (sourceInstanceId) blockByInstanceId.set(sourceInstanceId, block);
+    const sourceInstanceIds = Array.isArray(block.sourceInstanceIds) ? block.sourceInstanceIds : [];
+    sourceInstanceIds.forEach((instanceId) => {
+      const normalized = String(instanceId || '').trim();
+      if (normalized) blockByInstanceId.set(normalized, block);
+    });
+    const blockEntity = String(block.entityType || block.category || '').toLowerCase();
+    const hasRecurringItems = !!(block.choreId || block.routineId || block.habitId)
+      || blockEntity.includes('chore')
+      || blockEntity.includes('routine')
+      || blockEntity.includes('habit')
+      || ((Array.isArray(block.items) ? block.items : []).some((item) => {
+        const sourceType = String(item?.sourceType || item?.entityType || '').toLowerCase();
+        return ['chore', 'routine', 'habit'].includes(sourceType);
+      }));
+    if (hasRecurringItems && sourceInstanceIds.length > 1) {
+      groupedRecurringBlockIds.add(block.id);
+      sourceInstanceIds.forEach((instanceId) => {
+        const normalized = String(instanceId || '').trim();
+        if (normalized) groupedRecurringInstanceIds.add(normalized);
+      });
+    }
+  });
+
+  scheduledInstances.forEach((instance) => {
+    const sourceType = String(instance.sourceType || '').trim().toLowerCase();
+    const sourceId = String(instance.sourceId || '').trim();
+    const dayKey = instanceDayKey(instance.occurrenceDate);
+    if (!sourceType || !sourceId || !dayKey) return;
+    instanceById.set(instance.id, instance);
+    const ms = dayKeyToMs(dayKey);
+    if (ms == null || ms < startOfDayMs(rangeStartMs) || ms > startOfDayMs(rangeEndMs)) return;
+    const key = `${sourceType}:${sourceId}`;
+    const existing = instanceMap.get(key) || [];
+    existing.push(instance);
+    instanceMap.set(key, existing);
+  });
+
+  const push = (row: PlannerItem, dedupeKey = row.id) => {
+    if (seen.has(dedupeKey)) return;
+    seen.add(dedupeKey);
+    rows.push(row);
+  };
+
+  const addRecurringRows = (task: Task) => {
+    const choreKind = getChoreKind(task);
+    if (!choreKind) return false;
+      const candidateSourceTypes = choreKind === 'habit' ? ['habit', 'routine', 'chore'] : [choreKind];
+      const matchingInstances = candidateSourceTypes.flatMap((sourceType) => instanceMap.get(`${sourceType}:${task.id}`) || []);
+    if (matchingInstances.length === 0) return false;
+
+    matchingInstances.forEach((instance) => {
+      if (groupedRecurringInstanceIds.has(instance.id)) return;
+      const status = String(instance.status || '').trim().toLowerCase();
+      if (['completed', 'missed', 'skipped', 'cancelled'].includes(status)) return;
+      const dayKey = instanceDayKey(instance.occurrenceDate);
+      if (!dayKey) return;
+      const dayMs = dayKeyToMs(dayKey);
+      if (dayMs == null) return;
+      const linkedBlock = blockByInstanceId.get(instance.id) || (instance.blockId ? calendarBlockById.get(String(instance.blockId)) || null : null);
+      const startMs = linkedBlock ? toMs(linkedBlock.start) : toMs(instance.plannedStart);
+      const endMs = linkedBlock ? toMs(linkedBlock.end) : toMs(instance.plannedEnd);
+      const goalId = String((task as any).goalId || '').trim() || null;
+      const goal = goalId ? goalMap.get(goalId) || null : null;
+      const bucket = bucketFromTime(startMs ?? dayMs, instance.timeOfDay || (task as any).timeOfDay, 'morning');
+      const sortMs = startMs ?? bucketPseudoTime(dayMs, bucket);
+      push({
+        id: `instance-${instance.id}`,
+        kind: 'chore',
+        title: task.title || 'Recurring item',
+        ref: resolveTaskRef(task),
+        dayKey,
+        timeOfDay: bucket,
+        timeLabel: formatBucketBackfillLabel(startMs, endMs, instance.timeOfDay || (task as any).timeOfDay),
+        sortMs,
+        bucket,
+        sourceId: task.id,
+        isTop3: false,
+        deferredUntilMs: toMs((task as any).deferredUntil),
+        dueAt: startMs ?? sortMs,
+        statusLabel: taskStatusText((task as any).status),
+        progressPct: Number.isFinite(Number((task as any).progressPct)) ? Number((task as any).progressPct) : null,
+        scheduledSourceLabel: linkedBlock ? scheduledSourceLabelForBlock(linkedBlock) : 'recurring schedule',
+        goalId,
+        goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
+        goalTheme: goal ? String((goal as any).theme || '') || null : null,
+        isFocusAligned: isGoalAlignedToFocus(goalId, goals, activeFocusGoalIds),
+        rawTask: task,
+        rawStory: null,
+        scheduledBlockStart: startMs,
+        scheduledBlockEnd: endMs,
+        scheduledBlockId: linkedBlock?.id || String(instance.blockId || '') || null,
+        scheduledInstanceId: instance.id,
+      });
+    });
+
+    return matchingInstances.length > 0;
+  };
+
+  groupedRecurringBlockIds.forEach((blockId) => {
+    const block = calendarBlockById.get(blockId);
+    if (!block) return;
+    const instanceIds = Array.isArray(block.sourceInstanceIds)
+      ? block.sourceInstanceIds.map((value) => String(value || '').trim()).filter(Boolean)
+      : [];
+    const childItems = instanceIds
+      .map((instanceId) => {
+        const instance = instanceById.get(instanceId);
+        if (!instance) return null;
+        const status = String(instance.status || '').trim().toLowerCase();
+        if (['completed', 'missed', 'skipped', 'cancelled'].includes(status)) return null;
+        const task = taskMap.get(String(instance.sourceId || '').trim());
+        if (!task) return null;
+        const dayKey = instanceDayKey(instance.occurrenceDate) || toDayKey(toMs(block.start) || rangeStartMs);
+        const startMs = toMs(block.start) || toMs(instance.plannedStart);
+        const endMs = toMs(block.end) || toMs(instance.plannedEnd);
+        const goalId = String((task as any).goalId || '').trim() || null;
+        const goal = goalId ? goalMap.get(goalId) || null : null;
+        const bucket = bucketFromTime(startMs, instance.timeOfDay || (task as any).timeOfDay, 'morning');
+        return {
+          id: `instance-${instance.id}`,
+          kind: 'chore' as const,
+          title: task.title || instance.title || 'Recurring item',
+          ref: resolveTaskRef(task),
+          dayKey,
+          timeOfDay: bucket,
+          timeLabel: formatBucketBackfillLabel(startMs, endMs, instance.timeOfDay || (task as any).timeOfDay),
+          sortMs: startMs ?? bucketPseudoTime(dayKeyToMs(dayKey) || rangeStartMs, bucket),
+          bucket,
+          sourceId: task.id,
+          isTop3: false,
+          deferredUntilMs: toMs((task as any).deferredUntil),
+          dueAt: startMs,
+          statusLabel: taskStatusText((task as any).status),
+          progressPct: Number.isFinite(Number((task as any).progressPct)) ? Number((task as any).progressPct) : null,
+          scheduledSourceLabel: scheduledSourceLabelForBlock(block),
+          goalId,
+          goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
+          goalTheme: goal ? String((goal as any).theme || '') || null : null,
+          isFocusAligned: isGoalAlignedToFocus(goalId, goals, activeFocusGoalIds),
+          rawTask: task,
+          rawStory: null,
+          scheduledBlockStart: startMs,
+          scheduledBlockEnd: endMs,
+          scheduledBlockId: block.id,
+          scheduledInstanceId: instance.id,
+        } satisfies PlannerItem;
+      })
+      .filter(Boolean) as PlannerItem[];
+
+    if (childItems.length === 0) return;
+    const earliestStart = childItems.reduce((min, child) => {
+      const value = child.scheduledBlockStart ?? child.sortMs ?? rangeStartMs;
+      return Math.min(min, value);
+    }, Number.MAX_SAFE_INTEGER);
+    const latestEnd = childItems.reduce((max, child) => {
+      const value = child.scheduledBlockEnd ?? child.scheduledBlockStart ?? child.sortMs ?? rangeStartMs;
+      return Math.max(max, value);
+    }, 0);
+    const bucket = bucketFromTime(earliestStart, childItems[0]?.timeOfDay, 'morning');
+    push({
+      id: `chore-group-${block.id}`,
+      kind: 'chore',
+      title: String(block.title || 'Chore block').trim() || 'Chore block',
+      ref: null,
+      dayKey: toDayKey(earliestStart),
+      timeOfDay: bucket,
+      timeLabel: formatBucketBackfillLabel(earliestStart, latestEnd),
+      sortMs: earliestStart,
+      bucket,
+      sourceId: block.id,
+      isTop3: false,
+      deferredUntilMs: null,
+      dueAt: earliestStart,
+      statusLabel: null,
+      progressPct: null,
+      scheduledSourceLabel: scheduledSourceLabelForBlock(block),
+      goalId: null,
+      goalTitle: null,
+      goalTheme: null,
+      isFocusAligned: childItems.some((child) => child.isFocusAligned),
+      rawTask: null,
+      rawStory: null,
+      scheduledBlockStart: earliestStart,
+      scheduledBlockEnd: latestEnd || null,
+      scheduledBlockId: block.id,
+      childItems,
+    });
+  });
+
+  tasks
+    .filter((task) => !isDoneStatus((task as any).status))
+    .forEach((task) => {
+      const choreKind = getChoreKind(task);
+      if (choreKind && addRecurringRows(task)) return;
+
+      if (choreKind) {
+        const fallbackDate = new Date(rangeStartMs);
+        fallbackDate.setHours(0, 0, 0, 0);
+        const dueOnFallback = isRecurringDueOnDate(task, fallbackDate, fallbackDate.getTime());
+        if (!dueOnFallback && !blockByTaskId.get(task.id)) return;
+      }
+
+      const linkedBlock = blockByTaskId.get(task.id) || null;
+      const parentStory = (task as any).storyId ? storyMap.get((task as any).storyId) || null : null;
+      const goalId = String((task as any).goalId || (parentStory as any)?.goalId || '').trim() || null;
+      const goal = goalId ? goalMap.get(goalId) || null : null;
+      const deferredUntilMs = toMs((task as any).deferredUntil);
+      if (deferredUntilMs != null && startOfDayMs(deferredUntilMs) > rangeEndDayMs) return;
+      const top3ForToday = isTop3ForToday(task);
+      const dueMs = linkedBlock ? toMs(linkedBlock.start) : resolveTaskDueMs(task);
+      const endMs = linkedBlock ? toMs(linkedBlock.end) : null;
+      const include = linkedBlock
+        ? true
+        : (isSingleDayRange && top3ForToday)
+          ? true
+        : dueMs == null
+          ? includeUnscheduledTasks
+          : (dueMs >= rangeStartMs && dueMs <= rangeEndMs);
+      if (!include) return;
+
+      const forceIntoSingleDayPlan = isSingleDayRange && top3ForToday && !linkedBlock && !(dueMs != null && dueMs >= rangeStartMs && dueMs <= rangeEndMs);
+      const plannerBaseMs = forceIntoSingleDayPlan ? startOfDayMs(rangeStartMs) : (dueMs ?? startOfDayMs(rangeStartMs));
+      const bucket = forceIntoSingleDayPlan
+        ? bucketFromTime(null, (task as any).timeOfDay, 'morning')
+        : bucketFromTime(dueMs, (task as any).timeOfDay, 'morning');
+      const sortMs = forceIntoSingleDayPlan ? bucketPseudoTime(plannerBaseMs, bucket) : (dueMs ?? bucketPseudoTime(startOfDayMs(plannerBaseMs), bucket));
+      const dayKey = toDayKey(sortMs ?? rangeStartMs);
+
+      push({
+        id: `${choreKind ? 'chore' : 'task'}-${task.id}`,
+        kind: choreKind ? 'chore' : 'task',
+        title: task.title || (choreKind ? 'Chore' : 'Task'),
+        ref: resolveTaskRef(task),
+        dayKey,
+        timeOfDay: bucket,
+        timeLabel: forceIntoSingleDayPlan
+          ? formatBucketBackfillLabel(null, null, (task as any).timeOfDay)
+          : formatBucketBackfillLabel(dueMs, endMs, (task as any).timeOfDay),
+        sortMs,
+        bucket,
+        sourceId: task.id,
+        isTop3: top3ForToday,
+        deferredUntilMs,
+        dueAt: dueMs,
+        statusLabel: taskStatusText((task as any).status),
+        progressPct: Number.isFinite(Number((task as any).progressPct)) ? Number((task as any).progressPct) : null,
+        scheduledSourceLabel: linkedBlock ? scheduledSourceLabelForBlock(linkedBlock) : null,
+        goalId,
+        goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
+        goalTheme: goal ? String((goal as any).theme || '') || null : null,
+        isFocusAligned: isGoalAlignedToFocus(goalId, goals, activeFocusGoalIds),
+        rawTask: task,
+        rawStory: null,
+        scheduledBlockStart: linkedBlock ? toMs(linkedBlock.start) : null,
+        scheduledBlockEnd: linkedBlock ? toMs(linkedBlock.end) : null,
+        scheduledBlockId: linkedBlock?.id || null,
+      });
+    });
+
+  stories
+    .filter((story) => !isDoneStatus((story as any).status))
+    .filter((story) => (selectedSprintId ? String((story as any).sprintId || '') === String(selectedSprintId) : true))
+    .forEach((story) => {
+      const linkedBlock = blockByStoryId.get(story.id) || null;
+      const deferredUntilMs = toMs((story as any).deferredUntil);
+      if (deferredUntilMs != null && startOfDayMs(deferredUntilMs) > rangeEndDayMs) return;
+      const top3ForToday = isTop3ForToday(story);
+      const dueMs = linkedBlock ? toMs(linkedBlock.start) : toMs((story as any).targetDate || (story as any).dueDate || (story as any).plannedStartDate);
+      const endMs = linkedBlock ? toMs(linkedBlock.end) : null;
+      const include = linkedBlock
+        ? true
+        : (isSingleDayRange && top3ForToday)
+          ? true
+        : dueMs == null
+          ? includeUnscheduledTasks
+          : (dueMs >= rangeStartMs && dueMs <= rangeEndMs);
+      if (!include) return;
+
+      const forceIntoSingleDayPlan = isSingleDayRange && top3ForToday && !linkedBlock && !(dueMs != null && dueMs >= rangeStartMs && dueMs <= rangeEndMs);
+      const plannerBaseMs = forceIntoSingleDayPlan ? startOfDayMs(rangeStartMs) : (dueMs ?? startOfDayMs(rangeStartMs));
+      const bucket = forceIntoSingleDayPlan
+        ? bucketFromTime(null, (story as any).timeOfDay, 'morning')
+        : bucketFromTime(dueMs, (story as any).timeOfDay, 'morning');
+      const sortMs = forceIntoSingleDayPlan ? bucketPseudoTime(plannerBaseMs, bucket) : (dueMs ?? bucketPseudoTime(startOfDayMs(plannerBaseMs), bucket));
+      const dayKey = toDayKey(sortMs ?? rangeStartMs);
+      const goalId = String((story as any).goalId || '').trim() || null;
+      const goal = goalId ? goalMap.get(goalId) || null : null;
+
+      push({
+        id: `story-${story.id}`,
+        kind: 'story',
+        title: story.title || 'Story',
+        ref: resolveStoryRef(story),
+        dayKey,
+        timeOfDay: bucket,
+        timeLabel: forceIntoSingleDayPlan
+          ? formatBucketBackfillLabel(null, null, (story as any).timeOfDay)
+          : formatBucketBackfillLabel(dueMs, endMs, (story as any).timeOfDay),
+        sortMs,
+        bucket,
+        sourceId: story.id,
+        isTop3: top3ForToday,
+        deferredUntilMs,
+        dueAt: dueMs,
+        statusLabel: storyStatusText((story as any).status),
+        progressPct: Number.isFinite(Number((story as any).progressPct)) ? Number((story as any).progressPct) : null,
+        scheduledSourceLabel: linkedBlock ? scheduledSourceLabelForBlock(linkedBlock) : null,
+        goalId,
+        goalTitle: goalId ? getGoalDisplayPath(goalId, goals) : (goal?.title || null),
+        goalTheme: goal ? String((goal as any).theme || '') || null : null,
+        isFocusAligned: isGoalAlignedToFocus(goalId, goals, activeFocusGoalIds),
+        rawTask: null,
+        rawStory: story,
+        scheduledBlockStart: linkedBlock ? toMs(linkedBlock.start) : null,
+        scheduledBlockEnd: linkedBlock ? toMs(linkedBlock.end) : null,
+        scheduledBlockId: linkedBlock?.id || null,
+      });
+    });
+
+  calendarBlocks
+    .filter((block) => !String(block.taskId || '').trim() && !String(block.storyId || block.linkedStoryId || '').trim())
+    .forEach((block) => {
+      const startMs = toMs(block.start);
+      if (startMs == null || startMs < rangeStartMs || startMs > rangeEndMs) return;
+      const endMs = toMs(block.end);
+      const bucket = bucketFromTime(startMs, null, 'morning');
+      const timeLabel = formatBucketBackfillLabel(startMs, endMs);
+      const dedupeKey = `event:${String(block.title || '').toLowerCase()}:${timeLabel}`;
+      push({
+        id: `event-block-${block.id}`,
+        kind: 'event',
+        title: String(block.title || 'Calendar event').trim() || 'Calendar event',
+        ref: null,
+        dayKey: toDayKey(startMs),
+        timeOfDay: bucket,
+        timeLabel,
+        sortMs: startMs ?? bucketPseudoTime(startOfDayMs(rangeStartMs), bucket),
+        bucket,
+        goalTitle: null,
+        goalTheme: null,
+        isFocusAligned: false,
+        rawTask: null,
+        rawStory: null,
+        scheduledBlockStart: startMs,
+        scheduledBlockEnd: endMs,
+      }, dedupeKey);
+    });
+
+  summaryEvents.forEach((event) => {
+    if (event.startMs != null && (event.startMs < rangeStartMs || event.startMs > rangeEndMs)) return;
+    const anchorMs = event.startMs ?? rangeStartMs;
+    const bucket = bucketFromTime(event.startMs, null, 'anytime');
+    const timeLabel = formatBucketBackfillLabel(event.startMs, event.endMs);
+    const dedupeKey = `event:${event.title.toLowerCase()}:${timeLabel}`;
+    push({
+      id: `event-summary-${event.id}`,
+      kind: 'event',
+      title: event.title,
+      ref: null,
+      dayKey: toDayKey(anchorMs),
+      timeOfDay: bucket,
+      timeLabel,
+      sortMs: event.startMs ?? bucketPseudoTime(startOfDayMs(anchorMs), bucket),
+      bucket,
+      goalTitle: null,
+      goalTheme: null,
+      isFocusAligned: false,
+      rawTask: null,
+      rawStory: null,
+      scheduledBlockStart: event.startMs,
+      scheduledBlockEnd: event.endMs,
+    }, dedupeKey);
+  });
+
+  return rows.sort((a, b) => {
+    const aMs = a.sortMs ?? Number.MAX_SAFE_INTEGER;
+    const bMs = b.sortMs ?? Number.MAX_SAFE_INTEGER;
+    if (aMs !== bMs) return aMs - bMs;
+    return a.title.localeCompare(b.title);
+  });
+};

--- a/react-app/src/utils/plannerRecommendations.ts
+++ b/react-app/src/utils/plannerRecommendations.ts
@@ -1,0 +1,124 @@
+import type { Sprint, Task } from '../types';
+import type { PlannerItem } from './plannerItems';
+import type { TimelineBucket } from './timelineBuckets';
+import { bucketLabel } from './timelineBuckets';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface PlannerRecommendation {
+  action: 'keep_week' | 'move_day' | 'next_sprint' | 'next_recurrence';
+  label: string;
+  rationale: string;
+  targetDateMs?: number | null;
+  targetBucket?: TimelineBucket | null;
+}
+
+const startOfDayMs = (value: number) => {
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+};
+
+const titleForDay = (ms: number) =>
+  new Date(ms).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
+
+const normaliseRecurringFrequency = (data: any) => {
+  const direct = String(data?.repeatFrequency || data?.recurrence?.frequency || data?.recurrence?.freq || '').trim().toLowerCase();
+  if (['daily', 'weekly', 'monthly', 'yearly'].includes(direct)) return direct;
+  const rrule = String(data?.rrule || '').toUpperCase();
+  if (rrule.includes('DAILY')) return 'daily';
+  if (rrule.includes('WEEKLY')) return 'weekly';
+  if (rrule.includes('MONTHLY')) return 'monthly';
+  if (rrule.includes('YEARLY') || rrule.includes('ANNUAL')) return 'yearly';
+  return null;
+};
+
+export const recurrenceAwareDeferDays = (data: Task | any) => {
+  const frequency = normaliseRecurringFrequency(data);
+  if (!frequency) return null;
+  const interval = Math.max(1, Number(data?.repeatInterval || data?.recurrence?.interval || 1) || 1);
+  if (frequency === 'daily') return interval;
+  if (frequency === 'weekly') return 7 * interval;
+  if (frequency === 'monthly') return 14 * interval;
+  if (frequency === 'yearly') return 60 * interval;
+  return null;
+};
+
+interface BuildParams {
+  item: PlannerItem;
+  weekStartMs: number;
+  weekEndMs: number;
+  dailyLoadHours: Map<string, number>;
+  nextSprint: Sprint | null;
+  dailyCapacityHours?: number;
+}
+
+export const buildPlannerRecommendation = ({
+  item,
+  weekStartMs,
+  weekEndMs,
+  dailyLoadHours,
+  nextSprint,
+  dailyCapacityHours = 8,
+}: BuildParams): PlannerRecommendation => {
+  const parsedDayMs = Date.parse(`${item.dayKey}T12:00:00`);
+  const itemDayMs = startOfDayMs(item.dueAt ?? (Number.isNaN(parsedDayMs) ? weekStartMs : parsedDayMs));
+  const thisDayKey = new Date(itemDayMs).toISOString().slice(0, 10);
+  const thisDayLoad = Number(dailyLoadHours.get(thisDayKey) || 0);
+  const weekLoads: Array<{ dayMs: number; dayKey: string; load: number }> = [];
+  for (let cursor = weekStartMs; cursor <= weekEndMs; cursor += DAY_MS) {
+    const dayMs = startOfDayMs(cursor);
+    const dayKey = new Date(dayMs).toISOString().slice(0, 10);
+    weekLoads.push({ dayMs, dayKey, load: Number(dailyLoadHours.get(dayKey) || 0) });
+  }
+  const lowestLoad = [...weekLoads].sort((a, b) => {
+    if (a.load !== b.load) return a.load - b.load;
+    return a.dayMs - b.dayMs;
+  })[0] || null;
+  const isOverCapacity = thisDayLoad > dailyCapacityHours;
+
+  if (item.kind === 'chore' && item.rawTask) {
+    const recurrenceDays = recurrenceAwareDeferDays(item.rawTask);
+    if (recurrenceDays != null) {
+      const targetDateMs = itemDayMs + recurrenceDays * DAY_MS;
+      return {
+        action: 'next_recurrence',
+        label: 'Defer to next recurrence',
+        rationale: `Matches the ${String(item.rawTask.type || 'recurring').toLowerCase()} cadence and keeps the schedule aligned.`,
+        targetDateMs,
+        targetBucket: item.timeOfDay,
+      };
+    }
+  }
+
+  if (!item.isFocusAligned && !item.isTop3 && nextSprint?.startDate) {
+    return {
+      action: 'next_sprint',
+      label: `Move to next sprint`,
+      rationale: 'Outside active focus goals and this protects current sprint capacity.',
+      targetDateMs: Number(nextSprint.startDate),
+      targetBucket: item.timeOfDay,
+    };
+  }
+
+  if (lowestLoad && (isOverCapacity || lowestLoad.dayKey !== thisDayKey) && lowestLoad.load + 1 < thisDayLoad) {
+    const targetBucket = item.timeOfDay || 'morning';
+    return {
+      action: 'move_day',
+      label: `Move to ${titleForDay(lowestLoad.dayMs)} ${bucketLabel(targetBucket).toLowerCase()}`,
+      rationale: `Best low-load day is ${titleForDay(lowestLoad.dayMs)} at about ${lowestLoad.load.toFixed(1)} planned hours.`,
+      targetDateMs: lowestLoad.dayMs,
+      targetBucket,
+    };
+  }
+
+  return {
+    action: 'keep_week',
+    label: 'Keep this week',
+    rationale: item.isFocusAligned
+      ? 'Aligned to an active focus goal and fits this week.'
+      : 'Current week capacity can absorb this item.',
+    targetDateMs: itemDayMs,
+    targetBucket: item.timeOfDay,
+  };
+};

--- a/react-app/src/utils/plannerScheduling.test.ts
+++ b/react-app/src/utils/plannerScheduling.test.ts
@@ -1,0 +1,26 @@
+import { normalizePlannerSchedulingError } from './plannerScheduling';
+
+jest.mock('../firebase', () => ({
+  functions: {},
+}));
+
+describe('normalizePlannerSchedulingError', () => {
+  test('maps raw internal callable failures to a user-facing planner explanation', () => {
+    const result = normalizePlannerSchedulingError({
+      code: 'functions/failed-precondition',
+      message: 'internal',
+    });
+
+    expect(result.code).toBe('failed-precondition');
+    expect(result.message.toLowerCase()).toContain('planner could not place this item automatically');
+  });
+
+  test('preserves actionable backend messages when they are provided', () => {
+    const result = normalizePlannerSchedulingError({
+      code: 'functions/failed-precondition',
+      message: 'No feasible slot was available without conflicting with current calendar constraints.',
+    });
+
+    expect(result.message).toBe('No feasible slot was available without conflicting with current calendar constraints.');
+  });
+});

--- a/react-app/src/utils/plannerScheduling.ts
+++ b/react-app/src/utils/plannerScheduling.ts
@@ -1,0 +1,168 @@
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '../firebase';
+
+export type PlannerScheduleIntent = 'move' | 'defer';
+
+export interface SchedulePlannerItemRequest {
+  itemType: 'task' | 'story';
+  itemId: string;
+  targetDateMs: number;
+  targetBucket?: 'morning' | 'afternoon' | 'evening' | 'anytime' | null;
+  intent?: PlannerScheduleIntent;
+  source?: string;
+  rationale?: string | null;
+  linkedBlockId?: string | null;
+  targetSprintId?: string | null;
+  durationMinutes?: number | null;
+  planningMode?: 'smart' | 'strict' | null;
+  searchDays?: number | null;
+  maxTargetDateMs?: number | null;
+  allowSplit?: boolean;
+  debugRequestId?: string | null;
+}
+
+export interface SchedulePlannerItemResponse {
+  ok: boolean;
+  debugRequestId?: string | null;
+  planningMode: 'smart' | 'strict';
+  appliedStartMs: number;
+  appliedEndMs: number;
+  appliedDayMs: number;
+  appliedBucket: 'morning' | 'afternoon' | 'evening' | 'anytime' | null;
+  appliedWeekKey?: string | null;
+  appliedWeekStartMs?: number | null;
+  scheduledMinutes?: number;
+  blockCount?: number;
+  sprintId: string | null;
+  blockId: string | null;
+}
+
+export interface PlannerScheduleErrorInfo {
+  code: string;
+  rawMessage: string;
+  message: string;
+}
+
+export function normalizePlannerSchedulingError(error: any): PlannerScheduleErrorInfo {
+  const rawCode = String(error?.code || '').replace(/^functions\//, '').trim();
+  const rawMessage = String(error?.message || '').trim();
+  const detailsMessage = String(error?.details?.message || error?.details || '').trim();
+  const lowerMessage = rawMessage.toLowerCase();
+  const lowerDetails = detailsMessage.toLowerCase();
+  const code = rawCode || 'unknown';
+
+  if (rawMessage && rawMessage !== 'internal' && rawMessage !== 'unknown' && rawMessage !== rawCode) {
+    return {
+      code,
+      rawMessage,
+      message: rawMessage,
+    };
+  }
+
+  if (detailsMessage && detailsMessage !== 'internal' && detailsMessage !== 'unknown') {
+    return {
+      code,
+      rawMessage: detailsMessage,
+      message: detailsMessage,
+    };
+  }
+
+  if (code === 'permission-denied' || lowerMessage.includes('permission denied')) {
+    return {
+      code,
+      rawMessage: rawMessage || detailsMessage,
+      message: 'The planner could not update this item because you do not have permission to edit it.',
+    };
+  }
+
+  if (code === 'unauthenticated') {
+    return {
+      code,
+      rawMessage: rawMessage || detailsMessage,
+      message: 'You need to sign in again before deferring or moving this item.',
+    };
+  }
+
+  if (code === 'invalid-argument') {
+    return {
+      code,
+      rawMessage: rawMessage || detailsMessage,
+      message: 'The planner request was incomplete. Refresh the page and try again.',
+    };
+  }
+
+  if (
+    code === 'failed-precondition' ||
+    code === 'internal' ||
+    lowerMessage === 'internal' ||
+    lowerMessage === 'unknown' ||
+    lowerDetails === 'internal' ||
+    lowerDetails === 'unknown'
+  ) {
+    return {
+      code,
+      rawMessage: rawMessage || detailsMessage,
+      message: 'The planner could not place this item automatically. This usually means the suggested date conflicts with existing calendar blocks, sprint limits, or another scheduling constraint.',
+    };
+  }
+
+  return {
+    code,
+    rawMessage: rawMessage || detailsMessage || code,
+    message: rawMessage || detailsMessage || 'The planner could not update this item.',
+  };
+}
+
+const createPlannerDebugRequestId = () => (
+  `planner-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+);
+
+export async function schedulePlannerItem(
+  payload: SchedulePlannerItemRequest,
+): Promise<SchedulePlannerItemResponse> {
+  const callable = httpsCallable<SchedulePlannerItemRequest, SchedulePlannerItemResponse>(functions, 'schedulePlannerItem');
+  const requestPayload: SchedulePlannerItemRequest = {
+    ...payload,
+    debugRequestId: payload.debugRequestId || createPlannerDebugRequestId(),
+  };
+  try {
+    console.info('[plannerScheduling] request', {
+      debugRequestId: requestPayload.debugRequestId,
+      itemType: requestPayload.itemType,
+      itemId: requestPayload.itemId,
+      intent: requestPayload.intent || 'move',
+      source: requestPayload.source || 'planner',
+      targetDateMs: requestPayload.targetDateMs,
+      targetBucket: requestPayload.targetBucket || null,
+      linkedBlockId: requestPayload.linkedBlockId || null,
+      targetSprintId: requestPayload.targetSprintId || null,
+    });
+    const response = await callable(requestPayload);
+    console.info('[plannerScheduling] success', {
+      debugRequestId: requestPayload.debugRequestId,
+      itemType: requestPayload.itemType,
+      itemId: requestPayload.itemId,
+      result: response.data,
+    });
+    return {
+      ...response.data,
+      debugRequestId: response.data?.debugRequestId || requestPayload.debugRequestId || null,
+    };
+  } catch (error: any) {
+    const normalized = normalizePlannerSchedulingError(error);
+    console.error('[plannerScheduling] failure', {
+      debugRequestId: requestPayload.debugRequestId,
+      itemType: requestPayload.itemType,
+      itemId: requestPayload.itemId,
+      code: normalized.code,
+      rawMessage: normalized.rawMessage,
+      message: normalized.message,
+      error,
+    });
+    const nextError = new Error(normalized.message);
+    (nextError as any).code = normalized.code;
+    (nextError as any).rawMessage = normalized.rawMessage;
+    (nextError as any).debugRequestId = requestPayload.debugRequestId;
+    throw nextError;
+  }
+}

--- a/react-app/src/utils/planningQuery.ts
+++ b/react-app/src/utils/planningQuery.ts
@@ -1,0 +1,17 @@
+export const parseIdListParam = (value: string | null | undefined): string[] => (
+  String(value || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+);
+
+export const parseNumberListParam = (value: string | null | undefined): number[] => (
+  parseIdListParam(value)
+    .map((entry) => Number(entry))
+    .filter((entry) => Number.isFinite(entry))
+);
+
+export const parseBooleanParam = (value: string | null | undefined): boolean => {
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+};

--- a/react-app/src/utils/sprintAlignment.ts
+++ b/react-app/src/utils/sprintAlignment.ts
@@ -1,4 +1,5 @@
-import { Sprint } from '../types';
+import { Goal, Sprint } from '../types';
+import { isGoalInHierarchySet } from './goalHierarchy';
 
 export type SprintAlignmentMode = 'warn' | 'strict';
 
@@ -29,6 +30,7 @@ export const getSprintFocusGoalIds = (sprint: Sprint | null | undefined): string
 export const evaluateStorySprintAlignment = (
   sprint: Sprint | null | undefined,
   goalId: string | null | undefined,
+  goals: Goal[] = [],
 ): SprintAlignmentEvaluation => {
   const focusGoalIds = getSprintFocusGoalIds(sprint);
   const mode = getSprintAlignmentMode(sprint);
@@ -44,7 +46,10 @@ export const evaluateStorySprintAlignment = (
     };
   }
 
-  const aligned = !!normalizedGoalId && focusGoalIds.includes(normalizedGoalId);
+  const aligned = !!normalizedGoalId && (
+    focusGoalIds.includes(normalizedGoalId)
+    || isGoalInHierarchySet(normalizedGoalId, goals, focusGoalIds)
+  );
   if (aligned) {
     return {
       hasRule: true,
@@ -61,7 +66,7 @@ export const evaluateStorySprintAlignment = (
       mode,
       blocking: true,
       aligned: false,
-      message: 'This sprint is in strict focus mode. Story goal must match one of the sprint focus goals.',
+      message: 'This sprint is in strict focus mode. Story goal must map to one of the sprint focus goals or one of their leaf goals.',
     };
   }
 
@@ -70,6 +75,6 @@ export const evaluateStorySprintAlignment = (
     mode,
     blocking: false,
     aligned: false,
-    message: 'This story is outside sprint focus goals. You can continue, but it will be tracked as unaligned.',
+    message: 'This story is outside sprint focus goals. You can continue, but it will stay in the sprint’s unaligned-story warning until you link it to a focus leaf goal.',
   };
 };

--- a/react-app/src/utils/timelineBuckets.ts
+++ b/react-app/src/utils/timelineBuckets.ts
@@ -1,0 +1,59 @@
+export type TimelineBucket = 'morning' | 'afternoon' | 'evening' | 'anytime';
+export const bucketOrder: TimelineBucket[] = ['morning', 'afternoon', 'evening', 'anytime'];
+
+const normalizeTimeOfDay = (value: string | null | undefined): TimelineBucket | null => {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (normalized === 'morning' || normalized === 'afternoon' || normalized === 'evening') {
+    return normalized;
+  }
+  return null;
+};
+
+export const bucketLabel = (bucket: TimelineBucket): string => {
+  if (bucket === 'morning') return 'Morning';
+  if (bucket === 'afternoon') return 'Afternoon';
+  if (bucket === 'evening') return 'Evening';
+  return 'Anytime';
+};
+
+export const bucketFromTime = (
+  ms: number | null | undefined,
+  timeOfDay?: string | null,
+  fallback: TimelineBucket = 'morning',
+): TimelineBucket => {
+  const explicit = normalizeTimeOfDay(timeOfDay);
+  if (!ms || !Number.isFinite(ms)) return explicit || fallback;
+  const date = new Date(ms);
+  const minute = date.getHours() * 60 + date.getMinutes();
+  // Real scheduled times should win over stale bucket flags, except when the stored timestamp is date-only midnight.
+  if (minute === 0 && explicit) return explicit;
+  if (minute >= 300 && minute <= 779) return 'morning';
+  if (minute >= 780 && minute <= 1139) return 'afternoon';
+  if (minute >= 1140 || minute < 300) return 'evening';
+  return explicit || fallback;
+};
+
+export const bucketPseudoTime = (dayStartMs: number, bucket: TimelineBucket): number => {
+  if (bucket === 'morning') return dayStartMs + (9 * 60 * 60 * 1000);
+  if (bucket === 'afternoon') return dayStartMs + (14 * 60 * 60 * 1000);
+  if (bucket === 'evening') return dayStartMs + (19.5 * 60 * 60 * 1000);
+  return dayStartMs + (12 * 60 * 60 * 1000);
+};
+
+export const formatBucketBackfillLabel = (
+  startMs: number | null | undefined,
+  endMs?: number | null,
+  timeOfDay?: string | null,
+): string => {
+  if (!startMs || !Number.isFinite(startMs)) {
+    return `Unscheduled (${bucketLabel(bucketFromTime(null, timeOfDay))})`;
+  }
+  const start = new Date(startMs);
+  const startLabel = start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  if (endMs && Number.isFinite(endMs)) {
+    const end = new Date(endMs);
+    const endLabel = end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return `${startLabel} - ${endLabel}`;
+  }
+  return startLabel;
+};

--- a/ux-audit/01-surface-inventory.md
+++ b/ux-audit/01-surface-inventory.md
@@ -1,0 +1,259 @@
+# BOB UX Audit — 01: Surface Inventory & Route Map
+
+**Audit date**: 2026-03-17
+**Scope**: `/Users/jim/GitHub/bob/react-app/src`
+**Source**: App.tsx route map, SidebarLayout.tsx, MobileHome.tsx
+
+---
+
+## Classification Key
+
+| Column | Values |
+|--------|--------|
+| **Layout** | `table` / `kanban` / `card` / `planner` / `dashboard` / `mobile-tab` / `chart` / `form` / `list` / `redirect` |
+| **Mobile** | `full` — mobile-first surface; `partial` — responsive but not optimised; `inaccessible` — technically renders but unusable; `desktop-only` — should not be exposed on mobile |
+| **Status** | `primary` — current main surface for this workflow; `alternate` — valid alternative view; `legacy` — keep for compat but should not guide UX decisions; `redirect` — no own UI |
+
+---
+
+## Domain 1 — Dashboard & Overview
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/` | RootRedirect | redirect | — | redirect | Sends mobile → `/mobile`, desktop conditionally to `/dashboard`, `/sprints/kanban`, or `/calendar` by time of day |
+| `/dashboard` | Dashboard | dashboard | partial | primary | Multi-card layout with banners, sprint status, calendar events, habits |
+| `/metrics` | AdvancedOverview | chart | desktop-only | primary | Recharts analytics; no mobile adaptation |
+| `/metrics/progress` | ThemeProgressDashboard | chart | desktop-only | alternate | Theme-specific progress visualization |
+| `/mobile-priorities` | MobilePriorityDashboard | card | full | alternate | Mobile-optimised priority card grid |
+
+---
+
+## Domain 2 — Task Management
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/tasks` | TaskListView → ModernTaskTable or TasksCardView | table / card | partial | primary | Toggle between table and card view; no auto-switch on mobile |
+| `/tasks/:id` | DeepLinkTask | form | partial | primary | Deep link detail wrapper |
+| `/task` | → `/tasks` | redirect | — | redirect | Legacy compat |
+| `/tasks-management` | TasksManagement | kanban | desktop-only | legacy | Sprint-based kanban; superseded by `/sprints/kanban` |
+
+**Competing implementations**: ModernTaskTable (table), TasksCardView (card). Both rendered by TaskListView with a toggle. No dedicated mobile list surface.
+
+---
+
+## Domain 3 — Story Management
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/stories` | StoriesManagement → ModernStoriesTable or StoriesCardView | table / card | partial | primary | Toggle between views; same pattern as tasks |
+| `/stories/:id` | DeepLinkStory | form | partial | primary | Deep link detail wrapper |
+| `/sprints/stories` | StoriesManagement | table / card | partial | alternate | Same component in sprint context |
+
+**Competing implementations**: ModernStoriesTable (table), StoriesCardView (card), SortableStoryCard inside Kanban. Three rendering contexts for the same data type.
+
+---
+
+## Domain 4 — Kanban & Sprint Boards
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/sprints/kanban` | SprintKanbanPageV2 → KanbanBoardV2 | kanban | inaccessible | primary | 3-column drag-and-drop; horizontal scroll on mobile — not usable |
+| `/kanban` | → `/sprints/kanban` | redirect | — | redirect | Legacy compat |
+| `/current-sprint` | → `/sprints/kanban` | redirect | — | redirect | Legacy compat |
+
+**Note**: `ModernKanbanBoard.tsx` exists but its relationship to `KanbanBoardV2.tsx` is unclear. One appears to be a predecessor; the other drives the primary kanban. This should be resolved in a codebase triage separate from this audit.
+
+---
+
+## Domain 5 — Goals Management
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/goals` | GoalsManagement → ModernGoalsTable or GoalsCardView | table / card | partial | primary | Toggle views; no auto-switch |
+| `/goals/:id` | DeepLinkGoal | form | partial | primary | Deep link detail wrapper |
+| `/goals-management` | GoalsManagement | table / card | partial | redirect | Duplicate path for same component |
+| `/focus-goals` | FocusGoalsPage | dashboard | desktop-only | primary | Focus goals hub with countdown banner, wizard, KPI studio |
+| `/goals/year-planner` | GoalsYearPlanner | planner | desktop-only | primary | Hierarchical year-grid planning — complex interaction |
+| `/goals/roadmap` | GoalRoadmapV5 | chart | desktop-only | primary | Current default roadmap alias |
+| `/goals/roadmap-v5` | GoalRoadmapV5 | chart | desktop-only | alternate | Explicit V5 route |
+| `/goals/roadmap-v6` | GoalRoadmapV6 | chart | desktop-only | primary | Latest with hierarchy support — should become default |
+| `/goals/roadmap-legacy` | GoalRoadmapV3 | chart | desktop-only | legacy | V3 Gantt; superseded by V5/V6 |
+| `/goals/viz` | GoalVizPage | chart | desktop-only | alternate | Goal visualisation page |
+| `/goals/timeline` | EnhancedGanttChart | chart | desktop-only | alternate | Timeline Gantt variant |
+
+**Competing implementations**: 4 roadmap variants (V3, V5, V6, EnhancedGantt). Only V6 should be treated as the design target going forward.
+
+---
+
+## Domain 6 — Sprints & Planning
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/sprints` | SprintsPage | list | partial | primary | Sprint list landing page |
+| `/sprints/management` | SprintManagementView | tab | desktop-only | primary | Multi-tab hub: overview / board / table / burndown / retrospective / history |
+| `/sprints/table` | SprintTablePage → ModernSprintsTable | table | desktop-only | alternate | Sprint table extracted |
+| `/sprints/planning` | SprintPlanningMatrix | planner | desktop-only | primary | Planning matrix; complex interaction |
+| `/sprints/capacity` | CapacityDashboard | chart | desktop-only | primary | Capacity planning chart |
+| `/sprints/retrospective` | SprintRetrospective | form | partial | alternate | Retrospective form |
+| `/sprint-planning` | → `/sprints/management` | redirect | — | redirect | Legacy compat |
+| `/sprint-simple` | → `/sprints/management` | redirect | — | redirect | Legacy compat |
+| `/sprint-matrix` | → `/sprints/management` | redirect | — | redirect | Legacy compat |
+
+---
+
+## Domain 7 — Calendar & Planner
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/calendar` | UnifiedPlannerPage | planner | inaccessible | primary | React Big Calendar with drag-and-drop; not touch-safe |
+| `/calendar/planner` | WeeklyThemePlanner | planner | desktop-only | alternate | Theme-based week view |
+| `/calendar/themes` | → `/calendar/planner` | redirect | — | redirect | Legacy compat |
+| `/calendar/integration` | CalendarIntegrationView | form | partial | primary | Google Calendar sync settings |
+| `/calendar/sync` | CalendarIntegrationView | form | partial | redirect | Duplicate route for same component |
+| `/checkin/daily` | CheckInDaily | form | full | primary | Short daily checkin; mobile-appropriate |
+| `/checkin/weekly` | CheckInWeekly | form | full | primary | Weekly review form |
+| `/planning` | → `/calendar` | redirect | — | redirect | Legacy compat |
+| `/planning/approvals` | ApprovalsCenter | list | partial | primary | Approval queue |
+| `/planning/approval` | PlanningApprovalPage | form | partial | primary | Single approval detail |
+
+**Note**: `DailyPlanPage.tsx` is not a standalone route — it is embedded inside other components as a multi-mode panel (list/plan/review/checkin).
+
+---
+
+## Domain 8 — Finance
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/finance/dashboard` | FinanceDashboardAdvanced | dashboard | inaccessible | primary | Multi-tab: charts, budget, categories — complex; no mobile adaptation |
+| `/finance/advanced` | → `/finance/dashboard` | redirect | — | redirect | Legacy compat |
+| `/finance` | → `/finance/dashboard` | redirect | — | redirect | Legacy compat |
+| `/finance/budgets` | BudgetsPage | table | desktop-only | primary | Budget table and edit modals |
+| `/finance/merchants` | MerchantMappings | table | desktop-only | primary | Merchant mapping configuration |
+| `/finance/categories` | → `/finance/merchants` | redirect | — | redirect | Legacy compat |
+| `/finance/transactions` | TransactionsList | table | desktop-only | primary | Dense transaction table |
+| `/finance/flow` | FinanceFlowDiagram | chart | desktop-only | alternate | Sankey flow diagram |
+| `/finance/pots` | PotsBoard | kanban | desktop-only | alternate | Money pot kanban board |
+| `/finance/goals` | GoalPotLinking | form | desktop-only | primary | Goal-to-pot linking interface |
+
+**Competing implementations**: 3 finance dashboard components (FinanceDashboard, FinanceDashboardModern, FinanceDashboardAdvanced). Only FinanceDashboardAdvanced is currently active via routing.
+
+---
+
+## Domain 9 — Fitness & Health
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/fitness` | WorkoutsDashboard | dashboard | partial | primary | Workout charts + Strava/Parkrun table |
+| `/parkrun-results` | WorkoutsDashboard | dashboard | partial | alternate | Parkrun-specific variant |
+| `/running-results` | → `/fitness` | redirect | — | redirect | Legacy compat |
+| `/workouts` | → `/fitness` | redirect | — | redirect | Legacy compat |
+
+---
+
+## Domain 10 — Chores & Habits
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/dashboard/habit-tracking` | HabitsChoresDashboard | dashboard | partial | primary | Habit tracking grid |
+| `/habits` | → `/dashboard/habit-tracking` | redirect | — | redirect | Legacy compat |
+| `/chores` | ChoresTasksPage | list | partial | primary | Chore task management |
+| `/chores/checklist` | ChoreChecklistPage | list | full | primary | Checklist-style chore view; mobile-appropriate |
+
+---
+
+## Domain 11 — Content Backlogs
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/games-backlog` | GamesBacklog | list | partial | primary | Game backlog |
+| `/shows-backlog` | ShowsBacklog | list | partial | primary | TV shows backlog |
+| `/books-backlog` | BooksBacklog | list | partial | primary | Books backlog |
+| `/videos-backlog` | VideosBacklog | list | partial | primary | Videos backlog |
+| `/youtube-history` | YouTubeHistoryDashboard | dashboard | desktop-only | primary | YouTube history analytics |
+| `/personal-lists` | BacklogManager | list | partial | legacy | Generic personal lists |
+| `/personal-lists-modern` | PersonalListsManagement | table | partial | primary | Modern table variant |
+
+---
+
+## Domain 12 — Journals
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/journals` | JournalsManagement | list | partial | primary | Journal list |
+| `/journals/insights` | JournalInsightsPage | dashboard | desktop-only | primary | AI-generated journal insights |
+| `/journals/:id` | JournalsManagement | form | partial | primary | Single journal detail |
+
+---
+
+## Domain 13 — Settings & Integrations
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/settings` | SettingsPage | tab | desktop-only | primary | Multi-tab hub: profile/ai/finance/notifications/privacy/developer |
+| `/settings/email` | SettingsEmailPage | form | desktop-only | primary | Email settings |
+| `/settings/planner` | SettingsPlannerPage | form | desktop-only | primary | Planner settings |
+| `/settings/integrations` | IntegrationSettings | list | desktop-only | primary | Integration hub |
+| `/settings/integrations/*` | Various | form | desktop-only | primary | Per-integration settings (Google, Monzo, Strava, Steam, Hardcover, Trakt, YouTube) |
+
+---
+
+## Domain 14 — Mobile-First Surfaces
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/mobile` | MobileHome | mobile-tab | full | primary | 5-tab: overview / tasks / stories / goals / chores — the only intentional mobile UI |
+| `/mobile-view` | MobileView | list | full | primary | Mobile detail view |
+| `/mobile-checklist` | MobileChecklistView | list | full | primary | Mobile checklist view |
+
+---
+
+## Domain 15 — Diagnostics & Logs
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/logs/integrations` | IntegrationLogs | list | desktop-only | primary | Integration log viewer |
+| `/logs/ai` | AiDiagnosticsLogs | list | desktop-only | primary | AI diagnostics |
+| `/logs/transcripts` | TranscriptProcessingLogs | list | desktop-only | primary | Transcript processing logs |
+
+---
+
+## Domain 16 — Miscellaneous & Visualisation
+
+| Route | Component | Layout | Mobile | Status | Notes |
+|-------|-----------|--------|--------|--------|-------|
+| `/travel` | TravelMap | chart | desktop-only | primary | Travel map (lazy-loaded) |
+| `/canvas` | VisualCanvas | chart | desktop-only | primary | Visual canvas |
+| `/visual-canvas` | VisualCanvas | chart | desktop-only | redirect | Duplicate route |
+| `/routes` | RoutesManagementView | list | desktop-only | primary | Route management |
+| `/routes/optimization` | RoutesManagementView | list | desktop-only | primary | Route optimisation |
+| `/share/:shareCode` | PublicGoalView | card | partial | primary | Public shared goal view |
+
+---
+
+## Summary Statistics
+
+| Category | Count |
+|----------|-------|
+| Total routes (including redirects) | ~65 |
+| Redirect-only routes | ~18 |
+| Unique UI surfaces | ~47 |
+| Mobile-first surfaces | 3 (`/mobile`, `/mobile-view`, `/mobile-checklist`) |
+| Fully mobile-appropriate surfaces | ~8 (checkins, chore checklist, approvals, forms) |
+| Surfaces classified as `inaccessible` on mobile | ~6 (kanban, finance dashboard, calendar/planner, roadmap, sprint planning, year planner) |
+| Surfaces classified `desktop-only` by design intent | ~20 |
+| Domains with competing implementations | 5 (goals, tasks, stories, kanban, finance) |
+| Legacy routes still active in routing | ~18 |
+
+---
+
+## Key Structural Observations
+
+1. **The mobile story is MobileHome only.** Every other route defaults to desktop-first, and mobile users who navigate away from `/mobile` land on surfaces that are at best partially responsive and at worst completely unusable on touch.
+
+2. **Competing implementations are unresolved in routing.** Goals, tasks, and stories each have 2 view modes (table + card) toggled manually. There is no automatic breakpoint behaviour to switch to card view on narrow viewports.
+
+3. **Legacy routes remain live.** Approximately 18 redirect-only routes exist for backwards compatibility. These do not degrade UX directly but add maintenance surface area and dilute the conceptual surface map.
+
+4. **Roadmap proliferation.** Four roadmap implementations (V3, V5, V6, EnhancedGantt) are all routable. Only V6 should be the design target; the others should be explicitly marked legacy in documentation and removed from the nav.
+
+5. **Settings and diagnostic surfaces are desktop-only by nature.** These are correctly gated but there is no explicit "requires desktop" message shown to mobile users who navigate to them.

--- a/ux-audit/02-consistency-matrix.md
+++ b/ux-audit/02-consistency-matrix.md
@@ -1,0 +1,267 @@
+# BOB UX Audit — 02: UI Consistency Matrix
+
+**Audit date**: 2026-03-17
+**Domains compared**: Goals, Stories, Tasks, Sprints, Finance, Calendar/Planner
+**View types compared**: Modern Table, Card View, Kanban Card, Mobile Card, Planner Card
+
+---
+
+## Reading This Matrix
+
+Each section below compares one UX dimension across all domains and view types. Cells marked **✓** indicate the expected pattern is present; **△** means partially present or inconsistent; **✗** means absent or divergent.
+
+---
+
+## Matrix 1: Layout Pattern
+
+| Domain | Modern Table | Card View | Kanban | Mobile (MobileHome) | Planner |
+|--------|-------------|-----------|--------|---------------------|---------|
+| **Goals** | ModernGoalsTable — sortable rows, draggable, inline dropdowns | GoalsCardView — responsive CSS grid, border-left theme strip | KanbanBoardV2 — 3 cols (Backlog/In Progress/Done) | 5th tab in MobileHome | — |
+| **Stories** | ModernStoriesTable — sortable rows, story points col, linked tasks panel | StoriesCardView — grid, same visual pattern as goals cards | SortableStoryCard inside KanbanBoardV2 | 3rd tab in MobileHome | PlannerWorkCard (UnifiedPlannerPage) |
+| **Tasks** | ModernTaskTable — sortable rows, sprint detection, inline editing | TasksCardView — grid | TaskCard inside KanbanBoardV2 story groups | 2nd tab in MobileHome | PlannerWorkCard |
+| **Sprints** | ModernSprintsTable | — | SprintManagementView > KanbanBoardV2 tab | Not in MobileHome | — |
+| **Finance** | TransactionsList (Bootstrap table) | — | PotsBoard (Kanban) | Not accessible | — |
+| **Calendar** | — | — | — | — | UnifiedPlannerPage (React Big Calendar), DailyPlanPage (timeline) |
+
+**Observations**:
+- Goals, stories, and tasks share the same three-layout model (table / card / kanban) but they were built independently without a shared spec.
+- Sprint data only has table + kanban — no card view.
+- Finance has no card view and no mobile surface.
+- Calendar has no table or card view; it is planner-only.
+
+---
+
+## Matrix 2: Status Display
+
+| Domain | Modern Table | Card View | Kanban | Mobile |
+|--------|-------------|-----------|--------|--------|
+| **Goals** | Select dropdown, no visual pill | Clickable Button badge using `statusPillClass()` | Text label in meta row via `storyStatusText()` | Text label |
+| **Stories** | Select dropdown, no visual pill | Clickable Button badge | Text label in meta row | Compact badge |
+| **Tasks** | Select dropdown (`taskStatusText()` label) | Clickable Button badge | Text label in meta row | Compact badge |
+| **Sprints** | Status column as text | — | Status in sprint header | — |
+| **Finance** | Status text column (cleared/pending/etc.) | — | — | — |
+
+**Verdict**: Three incompatible renderings of the same data:
+- Tables → form control (no visual language)
+- Card views → clickable pill (interactive affordance)
+- Kanban → read-only text (no interaction)
+
+Status pills use CSS classes from `KanbanCards.css` (`.pill`, `.pill--danger`, `.pill--success`). Card views use inline `statusPillClass()` returning similar styles but applied to a `<Button>` element — same visual result, different DOM structure and interactivity.
+
+---
+
+## Matrix 3: Priority Display
+
+| Domain | Modern Table | Card View | Kanban | Mobile |
+|--------|-------------|-----------|--------|--------|
+| **Goals** | Select dropdown | Clickable Button badge (`priorityPillClass()`) | Pill via `priorityPillClass()` | Not shown |
+| **Stories** | Select dropdown | Clickable Button badge | Pill in meta row | Compact indicator |
+| **Tasks** | Select dropdown (`priorityLabel()`) | Clickable Button badge | Pill in meta row | Compact indicator |
+| **Sprints** | — | — | — | — |
+| **Finance** | — | — | — | — |
+
+**Verdict**: Tables lose all visual priority language. Kanban and card views share the same utility function (`priorityPillClass()`) producing consistent-looking pills, but card views add the clickable cycling interaction while Kanban does not.
+
+---
+
+## Matrix 4: AI Score Display
+
+| Domain | Modern Table | Card View | Kanban | Mobile |
+|--------|-------------|-----------|--------|--------|
+| **Goals** | `aiCriticalityScore` column (numeric) | Bootstrap `Badge bg="secondary"` "AI NN/100" | **Not shown** | Not shown |
+| **Stories** | `aiCriticalityScore` column | Bootstrap `Badge bg="secondary"` "AI NN/100" | **Not shown** | Not shown |
+| **Tasks** | `aiCriticalityScore` column | Likely same Badge pattern | **Not shown** | Not shown |
+
+**Verdict**: AI score is invisible in the most-used planning surface (Kanban). The badge format ("AI 85/100") is verbose and uses Bootstrap `Badge`, inconsistent with the pill CSS pattern used for status/priority.
+
+---
+
+## Matrix 5: Top 3 / Manual Priority Badge
+
+| Domain | Modern Table | Card View | Kanban | Mobile |
+|--------|-------------|-----------|--------|--------|
+| **Goals** | Not shown | Bootstrap `Badge bg="danger"` "#N Priority" | **Not shown** | Not shown |
+| **Stories** | Not shown | Bootstrap `Badge bg="danger"` "#N Priority" | CSS class badge in `SortableStoryCard` | Not shown |
+| **Tasks** | Not shown | Likely same Badge | **Not shown** | Not shown |
+
+**Verdict**: The Top 3 / manual priority badge is the most inconsistent piece of metadata in the product. It uses two different rendering mechanisms (Bootstrap Badge vs CSS class badge), is absent from Kanban for tasks and goals, and is absent from all table views.
+
+---
+
+## Matrix 6: Action Buttons
+
+| Domain | Card View (desktop) | Kanban | Mobile | Table |
+|--------|---------------------|--------|--------|-------|
+| **Goals** | Top-right: Schedule (Calendar), Activity, Edit; Bottom: Defer, Delete | Action row in card header (small icon buttons) | Tap item → modal | Modal-based (assumed) |
+| **Stories** | Same as goals | Same | Same | Same |
+| **Tasks** | Same as goals | Same | Same | Same |
+
+**Common actions across all**: Schedule, Activity, Edit, Defer, Delete
+
+**Observed icon inconsistencies**:
+
+| Action | Kanban | Card View | Table (where visible) |
+|--------|--------|-----------|----------------------|
+| Edit | `Edit3` | `Edit3` | `Pencil` (in some tables) |
+| Schedule | `CalendarClock` or `CalendarPlus` | `Calendar` | `CalendarClock` |
+| Defer | `Clock3` | `Clock3` | Absent |
+| Activity | `Activity` | `Activity` | `Activity` |
+| Delete | `Trash2` | `Trash2` | `Trash2` |
+| AI/Magic | `Wand2` | `Wand2` | `Wand2` |
+
+**Verdict**: Edit and Schedule icons are inconsistent. Defer is missing from table views. Button sizes differ significantly: 12-16px icon buttons in Kanban vs 24px icon buttons in card views. No tooltip labels in either context.
+
+---
+
+## Matrix 7: Filter Controls
+
+| Domain | Table | Card View | Kanban | Mobile |
+|--------|-------|-----------|--------|--------|
+| **Goals** | Column visibility toggles, inline sort | Display toggles (show description, show activity) | Props-based: dueFilter, goalFilter, themeFilter, sortBy | Tab + filter dropdown in MobileHome |
+| **Stories** | Column visibility, inline sort | Same display toggles | Same props | Same mobile filters |
+| **Tasks** | Column visibility, inline sort | Same display toggles | Same props | top3 / due_today / overdue / all |
+| **Sprints** | Sort controls | — | Sprint selector | — |
+| **Finance** | Category/date filter | — | — | — |
+
+**Verdict**: No surface uses a shared filter chip/button design. Filters are ad-hoc per-component, never unified. MobileHome has the most coherent filter UX (explicit filter pills at the top of each tab), but this pattern is not used on desktop.
+
+---
+
+## Matrix 8: Chip / Badge Design Language
+
+| Context | Pattern | CSS Mechanism | Interactive? | Dark Mode Safe? |
+|---------|---------|---------------|-------------|-----------------|
+| Status pills (card views) | Rounded button with background color | `statusPillClass()` returning class string + inline styles from `KanbanCards.css` | Yes (cycle on click) | Partial — hardcoded RGBA values |
+| Priority pills (card views) | Same as status | `priorityPillClass()` | Yes (cycle on click) | Partial |
+| Status labels (Kanban) | Inline text with pill class | `.kanban-card__pill` CSS class | No | Partial |
+| AI score (card views) | Bootstrap `Badge bg="secondary"` | Bootstrap utility | No | No — Bootstrap badge does not adapt to custom dark theme |
+| Top 3 (card views) | Bootstrap `Badge bg="danger"` | Bootstrap utility | No | No |
+| Top 3 (Kanban) | `.kanban-card__meta-badge` + inline red style | CSS class + inline | No | No — hardcoded `rgba(220, 53, 69, 0.45)` |
+| Manual priority (card views) | Bootstrap `Badge bg="danger"` | Bootstrap utility | No | No |
+| Theme badges | Custom CSS with `--theme-X-primary` | Domain theme CSS vars | No | **No** — ThemeColors.css has no dark overrides |
+
+**Verdict**: Badges and chips use 4+ different rendering mechanisms across the product. Bootstrap badges are not adapted for the custom dark theme. The pill CSS classes (KanbanCards.css) are the most consistent mechanism but are not universally applied.
+
+---
+
+## Matrix 9: Card Structure Comparison (Goals / Stories / Tasks)
+
+### Kanban Card (KanbanCardV2 / SortableStoryCard)
+```
+[GripVertical] [Ref ID]                        [Actions: icons at 12-16px]
+[Title — bold, full width]
+[Description — optional, muted text]
+[Tags — optional chips]
+[Meta row: status pill | priority pill | points | Top3 badge (stories only)]
+[Goal link — if story/task linked to goal]
+```
+- Compact density
+- No dates shown
+- No AI score shown
+- Actions always visible (not hover-revealed)
+
+### Card View (StoriesCardView / TasksCardView)
+```
+[Ref ID — muted]                               [Schedule] [Activity] [Edit]
+[Title — bold, full width]
+[Status button] [Priority button] [AI score badge] [Manual priority badge]
+[Description box — if toggled on]
+[Latest activity — if toggled on]
+[Goal link box — stories only]
+[Theme badge]                                  [Defer button] [Delete button]
+[Scheduled block info — if present]
+[Footer: Created / Updated dates]
+```
+- Spacious density (min-height 220px)
+- Dates visible
+- AI score and manual priority visible
+- Actions split between top-right and bottom bar
+
+### Mobile Card (MobileHome)
+```
+[Title]                             [Priority indicator] [Due date]
+[Status compact label]
+[Goal / sprint link]
+```
+- Minimal density
+- Touch-safe tap area (entire card)
+- No action buttons visible inline
+
+### Table Row (ModernTaskTable / ModernStoriesTable / ModernGoalsTable)
+```
+[Grip] [Ref] [Title (inline edit)] [Status dropdown] [Priority dropdown] [Sprint] [Due] [AI col] [...]
+```
+- Dense, data-grid style
+- Status and priority are form controls, not visual badges
+- Actions in row or in overflow (not fully audited)
+
+**Verdict**: Four completely different structural approaches for the same data type. No shared component or CSS base. A new engineer looking at any one of these would not recognise it as the same domain object rendered differently.
+
+---
+
+## Matrix 10: Empty / Loading / Error States
+
+| Context | Loading State | Empty State | Error State |
+|---------|---------------|-------------|-------------|
+| Kanban (KanbanBoardV2) | `<div>Loading board...</div>` — plain text | Not visible in source | Not visible in source |
+| Card views (StoriesCardView, TasksCardView) | Not visible (assumes data from parent) | ✓ Proper: icon (Target/48px) + headline + sub-text | Not visible |
+| Mobile (MobileHome) | Not visible | Brief text per section | Not visible |
+| Tables | Not visible in audit | Not visible in audit | Not visible in audit |
+
+**Verdict**: Only card views implement a proper empty state. Kanban uses a minimal text placeholder. Tables and mobile states are unknown. No component appears to implement a structured error state (network failure, permission error, etc.).
+
+---
+
+## Matrix 11: Theme Treatment
+
+| Domain / Component | Uses CSS Variables | Hard-Coded Colors | Bootstrap Utilities | Dark Mode Risk |
+|--------------------|--------------------|--------------------|---------------------|----------------|
+| KanbanBoardV2 / KanbanCardV2 | Partial | `rgba(59,130,246,…)` drag handle; `#dc3545` blocked border | Minimal | Medium |
+| StoriesCardView / TasksCardView | Partial | `withAlpha(themeColor, 0.25)` for border | Badge components | Medium |
+| SortableStoryCard | Partial | `rgba(220, 53, 69, 0.45)` manual priority badge | — | Medium |
+| ModernGoalsTable / TaskTable / StoriesTable | Unknown | Likely inline styles for status | Bootstrap table classes | Unknown |
+| MobileHome | No — uses hard-coded `THEME_COLORS` map | Category colour map | Some | High |
+| FocusGoalCountdownBanner | No | `#dc3545`, `#fd7e14`, `#0066cc` | — | **Critical** |
+| Dashboard | Partial | `#3b82f6`, `#fd7e14` gradient | Bootstrap | High |
+| FinanceDashboardAdvanced | Unknown | Likely — finance dashboards rarely adapt | Extensive Bootstrap | High |
+
+---
+
+## Matrix 12: Mobile Support Level (Summary)
+
+| Surface | Rating | Reason |
+|---------|--------|--------|
+| MobileHome (/mobile) | ✓ Full | Built for mobile — tabs, compact cards, touch filters |
+| CheckInDaily/Weekly | ✓ Full | Form-based, mobile-appropriate |
+| ChoreChecklistPage | ✓ Full | List-based, mobile-appropriate |
+| ApprovalsCenter | △ Partial | Readable but not optimised for touch |
+| TasksCardView | △ Partial | CSS Grid is responsive but action buttons are too small for touch |
+| StoriesCardView | △ Partial | Same as TasksCardView |
+| ModernTaskTable | ✗ Inaccessible | Dense table — columns overflow, dropdowns are small, drag-drop unusable on touch |
+| ModernGoalsTable | ✗ Inaccessible | Same as ModernTaskTable |
+| KanbanBoardV2 | ✗ Inaccessible | Horizontal 3-column flex, no mobile stack, drag-drop requires pointer |
+| UnifiedPlannerPage | ✗ Inaccessible | React Big Calendar drag-and-drop — not touch-safe |
+| GoalRoadmapV6 | ✗ Inaccessible | Canvas-based Gantt — no touch interaction, no zoom |
+| GoalsYearPlanner | ✗ Inaccessible | Complex planning grid, no mobile adaptation |
+| FinanceDashboardAdvanced | ✗ Inaccessible | Charts + dense tables — no mobile layout |
+| SprintPlanningMatrix | ✗ Inaccessible | Dense matrix — desktop-only interaction |
+| Settings pages | ✗ Desktop-only | Configuration surfaces — inappropriate on mobile |
+
+---
+
+## Cross-Cutting Findings
+
+### Finding A: Three Parallel Component Families, No Shared Base
+Goals, stories, and tasks each have table + card + kanban representations. None of these share a base component, CSS module, or state management pattern. Changes to any shared concern (e.g. priority pill design) must be made in 9+ places.
+
+### Finding B: Bootstrap Badges Are Inconsistent with Pill CSS
+Card views render AI score and manual priority as Bootstrap `Badge` components. Status and priority use custom CSS class pills from KanbanCards.css. These are visually different and neither adapts correctly to the dark theme.
+
+### Finding C: Drag-and-Drop Is Pervasive and Mobile-Hostile
+Drag handles and sortable rows appear in tables, card views, and kanban. None of these contexts have a mobile-safe alternative interaction. On touch devices, items cannot be reordered.
+
+### Finding D: Action Rows Have No Discoverable Labelling
+Every action button across all view types is icon-only (no label, no tooltip in most cases). For the Schedule, Defer, and Convert-to-Story actions, there is genuine ambiguity about what the icon means. This is an accessibility concern even on desktop.
+
+### Finding E: The MobileHome Tab Structure Duplicates Desktop Domains but with Different UX Rules
+MobileHome independently reimplements task, story, goal, and chore lists with its own data fetching, filter logic, and card design. This creates two diverging implementations of the same domain logic: one optimised for desktop, one for mobile, with no shared components.

--- a/ux-audit/03-recommendation-backlog.md
+++ b/ux-audit/03-recommendation-backlog.md
@@ -1,0 +1,731 @@
+# BOB UX Audit — 03: Recommendation Backlog
+
+**Audit date**: 2026-03-17
+**Total recommendations**: 42
+**Implementation note**: All recommendations are design/UX changes only. No backend, Firestore schema, or Cloud Function changes are implied or required.
+
+---
+
+## Severity Legend
+
+| Severity | Definition |
+|----------|------------|
+| **Critical** | Misleading, broken, inaccessible, or unsupported on mobile. Causes user failure or significant confusion. |
+| **High** | Inconsistent interaction model or major theme/readability issue. Creates meaningful friction or unreliability. |
+| **Medium** | Visual inconsistency, density problem, weak affordance, icon mismatch. Reduces trust and polish. |
+| **Low** | Polish, terminology, or cleanup. Low user impact but worth addressing for coherence. |
+
+## Effort Legend
+
+| Effort | Definition |
+|--------|------------|
+| **S** | ≤ 1 day: CSS variable change, icon swap, copy update |
+| **M** | 2–5 days: New shared component, single-component refactor |
+| **L** | 1–2 weeks: Refactor of a view family (e.g., all tables), responsive breakpoint logic |
+| **XL** | > 2 weeks: Cross-cutting change affecting 3+ domains, new design system primitive |
+
+---
+
+## Critical Severity
+
+---
+
+### REC-001: FocusGoalCountdownBanner dark mode contrast failure
+
+**Severity**: Critical
+**Effort**: S
+**User impact**: Orange urgency text (`#fd7e14`) on the dark theme background (`#0b0d11`) fails WCAG AA contrast (ratio ~2.8:1 vs required 4.5:1). Users in dark mode cannot reliably read urgency indicators in the focus goals countdown.
+**Affected surfaces**: `/focus-goals` — FocusGoalCountdownBanner.tsx
+**Observed issue**: `getUrgencyColor()` returns hard-coded hex values (`#dc3545`, `#fd7e14`, `#0066cc`, `#6c757d`) used as inline text/icon colours. These are never overridden for dark theme.
+**Recommended standard**: Replace all hard-coded urgency colours with semantic CSS variables defined in `:root` and `[data-theme="dark"]`. Define `--color-urgency-critical`, `--color-urgency-high`, `--color-urgency-normal`, `--color-urgency-low` with WCAG-safe values for both modes.
+**Specific UI change**: In FocusGoalCountdownBanner.tsx, replace the `getUrgencyColor()` switch statement with CSS variable lookups. In index.css, define the four urgency colour tokens with dark mode overrides that shift to lighter, higher-contrast values.
+**Responsive rule**: Show full feature — the banner itself is appropriate for mobile if made responsive.
+**Theme/a11y implications**: Both themes affected. Resolves WCAG AA violation. Ensures colour-meaning consistency with priority chips (which use similar colour semantics).
+**Dependencies**: REC-020 (centralise colour tokens), REC-022 (theme governance)
+
+---
+
+### REC-002: Dashboard calendar hard-coded current-time indicator
+
+**Severity**: Critical
+**Effort**: S
+**User impact**: The red current-time line in the calendar view disappears or looks broken in dark mode because `#dc3545` on a dark calendar surface is nearly invisible.
+**Affected surfaces**: `/dashboard` — Dashboard.css lines 413-420, Dashboard.tsx
+**Observed issue**: `.rbc-current-time-indicator { background-color: #dc3545; }` is hard-coded. Dark mode provides no override.
+**Recommended standard**: Move to `var(--color-urgency-critical)` (defined in REC-001) so it inherits the dark-safe red.
+**Specific UI change**: In Dashboard.css, replace `#dc3545` with `var(--color-urgency-critical)`.
+**Responsive rule**: Desktop-only (calendar is desktop-only per responsive policy).
+**Theme/a11y implications**: Resolves dark mode invisibility. Single-line CSS change.
+**Dependencies**: REC-001
+
+---
+
+### REC-003: Kanban board is inaccessible on touch devices
+
+**Severity**: Critical
+**Effort**: L
+**User impact**: Mobile users who navigate to `/sprints/kanban` encounter a three-column horizontal-scroll layout with pointer-dependent drag-and-drop. Items cannot be moved, the layout overflows the viewport, and touch targets are too small (12-16px icon buttons).
+**Affected surfaces**: `/sprints/kanban` — KanbanBoardV2.tsx, SprintKanbanPageV2.tsx
+**Observed issue**: Layout is `display: flex; gap: 16px` (horizontal, no wrap). Drag-and-drop library requires pointer events. No mobile fallback.
+**Recommended standard**: Below 768px, switch to a single-column stacked list view. Drag-and-drop is replaced by a status picker (swipe left/right or a tap action). See REC-004 for the shared status interaction pattern.
+**Specific UI change**: Add a `useIsMobile()` breakpoint check in SprintKanbanPageV2. On mobile, render a stacked flat list of cards grouped by status, with a status dropdown/picker on each card instead of drag-to-column. Action buttons increase to 44px minimum tap targets.
+**Responsive rule**: Show simplified card version — vertical stack replacing horizontal kanban.
+**Theme/a11y implications**: Increases tap target compliance (WCAG 2.5.5). No theme impact.
+**Dependencies**: REC-004 (status interaction standard), REC-024 (mobile card standard)
+
+---
+
+### REC-004: Goal/story/task tables are unusable on narrow viewports
+
+**Severity**: Critical
+**Effort**: L
+**User impact**: Users accessing `/tasks`, `/stories`, or `/goals` on a mobile or tablet browser encounter a full-width dense data table with horizontal scroll, small dropdown controls, and drag handles that don't function on touch. This is technically the primary URL for each of these domains.
+**Affected surfaces**: `/tasks` (ModernTaskTable), `/stories` (ModernStoriesTable), `/goals` (ModernGoalsTable)
+**Observed issue**: No automatic view-mode switch at any breakpoint. The table layout is always active until the user manually toggles to card view — and the toggle control is itself a small desktop button.
+**Recommended standard**: Below 768px viewport width, automatically switch to card view. The view mode toggle is only rendered at ≥ 768px. Card views already exist for all three domains and are responsive.
+**Specific UI change**: In TaskListView, StoriesManagement, and GoalsManagement (the wrapper components), read `window.innerWidth` (or use a `useIsMobile()` hook) and default `viewMode` to `'card'` on mobile. Hide the toggle control on mobile. Document this as the canonical mobile entry point for these domains.
+**Responsive rule**: Show simplified card version — force card view below 768px.
+**Theme/a11y implications**: Card views already adapt better to both themes. Reduces horizontal scroll on mobile.
+**Dependencies**: REC-003, REC-024
+
+---
+
+### REC-005: Goal roadmap / year planner surfaces exposed on mobile with no fallback
+
+**Severity**: Critical
+**Effort**: M
+**User impact**: Users navigating to `/goals/roadmap` or `/goals/year-planner` on mobile see a partially-rendered canvas-based Gantt chart or a dense year grid with no interaction possible. There is no message directing them to desktop.
+**Affected surfaces**: `/goals/roadmap`, `/goals/roadmap-v6`, `/goals/year-planner`, `/goals/timeline` — GoalRoadmapV6, GoalsYearPlanner, EnhancedGanttChart
+**Observed issue**: These components perform no mobile detection. They render their full complexity on any viewport, resulting in broken, unusable views on mobile.
+**Recommended standard**: These surfaces should detect mobile viewport and render a "Desktop required" placeholder screen. The placeholder should explain the feature, show a preview thumbnail or description, and offer a button to share the link via email/clipboard to open later on desktop.
+**Specific UI change**: Add a `MobileUnsupportedScreen` component (see REC-033) wrapping each roadmap and year planner component. Trigger it when `isMobile === true`. Do not attempt to render the chart or planner on mobile.
+**Responsive rule**: Hide and route user to desktop.
+**Theme/a11y implications**: No chart rendering on mobile means no mobile-specific theme issues. The placeholder itself should respect the theme.
+**Dependencies**: REC-033 (MobileUnsupportedScreen component)
+
+---
+
+### REC-006: Sprint planning matrix exposed on mobile with no fallback
+
+**Severity**: Critical
+**Effort**: M
+**User impact**: Same class of issue as REC-005. `/sprints/planning` renders a complex matrix grid on mobile — inoperable for touch interactions.
+**Affected surfaces**: `/sprints/planning` — SprintPlanningMatrix.tsx
+**Observed issue**: No mobile detection or fallback.
+**Recommended standard**: Same MobileUnsupportedScreen treatment as REC-005.
+**Specific UI change**: Wrap SprintPlanningMatrix in mobile detection gate. Show `MobileUnsupportedScreen` with message "Sprint planning matrix is optimised for desktop use."
+**Responsive rule**: Hide and route user to desktop.
+**Theme/a11y implications**: None beyond placeholder theming.
+**Dependencies**: REC-033
+
+---
+
+### REC-007: UnifiedPlannerPage (Calendar) drag-and-drop not safe on touch
+
+**Severity**: Critical
+**Effort**: L
+**User impact**: React Big Calendar with drag-and-drop addon does not function correctly on touch devices. Event creation (click-drag on empty slot) and event moving are both broken on mobile. Users get a confusing non-interactive calendar.
+**Affected surfaces**: `/calendar` — UnifiedPlannerPage.tsx
+**Observed issue**: `withDragAndDrop` from react-big-calendar uses pointer events. Rendering a `DragDropCalendar` on touch devices produces inconsistent behaviour.
+**Recommended standard**: On mobile, switch to agenda-only view (React Big Calendar's built-in `'agenda'` view). Remove drag-and-drop. Replace event creation with a "+ Add" FAB that opens AddStoryModal. Event details open on tap.
+**Specific UI change**: In UnifiedPlannerPage, detect mobile. On mobile: set `defaultView="agenda"`, remove `withDragAndDrop` wrapper, render a static `Calendar` component, and show a FAB for adding items. Hide the view-switcher toolbar (day/week/month/agenda selector) on mobile — lock to agenda.
+**Responsive rule**: Show summary/read-only version — agenda list with tap-to-view, no drag-and-drop.
+**Theme/a11y implications**: Agenda view is already more screen-reader-friendly. No additional theme impact.
+**Dependencies**: REC-033
+
+---
+
+## High Severity
+
+---
+
+### REC-008: Status and priority use three different interaction models
+
+**Severity**: High
+**Effort**: XL
+**User impact**: Users who switch between kanban and card views find that status and priority behave differently in each context. In card views they can click to cycle; in kanban they are read-only; in tables they are dropdowns. This breaks the mental model and creates inconsistent expectations.
+**Affected surfaces**: KanbanCardV2, StoriesCardView, TasksCardView, GoalsCardView, ModernTaskTable, ModernStoriesTable, ModernGoalsTable
+**Observed issue**: Three patterns in use simultaneously:
+  1. Kanban: CSS class pill (read-only, visual only)
+  2. Card views: `<Button>` with `statusPillClass()` / `priorityPillClass()` (clickable, cycles value)
+  3. Tables: `<select>` dropdown (form control)
+**Recommended standard**: Define one shared `StatusPill` and one shared `PriorityPill` component (see REC-034, REC-035 in UI Standards). The component accepts a `mode` prop: `readonly` (Kanban, mobile), `interactive` (card views — click to cycle), or `select` (tables — renders as a styled dropdown with the pill appearance). This way the visual language is identical; only the interaction differs per context.
+**Specific UI change**: Create `src/components/shared/StatusPill.tsx` and `PriorityPill.tsx`. Replace existing patterns in all 7+ components. Apply CSS class approach from KanbanCards.css (`.pill`, `.pill--danger`, etc.) as the shared visual base — this is already the most consistent and theme-safe mechanism.
+**Responsive rule**: `readonly` mode on mobile; `interactive` mode on cards; `select` mode on tables.
+**Theme/a11y implications**: Consolidating to CSS classes removes Bootstrap Badge inconsistency. Dark mode safety depends on REC-020 (token centralisation).
+**Dependencies**: REC-020, REC-035
+
+---
+
+### REC-009: AI score badge is invisible in Kanban and inconsistent everywhere
+
+**Severity**: High
+**Effort**: M
+**User impact**: The AI score is a key decision-making signal (used to sort, filter, and surface Top 3 items), yet it is invisible in the most-used planning surface (Kanban). Users cannot see which items the AI considers critical while triaging the board.
+**Affected surfaces**: KanbanCardV2.tsx, SortableStoryCard.tsx, ModernTaskTable, ModernStoriesTable, ModernGoalsTable
+**Observed issue**: AI score shown only in card views (as "AI NN/100" Bootstrap Badge) and in table column. Not shown in Kanban cards.
+**Recommended standard**: Define one shared `AiScoreBadge` component that renders `AI NN` (compact, no "/100" suffix) as a small pill using the shared pill CSS. Apply it consistently to kanban cards, card views, and table rows. Hide when score is 0 or below a threshold (e.g., < 20).
+**Specific UI change**: In KanbanCardV2 and SortableStoryCard, add `AiScoreBadge` to the meta row after priority pill. In card views, replace Bootstrap `Badge bg="secondary"` with `AiScoreBadge`. In tables, align column format to same compact style.
+**Responsive rule**: Hide on mobile (too dense; AI sort is applied automatically on mobile).
+**Theme/a11y implications**: Remove Bootstrap `Badge` dependency (dark mode unsafe). Use shared pill CSS.
+**Dependencies**: REC-008, REC-020
+
+---
+
+### REC-010: Top 3 / manual priority badge is inconsistent and absent from Kanban
+
+**Severity**: High
+**Effort**: M
+**User impact**: The Top 3 designation is one of the most important daily planning signals. It appears in 3 different visual forms across the product and is missing from the Kanban board entirely.
+**Affected surfaces**: SortableStoryCard, StoriesCardView, TasksCardView, KanbanCardV2 (missing), all tables (missing)
+**Observed issue**:
+  - SortableStoryCard: CSS class `.kanban-card__meta-badge` + inline `rgba(220, 53, 69, 0.45)`
+  - Card views: Bootstrap `Badge bg="danger"` "#N Priority"
+  - KanbanCardV2: Not present at all
+  - Tables: Not present at all
+**Recommended standard**: Define one `ManualPriorityBadge` component rendering `#N` in a compact high-contrast badge. Apply to KanbanCardV2 (add to meta row), SortableStoryCard (replace existing), card views (replace Bootstrap Badge), and table rows (add as an inline element).
+**Specific UI change**: Create `ManualPriorityBadge` using the shared pill CSS, colour `var(--color-urgency-critical)` for rank ≤ 3. Render in all three contexts. In KanbanCardV2 meta row, place before priority pill.
+**Responsive rule**: Show on mobile card (compact `#N` label only).
+**Theme/a11y implications**: Replace Bootstrap Badge dependency. Inherits dark mode from REC-001 urgency tokens.
+**Dependencies**: REC-001, REC-008
+
+---
+
+### REC-011: Action button size is too small for touch use in card views
+
+**Severity**: High
+**Effort**: M
+**User impact**: Action buttons in card views (StoriesCardView, TasksCardView, GoalsCardView) are 24px × 24px. WCAG 2.5.5 requires 44 × 44px minimum touch targets. On mobile, these buttons are untappable without precision.
+**Affected surfaces**: StoriesCardView, TasksCardView, GoalsCardView
+**Observed issue**: Action buttons use `width: 24px; height: 24px` inline styles. The card views are accessible on mobile (responsive grid) but the actions are not.
+**Recommended standard**: Increase action button tap targets to minimum 44 × 44px with `padding` (visual size can remain smaller). On viewports ≤ 768px, collapse the 3-button top-right row into a single `...` overflow button that opens a bottom sheet / dropdown menu.
+**Specific UI change**: Add `min-width: 44px; min-height: 44px` to action buttons via CSS media query `@media (max-width: 768px)`. Add a `<OverflowMenu>` component triggered by `...` on mobile that lists Schedule, Activity, Edit, Defer, Delete as full-width rows.
+**Responsive rule**: Show simplified card version — overflow menu on mobile.
+**Theme/a11y implications**: Improves WCAG 2.5.5 compliance. No theme impact.
+**Dependencies**: REC-024
+
+---
+
+### REC-012: Domain theme colours (ThemeColors.css) have no dark mode overrides
+
+**Severity**: High
+**Effort**: M
+**User impact**: Story and goal cards that use domain theme colours (Health, Wealth, Growth, etc.) display light-mode colour backgrounds and borders in dark mode. The visual theme system that makes goals and stories visually distinctive breaks entirely in dark theme.
+**Affected surfaces**: All card views and kanban cards that render with a domain `theme` property — goal cards, story cards, sprint blocks, calendar blocks
+**Observed issue**: `ThemeColors.css` defines `--theme-health-lighter: rgba(229, 62, 62, 0.1)` etc. There are no `[data-theme="dark"]` overrides, so dark mode cards use the same light-background colour values as light mode.
+**Recommended standard**: For each of the 16 domain themes, define `[data-theme="dark"]` overrides that increase saturation and adjust opacity to remain visible and distinctive on dark backgrounds. Dark theme cards should use slightly higher opacity backgrounds (e.g., 0.15 instead of 0.1) with a lighter primary colour variant.
+**Specific UI change**: In ThemeColors.css, add a `[data-theme="dark"]` block for each domain theme with adjusted `-lighter` and `-light` values. Test against `--bg: #0b0d11` and `--card: #171a21` for sufficient contrast.
+**Responsive rule**: No responsive impact — applies in both mobile and desktop card views.
+**Theme/a11y implications**: Core dark mode visual fix. Prevents theme strips from disappearing in dark mode.
+**Dependencies**: REC-022
+
+---
+
+### REC-013: Action buttons have no accessible labels (icon-only)
+
+**Severity**: High
+**Effort**: M
+**User impact**: All action buttons in Kanban, card views, and table rows are icon-only with no visible label and (in most cases) no tooltip or `aria-label`. Users relying on screen readers cannot identify actions. Sighted users face ambiguity on less-common actions (Convert to Story, Schedule, Defer).
+**Affected surfaces**: KanbanCardV2, StoriesCardView, TasksCardView, GoalsCardView, ModernTaskTable
+**Observed issue**: Buttons render `<Edit3 size={16} />` with no surrounding text or `title` attribute. Some have `aria-label` (not audited exhaustively), but even where present, there are no visible labels.
+**Recommended standard**: All action buttons must have an `aria-label` or `title` attribute for screen reader / tooltip support. For ambiguous actions (Schedule, Defer, Convert to Story), add visible text labels on desktop at ≥ 992px. On narrower viewports, icons-only with tooltip are acceptable.
+**Specific UI change**: Add `title="Edit"`, `title="Schedule"`, etc. to all icon buttons. For Convert to Story and Defer (most ambiguous), add a visible text label `<span className="d-none d-xl-inline">Schedule</span>` beside the icon at full desktop width.
+**Responsive rule**: Show label text at ≥ 992px; icon-only with tooltip at smaller.
+**Theme/a11y implications**: WCAG 4.1.2 (Name, Role, Value) compliance. No theme impact.
+**Dependencies**: None
+
+---
+
+### REC-014: Lucide icon inconsistency for Edit and Schedule actions
+
+**Severity**: High
+**Effort**: S
+**User impact**: The same "Edit" action uses `Edit3` icon in Kanban and card views but `Pencil` in some table components. The same "Schedule" action uses `Calendar`, `CalendarClock`, and `CalendarPlus` across different components. Users learn different visual vocabularies for the same action.
+**Affected surfaces**: ModernTaskTable, ModernStoriesTable (Pencil), KanbanCardV2, StoriesCardView (Edit3); CalendarClock/Calendar/CalendarPlus variations
+**Observed issue**: Icon choice was made ad-hoc per component.
+**Recommended standard**: See UI Standards (04-ui-standards.md). Standardise on:
+  - Edit: `Pencil` everywhere (more semantically precise than `Edit3`)
+  - Schedule/Add to calendar: `CalendarClock` everywhere (implies time + calendar)
+  - Defer: `Clock3` everywhere (already consistent)
+  - All others: audit and lock in UI Standards doc
+**Specific UI change**: Global icon swap across all components. In each file importing `Edit3`, change to `Pencil`. In components using `CalendarPlus` or `Calendar` for the schedule action, change to `CalendarClock`.
+**Responsive rule**: No responsive impact.
+**Theme/a11y implications**: No theme impact. Icon semantics improvement.
+**Dependencies**: None (but should be done alongside REC-013 for a single icon audit pass)
+
+---
+
+### REC-015: MobileHome category colour map is hard-coded and theme-unaware
+
+**Severity**: High
+**Effort**: M
+**User impact**: In dark mode, MobileHome renders category colours defined in a hard-coded `THEME_COLORS` map with specific hex values. These do not adapt to dark theme, potentially producing unreadable labels or washed-out backgrounds.
+**Affected surfaces**: `/mobile` — MobileHome.tsx
+**Observed issue**: `THEME_COLORS` object maps category names to specific hex colour strings (e.g., `'learning & education': '#3b82f6'`). No dark mode variant.
+**Recommended standard**: Replace hard-coded map with references to `--theme-X-primary` CSS variables from ThemeColors.css (already defined and will be fixed by REC-012). Map category names to theme variable names, not hex values.
+**Specific UI change**: In MobileHome.tsx, replace the `THEME_COLORS` object with a `THEME_CSS_VARS` map pointing to CSS variable names. Apply via `style={{ color: 'var(--theme-learning-primary)' }}` etc. This automatically inherits any dark mode overrides added by REC-012.
+**Responsive rule**: Mobile-specific fix — applies to MobileHome only.
+**Theme/a11y implications**: Dark mode compliance for the only mobile-first surface.
+**Dependencies**: REC-012
+
+---
+
+### REC-016: No shared empty state design across views
+
+**Severity**: High
+**Effort**: M
+**User impact**: When Kanban columns are empty, users see no message or illustration. When tables have no data, the experience is unknown/inconsistent. Only card views show a proper empty state. Inconsistent feedback when data is absent undermines trust.
+**Affected surfaces**: KanbanBoardV2 (empty columns), ModernTaskTable, ModernStoriesTable, ModernGoalsTable (empty rows), MobileHome (empty tab sections)
+**Observed issue**: KanbanBoardV2: `<div>Loading board...</div>` only. Card views: icon + headline + sub-text (correct pattern). Tables and mobile: not audited but expected to be inconsistent.
+**Recommended standard**: Create a shared `EmptyState` component used by all three view types. It accepts `icon`, `title`, `message`, and optionally `action` (a button). Apply to Kanban empty columns, table empty rows, and mobile empty tab sections.
+**Specific UI change**: Extract the empty state pattern from StoriesCardView into a shared `src/components/shared/EmptyState.tsx`. Apply in: KanbanBoardV2 (for each empty column), all ModernTable components (empty tbody), MobileHome (empty tab sections).
+**Responsive rule**: Show full feature — empty states apply to all viewports.
+**Theme/a11y implications**: Use `var(--muted)` for text. Icon opacity 0.5. Fully theme-safe if using CSS variables.
+**Dependencies**: None
+
+---
+
+### REC-017: Finance dashboard has no mobile version and no desktop-required gate
+
+**Severity**: High
+**Effort**: M
+**User impact**: `/finance/dashboard` renders a multi-tab dashboard with complex charts, Bootstrap tables, and dense data on mobile. None of it is adapted for touch or narrow viewports.
+**Affected surfaces**: `/finance/dashboard` — FinanceDashboardAdvanced, TransactionsList, BudgetsPage
+**Observed issue**: No mobile detection, no fallback. Finance components use Bootstrap tables extensively.
+**Recommended standard**: Finance is a desktop-first analytical surface. On mobile, show a summary card view: 2-3 key metrics (current month spending, budget remaining, recent transactions count), with a "Full dashboard available on desktop" prompt. Do not attempt to render charts or tables.
+**Specific UI change**: Add mobile detection to FinanceDashboardAdvanced. On mobile, render a `FinanceMobileSummary` component (key numbers only). The chart tabs and transaction table are hidden. Add a `MobileUnsupportedScreen` option for the deeper analytical pages (flow diagram, merchants, budgets).
+**Responsive rule**: Show summary/read-only version on mobile; full feature on desktop.
+**Theme/a11y implications**: Summary cards should use CSS variable colours. No chart library required on mobile.
+**Dependencies**: REC-033, REC-005
+
+---
+
+### REC-018: FocusGoalsPage not responsive on mobile
+
+**Severity**: High
+**Effort**: M
+**User impact**: `/focus-goals` renders the countdown banner, focus wizard, and KPI studio panel. None of these components are adapted for mobile. The wizard uses complex multi-step layout that overflows on small screens.
+**Affected surfaces**: `/focus-goals` — FocusGoalsPage, FocusGoalWizard, FocusGoalCountdownBanner, GoalKpiStudioPanel
+**Observed issue**: No mobile detection. FocusGoalWizard uses multi-column step layouts. GoalKpiStudioPanel renders data-heavy charts.
+**Recommended standard**: On mobile, show only the countdown banner (high-value status at a glance) and a simplified goal list. Hide the KPI studio panel and wizard. Add a "Manage focus goals on desktop" link.
+**Specific UI change**: In FocusGoalsPage, add mobile detection. On mobile: render banner + simplified goal cards only. Hide `FocusGoalWizard` and `GoalKpiStudioPanel`. Add a `MobileUnsupportedScreen` for the wizard and KPI studio sections.
+**Responsive rule**: Show summary/read-only version — banner + card list only on mobile.
+**Theme/a11y implications**: Fix REC-001 before this (banner contrast). No additional theme work.
+**Dependencies**: REC-001, REC-033
+
+---
+
+## Medium Severity
+
+---
+
+### REC-019: Filter controls have no shared design language
+
+**Severity**: Medium
+**Effort**: L
+**User impact**: Each surface implements its own filter UI. The Kanban board uses prop-based filters (no visible filter bar). Task/story/goal tables have column toggles and sort controls in different positions. MobileHome uses explicit filter pills. There is no consistent "filter chip" design.
+**Affected surfaces**: All task/story/goal/sprint surfaces
+**Observed issue**: No shared filter component or design pattern.
+**Recommended standard**: Define a shared `FilterBar` component with `FilterChip` elements. Active filters are visually highlighted chips. Tapping a chip toggles it off. A `+ Add filter` button opens a filter picker. This pattern is already approximated in MobileHome and should be generalised.
+**Specific UI change**: Create `src/components/shared/FilterBar.tsx` and `FilterChip.tsx`. Apply to: task/story/goal list headers (replacing existing sort dropdowns), Kanban toolbar (replacing programmatic filter props), MobileHome tab headers (replacing existing filter buttons).
+**Responsive rule**: Show full feature — chip-based filters work on mobile and desktop. Chips wrap to a second row on narrow viewports.
+**Theme/a11y implications**: Use CSS variable colours for active chip state. Sufficient contrast in both themes.
+**Dependencies**: None
+
+---
+
+### REC-020: Centralise colour tokens — eliminate hard-coded hex values in components
+
+**Severity**: Medium
+**Effort**: L
+**User impact**: 341+ hard-coded colour values across TSX files create divergent dark mode behaviour. Changes to brand or semantic colours require multi-file updates with no central source of truth.
+**Affected surfaces**: All components — especially FocusGoalCountdownBanner, Dashboard, KanbanCardV2, SortableStoryCard, MobileHome, FitnessKPIDisplay
+**Observed issue**: Hard-coded hex and RGBA values in inline `style={{}}` props and CSS files. Bootstrap fallback colours (`var(--bs-danger, #dc3545)`) bypass the custom theme system.
+**Recommended standard**: All feature components must reference only `var(--*)` tokens from index.css or ThemeColors.css. No inline hex values in component files. Create a token inventory (see 06-theme-governance.md for full list).
+**Specific UI change**: Audit each component in the violation list (06-theme-governance.md). Replace hex values with CSS variable references. Priority order: FocusGoalCountdownBanner → Dashboard → KanbanCardV2 → SortableStoryCard → MobileHome.
+**Responsive rule**: No responsive impact.
+**Theme/a11y implications**: Foundation change for dark mode reliability. No individual UI change visible to users.
+**Dependencies**: REC-001 (urgency tokens must be defined first)
+
+---
+
+### REC-021: Bootstrap Badge components are not dark-mode-adapted
+
+**Severity**: Medium
+**Effort**: M
+**User impact**: Bootstrap `Badge` components (`bg="secondary"`, `bg="danger"`) used for AI score and manual priority are rendered with Bootstrap's own colour system, which is incompatible with the custom dark theme (`data-theme="dark"` does not override Bootstrap's `data-bs-theme` colour tokens in the expected way across all components).
+**Affected surfaces**: StoriesCardView, TasksCardView, GoalsCardView (AI score badges and manual priority badges)
+**Observed issue**: `<Badge bg="secondary">` in dark mode may render a dark grey badge on a dark card background — low contrast.
+**Recommended standard**: Replace all Bootstrap Badge usages in feature-domain components with the shared pill CSS class approach from KanbanCards.css. This is already theme-safe and consistent with status/priority pills.
+**Specific UI change**: Remove Bootstrap `Badge` import from StoriesCardView, TasksCardView, GoalsCardView. Replace with `<span className="pill pill--secondary">` (add a `secondary` pill variant to KanbanCards.css). This is covered by REC-008 (StatusPill component) and REC-009 (AiScoreBadge).
+**Responsive rule**: No responsive impact.
+**Theme/a11y implications**: Resolves Bootstrap/custom theme collision. Improves dark mode reliability.
+**Dependencies**: REC-008, REC-009
+
+---
+
+### REC-022: Document and enforce theme selector precedence
+
+**Severity**: Medium
+**Effort**: S
+**User impact**: With 4 CSS files all defining `[data-theme="dark"]` rules, the cascade order determines which rules win. This is not documented. A minor CSS load order change could silently break theme behaviour.
+**Affected surfaces**: index.css, theme-aware.css, themeConsistency.css, MaterialDesign.css
+**Observed issue**: Three active theme systems (`[data-theme]`, `[data-bs-theme]`, `.dark`) set in ModernThemeContext, with CSS across multiple files all responding to these selectors.
+**Recommended standard**: Document the canonical CSS load order and intended precedence in a comment block at the top of index.css. Define which system is "active" (index.css + ThemeColors.css only), which is "secondary" (themeConsistency.css for Notion-style elements), and which is "deprecated" (MaterialDesign.css).
+**Specific UI change**: Add a `/* THEME SYSTEM — load order and precedence */` comment block to index.css. Mark MaterialDesign.css as deprecated in a file header comment. The actual CSS load order must match the documented precedence.
+**Responsive rule**: No responsive impact.
+**Theme/a11y implications**: Prevents silent cascade breakage. Low risk, high governance value.
+**Dependencies**: None
+
+---
+
+### REC-023: Competing kanban implementations need clear resolution
+
+**Severity**: Medium
+**Effort**: S (decision only)
+**User impact**: `ModernKanbanBoard.tsx` and `KanbanBoardV2.tsx` both exist. The routing sends all traffic to `KanbanBoardV2`. It is unclear if `ModernKanbanBoard` is a work-in-progress replacement, a legacy predecessor, or a second alternate view.
+**Affected surfaces**: ModernKanbanBoard.tsx, KanbanBoardV2.tsx
+**Observed issue**: Two kanban implementations in the codebase. Only one is routed.
+**Recommended standard**: Engineering decision needed: designate one as primary and delete (or clearly mark as legacy) the other. This audit recommends designating KanbanBoardV2 as primary (it is currently routed). ModernKanbanBoard should be either deleted or assigned a specific differentiated purpose.
+**Specific UI change**: None (code deletion or file rename/comment). This is a codebase triage task.
+**Responsive rule**: No responsive impact until REC-003 is implemented.
+**Theme/a11y implications**: Reduces surface area of dark mode audit.
+**Dependencies**: REC-003
+
+---
+
+### REC-024: Define mobile card standard with 44px tap targets
+
+**Severity**: Medium
+**Effort**: M
+**User impact**: Card views (StoriesCardView, TasksCardView, GoalsCardView) are responsive but not touch-optimised. Action buttons at 24px fail WCAG 2.5.5. Items on the card are clickable but tap-target size is inconsistent.
+**Affected surfaces**: All card views, MobileHome tab cards
+**Observed issue**: Action buttons are 24px × 24px. Item tap areas may not be full-row.
+**Recommended standard**: See 04-ui-standards.md for the mobile card spec. Summary: min tap target 44×44px (via padding), single-tap opens detail/edit modal, overflow `...` button for secondary actions, no visible AI score or manual priority badge rank on mobile (space too limited).
+**Specific UI change**: Add `@media (max-width: 768px)` block to card CSS expanding action button padding. Make the card title area a full-width tap target. Collapse secondary info to a `...` overflow button.
+**Responsive rule**: Simplified card version — different action layout on mobile.
+**Theme/a11y implications**: WCAG 2.5.5 improvement. No theme impact.
+**Dependencies**: None
+
+---
+
+### REC-025: Card view grid minimum card width creates awkward 1.5-column layouts at tablet sizes
+
+**Severity**: Medium
+**Effort**: S
+**User impact**: At tablet widths (768-992px), card grid layouts may produce 1.5 column widths due to CSS grid `auto-fill` with `minmax()` values not calibrated for the tablet breakpoint. This produces partially-cut-off cards.
+**Affected surfaces**: StoriesCardView, TasksCardView, GoalsCardView — `.goals-card-grid` CSS class
+**Observed issue**: Grid uses `auto-fill` with fixed min-width. At intermediate viewports, this can produce uneven column counts.
+**Recommended standard**: Define explicit column counts at each breakpoint: 1 column below 576px, 2 columns at 576-992px, 3 columns at 992-1200px, 4+ columns at > 1200px. Use media queries rather than `auto-fill` for predictable layout.
+**Specific UI change**: Update `.goals-card-grid` CSS to use explicit `grid-template-columns` at defined breakpoints.
+**Responsive rule**: Show full feature — properly responsive grid.
+**Theme/a11y implications**: No theme impact.
+**Dependencies**: None
+
+---
+
+### REC-026: Loading states are inconsistent and minimal
+
+**Severity**: Medium
+**Effort**: M
+**User impact**: Different surfaces show different loading treatments. Kanban shows plain text. Card views assume data is pre-loaded. Tables show nothing (or a brief flash of empty state). Users have inconsistent feedback about app responsiveness.
+**Affected surfaces**: KanbanBoardV2, ModernTaskTable, ModernStoriesTable, ModernGoalsTable
+**Observed issue**: Kanban: `<div>Loading board...</div>`. Card views: no visible loading state (parent handles). Tables: unknown.
+**Recommended standard**: Define a `<SkeletonCard>` and `<SkeletonRow>` component (see 04-ui-standards.md). Show 3-4 skeleton cards/rows while data loads, using the same card/row dimensions as real content. Remove the plain-text loading message.
+**Specific UI change**: Create `SkeletonCard` and `SkeletonRow` shared components with pulse animation. Apply in KanbanBoardV2 (show 4 skeleton cards per column), ModernTaskTable (show 8 skeleton rows), card views (show 4 skeleton cards). Use the `loading` prop already accepted by these components.
+**Responsive rule**: Show full feature — skeletons apply to all viewports.
+**Theme/a11y implications**: Skeleton uses `var(--line)` as base colour, which adapts to dark mode. Add `aria-busy="true"` on the container while loading.
+**Dependencies**: None
+
+---
+
+### REC-027: Sidebar navigation items have no active state on mobile
+
+**Severity**: Medium
+**Effort**: S
+**User impact**: In the mobile offcanvas sidebar, the active route may not have a visually distinct highlight compared to inactive routes. Users cannot easily tell where they are.
+**Affected surfaces**: SidebarLayout.tsx (mobile offcanvas variant)
+**Observed issue**: Desktop sidebar likely uses a highlight class for active routes. Verify whether this carries over to the offcanvas mobile version.
+**Recommended standard**: Active navigation item should use `var(--brand)` accent colour as background or left border, with contrasting text colour. This should apply identically in both desktop sidebar and mobile offcanvas.
+**Specific UI change**: Ensure the same `active` class / style logic applied to desktop nav links is applied in the mobile offcanvas sidebar.
+**Responsive rule**: Mobile-specific fix.
+**Theme/a11y implications**: `var(--brand)` is already dark-mode-aware. WCAG 1.4.1 (use of colour) compliance.
+**Dependencies**: None
+
+---
+
+### REC-028: Sprint management tabs have inconsistent surface patterns
+
+**Severity**: Medium
+**Effort**: M
+**User impact**: SprintManagementView hosts 6 tabs (overview, board, table, burndown, retrospective, history). Each tab renders a different layout pattern built independently. The visual language of the tabs themselves is inconsistent with the rest of the product's tab conventions.
+**Affected surfaces**: `/sprints/management` — SprintManagementView
+**Observed issue**: Tab-based navigation in this view uses a different pattern from SettingsPage tabs, and neither matches what is described in the UI Standards.
+**Recommended standard**: Apply the shared tab convention defined in 04-ui-standards.md: horizontal tab bar with underline indicator, no box borders, active tab uses `var(--brand)` underline. Tab panel content fills the available space. Same pattern used in SettingsPage and SprintManagementView.
+**Specific UI change**: Align SprintManagementView tab styles to match SettingsPage tab styles (or define a shared `TabBar` component that both use).
+**Responsive rule**: On mobile, collapse tabs to a horizontal scrollable row (scroll-snap, no wrapping).
+**Theme/a11y implications**: Tab underlines use `var(--brand)`. Full dark mode compatibility.
+**Dependencies**: None
+
+---
+
+### REC-029: Goal roadmap version proliferation creates navigation confusion
+
+**Severity**: Medium
+**Effort**: S
+**User impact**: Users who find `/goals/roadmap` via sidebar get GoalRoadmapV5. Users who know about `/goals/roadmap-v6` get a significantly different and more capable view. The UI offers no indication that V6 exists or that the sidebar link is not pointing to the latest version.
+**Affected surfaces**: `/goals/roadmap`, `/goals/roadmap-v5`, `/goals/roadmap-v6`, `/goals/roadmap-legacy`, sidebar navigation
+**Observed issue**: V5 and V6 are both active, named differently, and the default route alias (`/goals/roadmap`) points to V5.
+**Recommended standard**: Point `/goals/roadmap` to GoalRoadmapV6 (the latest). Mark the V3 and V5 routes as legacy in the sidebar (or remove them entirely from navigation). Only V6 and V3-legacy should remain, clearly labelled.
+**Specific UI change**: In App.tsx, change the `/goals/roadmap` route to render `GoalRoadmapV6`. Remove `/goals/roadmap-v5` from the sidebar navigation (keep route for bookmarks but add a redirect notice). Mark `/goals/roadmap-legacy` with a "(legacy)" label in sidebar if it must remain visible.
+**Responsive rule**: All roadmap routes → hide on mobile (per REC-005).
+**Theme/a11y implications**: No theme impact.
+**Dependencies**: REC-005
+
+---
+
+### REC-030: DailyPlanPage embedded context is not discoverable
+
+**Severity**: Medium
+**Effort**: S
+**User impact**: `DailyPlanPage` is a feature-rich multi-mode daily planning surface (list / plan / review / checkin). It is not on a discoverable route; it is embedded inside other components. Users who would benefit from it may never find it.
+**Affected surfaces**: DailyPlanPage.tsx (embedded, no own route)
+**Observed issue**: No standalone route for DailyPlanPage. It is only accessible from whichever parent component embeds it.
+**Recommended standard**: Assign DailyPlanPage a standalone route (e.g., `/plan/today`) linked from the sidebar under the Planning group. This is a discovery and navigation issue, not a visual one.
+**Specific UI change**: Add `/plan/today` route in App.tsx rendering DailyPlanPage. Add to sidebar navigation.
+**Responsive rule**: Show simplified version on mobile — the DailyPlanPage modes that involve drag scheduling should be hidden; show list and checkin modes only.
+**Theme/a11y implications**: No theme impact.
+**Dependencies**: None
+
+---
+
+### REC-031: Settings and integration pages shown to mobile users without a "desktop required" signal
+
+**Severity**: Medium
+**Effort**: M
+**User impact**: Mobile users who navigate to `/settings` or any of the 15+ integration setting routes encounter dense form-heavy pages that are technically functional but not mobile-optimised. More importantly, there is no signal that these are intended for desktop configuration.
+**Affected surfaces**: `/settings` and all `/settings/integrations/*` routes, `/logs/*` routes
+**Observed issue**: No mobile detection or indicator in settings pages.
+**Recommended standard**: Settings pages should either render a simplified mobile variant (key profile settings only) or show a `MobileUnsupportedScreen` for the full settings hub. Integration settings and developer/log pages should always show the desktop-required placeholder on mobile.
+**Specific UI change**: Add mobile detection to SettingsPage. On mobile: show profile and notification settings only (lightweight form). For all `/settings/integrations/*` and `/logs/*`, render `MobileUnsupportedScreen`.
+**Responsive rule**: Show summary/read-only for profile/notifications; hide for integrations/logs/developer.
+**Theme/a11y implications**: No theme impact. MobileUnsupportedScreen uses standard surface/text tokens.
+**Dependencies**: REC-033
+
+---
+
+## Low Severity
+
+---
+
+### REC-032: Terminology inconsistency: "Top 3" vs "Manual Priority" vs "AI Critical"
+
+**Severity**: Low
+**Effort**: S
+**User impact**: The product uses three overlapping priority concepts: "Top 3 for Today" (aiTop3ForDay), "Manual Priority" (manualPriority rank), and "AI Critical" (aiCriticalityScore > threshold). These are surface differently on different screens and the nomenclature is inconsistent.
+**Affected surfaces**: KanbanBoardV2 filter bar, StoriesCardView badge labels, MobileHome filter options
+**Observed issue**: Kanban filter button says "Top3". MobileHome filter says "top3" in code and "Top 3" in UI. Badge in card views says "#N Priority". AI score column is "AI Score". Filters are "AI Critical" on some surfaces.
+**Recommended standard**: Define canonical user-facing labels: "Top 3" (for Top 3 designation), "#1 Priority" / "#2 Priority" (for manual priority rank), "AI Score" (for aiCriticalityScore column header). Use these consistently across all filter labels, badge text, and column headers.
+**Specific UI change**: Global copy pass across kanban filters, card view badge labels, table column headers, and mobile filter labels to align with canonical terms.
+**Responsive rule**: No responsive impact.
+**Theme/a11y implications**: No theme impact.
+**Dependencies**: None
+
+---
+
+### REC-033: Create MobileUnsupportedScreen shared component
+
+**Severity**: Low (as a standalone recommendation; Critical when used by REC-003 through REC-007)
+**Effort**: S
+**User impact**: Multiple surfaces need a "this feature is designed for desktop" placeholder when accessed on mobile. Without a shared component, these will be implemented inconsistently.
+**Affected surfaces**: GoalRoadmapV6, GoalsYearPlanner, SprintPlanningMatrix, UnifiedPlannerPage (drag mode), FinanceDashboardAdvanced deep tabs, Settings integrations
+**Observed issue**: No such component exists.
+**Recommended standard**: Create `src/components/shared/MobileUnsupportedScreen.tsx` accepting `title`, `description`, and optional `copyLinkButton`. Renders a centred card with a desktop icon, title, brief description, and a "Copy link to open on desktop" button. Uses standard theme tokens.
+**Specific UI change**: Create component. It must be usable as a drop-in wrapper: `if (isMobile) return <MobileUnsupportedScreen title="..." description="..." />;`
+**Responsive rule**: Only visible on mobile.
+**Theme/a11y implications**: Use CSS variable tokens. Fully theme-safe.
+**Dependencies**: None
+
+---
+
+### REC-034: Remove legacy routes from sidebar navigation (keep routes for backwards compat)
+
+**Severity**: Low
+**Effort**: S
+**User impact**: The sidebar may surface legacy routes (V3 roadmap, old calendar routes) that create confusion when users find them.
+**Affected surfaces**: SidebarLayout.tsx navigation items
+**Observed issue**: Multiple legacy route aliases still exist in routing. If any are in the sidebar, they create navigation confusion.
+**Recommended standard**: Audit sidebar navigation items against the primary surface classification in 01-surface-inventory.md. Remove any nav items pointing to legacy or redirect routes. Keep the underlying routes live for backwards compatibility but do not link to them from the main navigation.
+**Specific UI change**: Review SidebarLayout.tsx nav items. Remove links to: V3/V5 roadmap variants (only V6 in nav), old sprint routes, old finance routes. Keep routes in App.tsx as redirects.
+**Responsive rule**: No responsive impact.
+**Theme/a11y implications**: No theme impact.
+**Dependencies**: REC-029
+
+---
+
+### REC-035: Remove unused MaterialDesign.css
+
+**Severity**: Low
+**Effort**: S
+**User impact**: 520 lines of CSS defining `--md-*` variables that are never consumed by any component. Dead code adds maintenance surface area and potential for future accidental reference.
+**Affected surfaces**: MaterialDesign.css (520 lines)
+**Observed issue**: No component references `--md-primary`, `--md-surface`, `--md-on-surface`, etc. The file is loaded but produces no visible output.
+**Recommended standard**: Delete MaterialDesign.css. Remove its import from wherever it is loaded.
+**Specific UI change**: Delete file. Remove import statement.
+**Responsive rule**: No responsive impact.
+**Theme/a11y implications**: No impact — file is currently inert.
+**Dependencies**: REC-022 (document theme systems first, confirm the file is truly unused)
+
+---
+
+### REC-036: Add a "requires desktop" badge to sidebar nav items for desktop-only surfaces
+
+**Severity**: Low
+**Effort**: S
+**User impact**: Mobile users navigating from the sidebar to desktop-only surfaces get a poor experience. A small indicator next to the nav item (or hiding it on mobile) would set correct expectations.
+**Affected surfaces**: SidebarLayout.tsx — nav items for roadmap, sprint planning, year planner, finance dashboard, calendar planner
+**Observed issue**: No visual indicator or hiding logic for desktop-only nav items on mobile.
+**Recommended standard**: On mobile viewports, hide nav items leading to surfaces classified `desktop-only` by the responsive policy (05-responsive-policy.md). Add a `title="Desktop only"` tooltip on desktop if the surface is expected to be desktop-primary (helps set expectations for narrow desktop views).
+**Specific UI change**: In SidebarLayout, conditionally hide nav items based on a `desktopOnly` metadata flag on each nav item definition. On mobile (`window.innerWidth <= 768`), skip rendering those items.
+**Responsive rule**: Mobile-specific: hide desktop-only nav items.
+**Theme/a11y implications**: No theme impact.
+**Dependencies**: REC-005, REC-007
+
+---
+
+### REC-037: Standardise modal header and footer treatment across all modals
+
+**Severity**: Low
+**Effort**: M
+**User impact**: Modals (AddStoryModal, EditStoryModal, EditTaskModal, DeferItemModal, FocusGoalWizard) have inconsistent header heights, footer button orders (confirm vs cancel position), and close button placements.
+**Affected surfaces**: All modals — AddStoryModal, EditStoryModal, EditTaskModal, DeferItemModal, FocusGoalWizard
+**Observed issue**: Not fully audited; modals were not the focus of this round. Known inconsistency in button order and header style.
+**Recommended standard**: Define a `<ModalLayout>` wrapper (see 04-ui-standards.md) with fixed: header with title + close button (right), body with standard padding, footer with Cancel (left/secondary) and Confirm (right/primary) buttons. Confirm button labelled with action ("Save", "Defer", "Create", "Update") not generic "OK".
+**Specific UI change**: Create a shared `ModalLayout` component. Refactor all feature modals to use it for header/footer, keeping only the body content component-specific.
+**Responsive rule**: Modals should be full-screen on mobile (bottom-sheet style) with the same button order.
+**Theme/a11y implications**: Use CSS variable tokens. Modal background uses `var(--panel)`. Standard focus trap on open.
+**Dependencies**: None
+
+---
+
+### REC-038: Checkin surfaces (daily and weekly) should be accessible from MobileHome
+
+**Severity**: Low
+**Effort**: S
+**User impact**: `/checkin/daily` and `/checkin/weekly` are among the best mobile-optimised surfaces in the product. They are not linked from MobileHome. Mobile users doing their daily review have to know the route or find it via sidebar.
+**Affected surfaces**: MobileHome.tsx, CheckInDaily.tsx, CheckInWeekly.tsx
+**Observed issue**: MobileHome overview tab has no link or card for the daily checkin.
+**Recommended standard**: Add a "Daily Check-in" card or action button in the MobileHome overview tab. If a check-in is pending (not yet completed today), show it as a highlighted CTA.
+**Specific UI change**: In MobileHome overview tab, add a `CheckInSummaryCard` component. If `!checkinCompletedToday`, render a prominent CTA. If completed, show a brief summary of what was checked in.
+**Responsive rule**: Mobile-specific addition.
+**Theme/a11y implications**: No theme concerns.
+**Dependencies**: None
+
+---
+
+### REC-039: Planner capacity banner is hidden on mobile but gives no indication
+
+**Severity**: Low
+**Effort**: S
+**User impact**: `PlannerCapacityBanner.tsx` is conditionally hidden on mobile. If a user is over capacity, they receive no mobile signal about this important scheduling state.
+**Affected surfaces**: PlannerCapacityBanner.tsx (hidden on mobile)
+**Observed issue**: Banner uses `d-none d-md-block` or equivalent — explicitly hidden on mobile.
+**Recommended standard**: On mobile, show a compact inline status indicator (1 line, not the full banner) in the MobileHome overview tab when capacity is exceeded. Full banner only on desktop.
+**Specific UI change**: Extract capacity state data from PlannerCapacityBanner into a hook. Use that hook in MobileHome overview to render a compact `CapacityWarningBadge` (small chip with "Over capacity" message and count).
+**Responsive rule**: Simplified status on mobile; full banner on desktop.
+**Theme/a11y implications**: Use `var(--color-urgency-high)` for the warning colour (depends on REC-001).
+**Dependencies**: REC-001
+
+---
+
+### REC-040: Public goal share page has no mobile optimisation
+
+**Severity**: Low
+**Effort**: S
+**User impact**: `/share/:shareCode` renders a public goal view. Recipients receiving a shared link on mobile may see a poorly-formatted page. This is an external-facing page — first impressions matter.
+**Affected surfaces**: `/share/:shareCode` — PublicGoalView
+**Observed issue**: Classified as `partial` mobile support in the surface inventory.
+**Recommended standard**: PublicGoalView should use the same mobile card pattern as the card views. Simple, full-width, no action buttons (read-only). Single column at all sizes.
+**Specific UI change**: Ensure PublicGoalView renders in single-column card layout on all viewports. Test at 375px (iPhone SE) width.
+**Responsive rule**: Show full feature — but layout is card-only, no table/kanban.
+**Theme/a11y implications**: Apply standard theme tokens. External-facing so light mode default is appropriate (not everyone has dark mode set in the app).
+**Dependencies**: None
+
+---
+
+### REC-041: Dashboard gradient backgrounds may fail in dark mode
+
+**Severity**: Low
+**Effort**: S
+**User impact**: Dashboard.tsx uses linear gradient backgrounds (e.g., `linear-gradient(135deg, #fd7e14 0%, #b35c00 100%)`) on banner cards. In dark mode these can produce a harsh, overly saturated appearance against the dark background.
+**Affected surfaces**: `/dashboard` — Dashboard.tsx banner cards
+**Observed issue**: Gradient colours are hard-coded and not dark-adapted.
+**Recommended standard**: In dark mode, gradient banners should use lower-opacity or desaturated versions of the gradient colours. Define dark-mode gradient tokens: `--gradient-accent-start` and `--gradient-accent-end` with appropriate dark values.
+**Specific UI change**: Replace hard-coded gradient values with CSS variable references. Add `[data-theme="dark"]` overrides in Dashboard.css for gradient banner cards.
+**Responsive rule**: No responsive impact.
+**Theme/a11y implications**: Subtle dark mode visual improvement.
+**Dependencies**: REC-020
+
+---
+
+### REC-042: Goal, story, and task card views show "No items found" instead of contextual empty messaging
+
+**Severity**: Low
+**Effort**: S
+**User impact**: The empty state in card views correctly shows an icon and title, but the message text may be generic across all domains. Goals, stories, and tasks should each have domain-specific messaging (e.g., "Create your first goal to start tracking progress" vs "No tasks match your current filters").
+**Affected surfaces**: StoriesCardView, TasksCardView, GoalsCardView
+**Observed issue**: Empty state messages are likely generic ("No Stories Found", "No Tasks Found") without distinguishing between "you have none" and "filters are hiding them".
+**Recommended standard**: Empty state messaging should have two variants: (a) "no items exist" — offer a create CTA, and (b) "filters are active but nothing matches" — offer a clear-filters CTA. The icon and title differ between these two states.
+**Specific UI change**: In each card view, check whether any filter/search is active when the list is empty. If yes, show "Nothing matches your filters — Clear filters". If no, show "You have no [goals/stories/tasks] yet — Create your first".
+**Responsive rule**: Show full feature — applies to all viewports.
+**Theme/a11y implications**: No theme impact.
+**Dependencies**: REC-016
+
+---
+
+## Recommendation Summary Table
+
+| ID | Title | Severity | Effort | Primary Domain |
+|----|-------|----------|--------|---------------|
+| REC-001 | FocusGoalCountdownBanner dark mode contrast | Critical | S | Theme |
+| REC-002 | Dashboard calendar hard-coded time indicator | Critical | S | Theme |
+| REC-003 | Kanban inaccessible on touch | Critical | L | Mobile |
+| REC-004 | Tables unusable on narrow viewports | Critical | L | Mobile |
+| REC-005 | Roadmap/year planner exposed on mobile | Critical | M | Mobile |
+| REC-006 | Sprint planning matrix exposed on mobile | Critical | M | Mobile |
+| REC-007 | Calendar drag-and-drop not safe on touch | Critical | L | Mobile |
+| REC-008 | Status/priority interaction model inconsistency | High | XL | Consistency |
+| REC-009 | AI score invisible in Kanban | High | M | Consistency |
+| REC-010 | Top 3 / manual priority badge inconsistency | High | M | Consistency |
+| REC-011 | Action button tap targets too small | High | M | Mobile |
+| REC-012 | Domain theme colours have no dark overrides | High | M | Theme |
+| REC-013 | Action buttons have no accessible labels | High | M | A11y |
+| REC-014 | Icon inconsistency: Edit and Schedule | High | S | Consistency |
+| REC-015 | MobileHome hard-coded category colours | High | M | Theme |
+| REC-016 | No shared empty state design | High | M | Consistency |
+| REC-017 | Finance dashboard no mobile version | High | M | Mobile |
+| REC-018 | FocusGoalsPage not responsive on mobile | High | M | Mobile |
+| REC-019 | Filter controls have no shared design language | Medium | L | Consistency |
+| REC-020 | Centralise colour tokens | Medium | L | Theme |
+| REC-021 | Bootstrap Badge not dark-mode adapted | Medium | M | Theme |
+| REC-022 | Document theme selector precedence | Medium | S | Theme |
+| REC-023 | Competing kanban implementations | Medium | S | Consistency |
+| REC-024 | Define mobile card standard | Medium | M | Mobile |
+| REC-025 | Card grid awkward at tablet breakpoints | Medium | S | Layout |
+| REC-026 | Loading states inconsistent | Medium | M | Consistency |
+| REC-027 | Sidebar active state missing on mobile | Medium | S | Mobile |
+| REC-028 | Sprint management tabs inconsistent | Medium | M | Consistency |
+| REC-029 | Goal roadmap version proliferation | Medium | S | Navigation |
+| REC-030 | DailyPlanPage not discoverable | Medium | S | Navigation |
+| REC-031 | Settings pages missing desktop-required signal | Medium | M | Mobile |
+| REC-032 | Terminology inconsistency (Top 3 / AI / Priority) | Low | S | Consistency |
+| REC-033 | Create MobileUnsupportedScreen component | Low | S | Mobile |
+| REC-034 | Remove legacy nav links | Low | S | Navigation |
+| REC-035 | Remove unused MaterialDesign.css | Low | S | Theme |
+| REC-036 | Desktop-required badge on nav items | Low | S | Mobile |
+| REC-037 | Standardise modal header/footer | Low | M | Consistency |
+| REC-038 | Checkins not linked from MobileHome | Low | S | Mobile |
+| REC-039 | Capacity banner hidden on mobile with no replacement | Low | S | Mobile |
+| REC-040 | Public share page mobile optimisation | Low | S | Mobile |
+| REC-041 | Dashboard gradient dark mode | Low | S | Theme |
+| REC-042 | Empty state messaging not contextual | Low | S | Consistency |

--- a/ux-audit/04-ui-standards.md
+++ b/ux-audit/04-ui-standards.md
@@ -1,0 +1,538 @@
+# BOB UX Audit — 04: Proposed UI Standards
+
+**Audit date**: 2026-03-17
+**Purpose**: Define the canonical interaction and visual patterns for goals, stories, and tasks across all view types. This document is the target state — it does not describe the current state.
+
+---
+
+## 1. Shared Data Object: The Work Item
+
+Goals, stories, and tasks share a common interaction language. From a UX perspective they are all "work items" with:
+- A reference ID
+- A title
+- A status
+- A priority
+- Optional AI score
+- Optional manual priority rank (Top 3)
+- Optional domain theme (for goals/stories)
+- Optional due date
+- Optional sprint association
+- Optional goal link
+
+The UI for a work item adapts to three density tiers — **Compact** (Kanban), **Standard** (Card), and **Dense** (Table) — and to two device contexts — **Desktop** and **Mobile**. The underlying data and action set are identical; only the presentation changes.
+
+---
+
+## 2. Status Pill Standard
+
+**Component**: `StatusPill`
+**File to create**: `src/components/shared/StatusPill.tsx`
+
+### Visual Spec
+```
+┌─────────────────┐
+│  In Progress    │   ← rounded pill, 4px border-radius
+└─────────────────┘
+```
+- Font: 11px, font-weight 600, letter-spacing 0.3px
+- Padding: 2px 8px
+- Background: semantic colour variable per status (see table below)
+- Border: none
+- Cursor: `pointer` in interactive mode, `default` in readonly mode
+
+### Status Colour Map
+| Status | CSS Variable | Light Value | Dark Value |
+|--------|-------------|-------------|------------|
+| Backlog / Not Started | `--status-backlog-bg` | `rgba(108, 117, 125, 0.15)` | `rgba(160, 165, 177, 0.2)` |
+| In Progress | `--status-inprogress-bg` | `rgba(13, 110, 253, 0.15)` | `rgba(100, 170, 255, 0.2)` |
+| Review / In Review | `--status-review-bg` | `rgba(253, 126, 20, 0.15)` | `rgba(253, 180, 100, 0.2)` |
+| Done / Complete | `--status-done-bg` | `rgba(25, 135, 84, 0.15)` | `rgba(100, 200, 140, 0.2)` |
+| Blocked | `--status-blocked-bg` | `rgba(220, 53, 69, 0.15)` | `rgba(230, 100, 110, 0.2)` |
+
+### Mode Variants
+- **`mode="readonly"`**: Plain span with pill class. No click handler.
+- **`mode="interactive"`**: Button element. Single click cycles to next status. Used in card views.
+- **`mode="select"`**: Styled `<select>` element that visually matches the pill. Used in tables. On focus, expands to show all status options.
+
+### Usage
+```tsx
+// Kanban (readonly)
+<StatusPill status={item.status} mode="readonly" />
+
+// Card view (interactive)
+<StatusPill status={item.status} mode="interactive" onChange={handleStatusChange} />
+
+// Table (select)
+<StatusPill status={item.status} mode="select" onChange={handleStatusChange} />
+```
+
+---
+
+## 3. Priority Pill Standard
+
+**Component**: `PriorityPill`
+**File to create**: `src/components/shared/PriorityPill.tsx`
+
+Identical structure to `StatusPill`. Uses a different colour map.
+
+### Priority Colour Map
+| Priority | Label | CSS Variable | Accent Colour |
+|----------|-------|-------------|---------------|
+| Critical (P4) | Critical | `--priority-critical-bg` | Red family |
+| High (P3) | High | `--priority-high-bg` | Orange family |
+| Medium (P2) | Medium | `--priority-medium-bg` | Yellow family |
+| Low (P1) | Low | `--priority-low-bg` | Grey family |
+| None | — | Hidden | — |
+
+Priority pills follow the same `mode` prop contract as StatusPill.
+
+---
+
+## 4. AI Score Badge Standard
+
+**Component**: `AiScoreBadge`
+**File to create**: `src/components/shared/AiScoreBadge.tsx`
+
+### Visual Spec
+```
+┌──────┐
+│ AI 87 │   ← compact, no "/100" suffix
+└──────┘
+```
+- Style: same pill base class as StatusPill, but with `--status-inprogress-bg` as a baseline (blue-tinted)
+- Font: 11px, font-weight 500
+- Text: `AI {score}` where score is rounded to nearest integer
+- Hidden when `score < 20` (configurable threshold)
+- Tooltip (title): "AI Criticality Score: NN/100"
+
+### Usage
+```tsx
+<AiScoreBadge score={item.aiCriticalityScore} />
+// Renders nothing if score < 20 or undefined
+```
+
+---
+
+## 5. Manual Priority Badge Standard
+
+**Component**: `ManualPriorityBadge`
+**File to create**: `src/components/shared/ManualPriorityBadge.tsx`
+
+### Visual Spec
+```
+┌────────┐
+│ #1     │   ← compact, bold, accent red
+└────────┘
+```
+- Style: pill with `var(--color-urgency-critical)` background at 20% opacity; text at 100% opacity
+- Font: 11px, font-weight 700
+- Text: `#{rank}` (e.g., `#1`, `#2`, `#3`)
+- Hidden when `rank` is undefined or 0
+- Tooltip: "Manual priority rank: #{rank}"
+
+### Usage
+```tsx
+<ManualPriorityBadge rank={getManualPriorityRank(item)} />
+```
+
+---
+
+## 6. Action Row Standard
+
+### Desktop Action Row (Card View and Kanban)
+Actions appear as icon buttons with `title` tooltip. Standard order (left to right):
+
+| Position | Action | Icon | `title` Attribute |
+|----------|--------|------|--------------------|
+| 1 | Schedule | `CalendarClock` | "Schedule" |
+| 2 | Activity | `Activity` | "Activity stream" |
+| 3 | Edit | `Pencil` | "Edit" |
+| 4 | Defer | `Clock3` | "Defer" |
+| 5 | Convert to Story (tasks only) | `BookOpen` | "Convert to story" |
+| 6 | Delete | `Trash2` | "Delete" |
+
+**Button sizing**:
+- Desktop (≥ 992px): 32px × 32px button with 14px icon. Visible on hover in kanban, always visible in card views.
+- Tablet (768–992px): 36px × 36px with 16px icon.
+- Mobile (< 768px): Collapsed to a single `...` overflow button (see Mobile Action Overflow below).
+
+**Button visual**:
+- Background: transparent at rest; `var(--notion-hover)` on hover
+- No border
+- Icon colour: `var(--muted)` at rest; `var(--text)` on hover
+
+### Mobile Action Overflow
+On viewports < 768px, all action buttons are replaced by a single `•••` button that opens a bottom-anchored dropdown menu:
+
+```
+┌──────────────────────────┐
+│ Schedule                  │
+│ Activity stream           │
+│ Edit                      │
+│ Defer                     │
+│ Delete                    │
+└──────────────────────────┘
+```
+Each row in the overflow menu is full-width with a 44px minimum tap target. Icons appear on the left.
+
+---
+
+## 7. Standard Work Item Card (Desktop)
+
+**Density**: Standard (Card View)
+**Applies to**: Goals, Stories, Tasks in card/grid view on desktop
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ GOAL-042  [CalendarClock] [Activity] [Pencil]            │
+│                                                          │
+│ Achieve first 10k race under 50 minutes                  │
+│                                                          │
+│ [In Progress] [High] [AI 72] [#2]                        │
+│                                                          │
+│ ─────────────────────────────────────────────────────── │
+│ ↳ Theme: Health                 [Clock3 Defer] [Trash2]  │
+│                                                          │
+│ Last updated 2 days ago                                  │
+└─────────────────────────────────────────────────────────┘
+```
+
+- Domain theme colour as left border (4px solid `var(--theme-X-primary)`)
+- Ref ID in muted small text top-left
+- Actions top-right, always visible
+- Status + Priority + AI Score + Manual Priority on same badge row
+- Theme label + secondary actions (Defer, Delete) on bottom bar
+- Date footer: `Updated N days ago` or absolute date
+
+---
+
+## 8. Compact Work Item Card (Kanban)
+
+**Density**: Compact (Kanban)
+**Applies to**: Stories and Tasks inside KanbanBoardV2
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ ⠿ STORY-012                [Pencil] [Activity] [•••]    │
+│                                                          │
+│ Refactor authentication middleware                       │
+│                                                          │
+│ [In Progress] [High] [AI 72] [#2]        [◉ Goal Name]  │
+└─────────────────────────────────────────────────────────┘
+```
+
+- Drag handle (`GripVertical`) on far left
+- Ref + type indicator top row
+- Action buttons always visible (not hover-only) at top right; tertiary actions in `•••` overflow
+- Status + Priority + AI Score + Manual Priority on same badge row as bottom meta
+- Goal link (if present) as compact label on right of meta row
+- No description shown by default (description in expanded state or via Activity)
+- No footer dates (space too limited)
+
+---
+
+## 9. Mobile Work Item Card
+
+**Density**: Mobile
+**Applies to**: All work items rendered in MobileHome tabs or in mobile-responsive card views
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Refactor authentication middleware         [High] [•••]  │
+│ STORY-012  •  In Progress  •  Due Mar 20               │
+│ ↳ Health goal                                           │
+└─────────────────────────────────────────────────────────┘
+```
+
+- Full-width tap target (entire card, minimum 60px height)
+- Title is the primary element — large, truncate to 2 lines
+- Meta row: Ref ID • Status text • Due date (compact inline)
+- Priority chip shown (compact, right-aligned in title row)
+- Manual priority badge (`#N`) replaces priority chip if present (one or the other)
+- AI Score: hidden
+- Actions: `•••` button only (opens bottom sheet with full action list)
+- Goal/theme link as small muted text on 3rd line if present
+- No drag handle
+
+### Tap Behaviours
+| Tap target | Action |
+|-----------|--------|
+| Main card area | Open detail/edit modal |
+| Priority chip | Quick cycle priority (if `interactive` mode) |
+| `•••` button | Open overflow action bottom sheet |
+
+---
+
+## 10. Table Row Standard
+
+**Density**: Dense (Table)
+**Applies to**: ModernTaskTable, ModernStoriesTable, ModernGoalsTable on desktop
+
+```
+┌──┬──────────┬──────────────────────────────────┬──────────┬──────────┬──────────┬────────┬──────┐
+│⠿ │ REF      │ Title                            │ Status ▼ │Priority ▼│ Due Date │ Sprint │ AI   │
+├──┼──────────┼──────────────────────────────────┼──────────┼──────────┼──────────┼────────┼──────┤
+│⠿ │ TASK-012 │ Refactor auth middleware         │[Sel pill]│[Sel pill]│ Mar 20   │ S-14   │ 72   │
+└──┴──────────┴──────────────────────────────────┴──────────┴──────────┴──────────┴────────┴──────┘
+```
+
+- Drag handle column (GripVertical, 24px wide)
+- Ref column (monospace, 80px wide, muted)
+- Title column (flex 1, inline editable on click)
+- Status column: `StatusPill mode="select"` — visually matches pill aesthetic
+- Priority column: `PriorityPill mode="select"` — same
+- Due Date column: date picker inline
+- Sprint column: sprint selector dropdown
+- AI Score column: numeric, sortable, right-aligned
+- Actions: inline at end of row, visible on row hover (desktop); in `•••` button on mobile
+- Manual priority rank: shown as `#N` compact indicator in the Ref column or as the first column (if sorting by manual priority)
+
+---
+
+## 11. Filter Bar Standard
+
+**Component**: `FilterBar` + `FilterChip`
+**Files to create**: `src/components/shared/FilterBar.tsx`, `src/components/shared/FilterChip.tsx`
+
+### Filter Bar Layout
+```
+[Top 3] [Overdue] [Critical] [AI Critical] [+ Add Filter]
+```
+
+- Chips displayed as horizontal scrollable row (no wrapping on mobile, wrapping on desktop)
+- Active chip: background `var(--brand)` at 15% opacity, border `var(--brand)`, text `var(--brand)`
+- Inactive chip: background transparent, border `var(--line)`, text `var(--muted)`
+- `+ Add Filter` opens a dropdown picker of available filters
+- Applied filters are visually highlighted
+
+### Standard Filter Set (Tasks, Stories, Goals)
+| Filter ID | Label | Description |
+|-----------|-------|-------------|
+| `top3` | Top 3 | Items where `aiTop3ForDay == true` today |
+| `overdue` | Overdue | Items with `dueDate` < today and not done |
+| `critical` | Critical | Items with priority = Critical |
+| `ai_critical` | AI Critical | Items with `aiCriticalityScore` ≥ 70 |
+| `unlinked` | Unlinked | Items not linked to a goal/story |
+| `sprint` | Current Sprint | Items in the current sprint |
+
+### Sort Options (Dropdown or Column Header)
+| Sort ID | Label |
+|---------|-------|
+| `manual` | Manual Priority |
+| `ai` | AI Score |
+| `due` | Due Date |
+| `priority` | Priority |
+| `updated` | Last Updated |
+| `created` | Created |
+| `default` | Default |
+
+---
+
+## 12. Empty State Standard
+
+**Component**: `EmptyState`
+**File to create**: `src/components/shared/EmptyState.tsx`
+
+### Props
+```tsx
+interface EmptyStateProps {
+  icon: LucideIcon;          // e.g. Target, CheckSquare, Flag
+  title: string;             // e.g. "No tasks yet"
+  message: string;           // e.g. "Create your first task to start tracking work"
+  action?: {
+    label: string;           // e.g. "Create task"
+    onClick: () => void;
+  };
+  filterActive?: boolean;    // If true, shows "clear filters" variant
+  onClearFilters?: () => void;
+}
+```
+
+### Two Variants
+
+**No-data variant**:
+```
+           🏁
+    No tasks yet
+    Create your first task to start tracking work.
+              [+ Create task]
+```
+
+**Filter-active variant**:
+```
+           🔍
+    Nothing matches your filters
+    Try clearing your filters or adjusting the search.
+              [Clear filters]
+```
+
+- Icon: 48px, `var(--muted)` colour, 50% opacity
+- Title: 18px, `var(--text)`, font-weight 600
+- Message: 14px, `var(--muted)`
+- CTA button: outlined style, `var(--brand)` border and text
+- Padding: 60px top/bottom, centred
+
+---
+
+## 13. Loading State Standard
+
+**Components**: `SkeletonCard`, `SkeletonRow`
+**Files to create**: `src/components/shared/SkeletonCard.tsx`, `src/components/shared/SkeletonRow.tsx`
+
+### SkeletonCard (for card grid views)
+Mimics the card dimensions (min-height 180px). Uses a pulsing grey block for each content area:
+```
+┌─────────────────────────────────────────────────────────┐
+│ ████  ██████████████████████████████████████████████   │
+│                                                          │
+│ ████████████████████████████████████                   │
+│                                                          │
+│ [████████] [██████] [████]                              │
+└─────────────────────────────────────────────────────────┘
+```
+CSS pulse animation using `@keyframes` with `var(--line)` → `var(--panel)` gradient.
+
+### SkeletonRow (for tables)
+Mimics table row height (40px). One block per column:
+```
+│ ⠿  │ ██████ │ ████████████████████████ │ ████████ │ ████ │ ████ │
+```
+
+---
+
+## 14. Mobile Unsupported Screen Standard
+
+**Component**: `MobileUnsupportedScreen`
+**File to create**: `src/components/shared/MobileUnsupportedScreen.tsx`
+
+```
+        [Monitor icon, 64px]
+
+    This feature works best on desktop
+
+    Sprint planning is a complex planning tool
+    designed for desktop use. Open the link on
+    your laptop or desktop to access it.
+
+    [📋 Copy link to clipboard]
+```
+
+- Background: `var(--panel)`
+- Text: `var(--text)` for title, `var(--muted)` for message
+- Icon: `Monitor` from Lucide, `var(--muted)` colour
+- Copy link button: outlined, `var(--brand)`
+- Full viewport height centred vertically
+
+---
+
+## 15. Modal Standard
+
+**Component**: `ModalLayout`
+**File to create**: `src/components/shared/ModalLayout.tsx`
+
+### Structure
+```
+┌─────────────────────────────────────────────────┐
+│ Modal Title                               [✕]   │ ← Header (56px)
+├─────────────────────────────────────────────────┤
+│                                                  │
+│  [Body content — specific to each modal]         │
+│                                                  │
+├─────────────────────────────────────────────────┤
+│ [Cancel]                          [Save / Action]│ ← Footer (56px)
+└─────────────────────────────────────────────────┘
+```
+
+- Header: `var(--panel)` background, title `var(--text)` 16px 600, close button top-right
+- Body: `var(--bg)` background, standard padding 20px
+- Footer: `var(--panel)` background, Cancel button (secondary) left, Confirm button (primary) right
+- Confirm button label: specific action word ("Save", "Create", "Defer", "Update") — never "OK" or "Confirm"
+- On mobile: full-screen bottom sheet, slides up from bottom
+
+---
+
+## 16. Tab Bar Standard
+
+**Applies to**: SettingsPage, SprintManagementView, AdvancedOverview, any multi-tab page
+
+```
+[Overview]  [Board]  [Table]  [Burndown]  [History]
+     ─────
+(active underline: 2px solid var(--brand))
+```
+
+- Horizontal row of text tabs
+- No border/box around tab bar itself — underline only
+- Active tab: `var(--brand)` 2px underline, `var(--text)` colour, font-weight 600
+- Inactive tab: no underline, `var(--muted)` colour, font-weight 400
+- Hover: `var(--text)` colour, no underline
+- On mobile: horizontal scroll row (scroll-snap), all tabs remain available
+
+---
+
+## 17. Icon Standard
+
+All icons are from **Lucide React** (the existing library). No other icon library should be introduced.
+
+### Locked Icon Assignments
+| Action/Concept | Icon | Notes |
+|----------------|------|-------|
+| Edit / Edit item | `Pencil` | Replace all `Edit3` usages |
+| Schedule / Add to calendar | `CalendarClock` | Replace `Calendar` and `CalendarPlus` usages |
+| Defer / Snooze | `Clock3` | Already consistent |
+| Delete / Remove | `Trash2` | Already consistent |
+| Activity / History stream | `Activity` | Already consistent |
+| AI / Magic / Generate | `Wand2` | Already consistent |
+| Convert to Story | `BookOpen` | Already consistent |
+| Drag handle | `GripVertical` | Already consistent |
+| Manual priority | `Star` | New; for indicating Top 3 status |
+| Desktop required | `Monitor` | For MobileUnsupportedScreen |
+| Empty state: tasks | `CheckSquare` | — |
+| Empty state: stories | `BookOpen` | — |
+| Empty state: goals | `Target` | Already used |
+| Empty state: sprints | `Layers` | — |
+| Empty state: finance | `DollarSign` | — |
+| Filters | `SlidersHorizontal` | For filter bar toggle |
+| Sort | `ArrowUpDown` | For sort control |
+| Overflow menu | `MoreHorizontal` | For `•••` buttons |
+
+### Icon Sizing
+| Context | Size |
+|---------|------|
+| Action buttons (desktop) | 14px |
+| Action buttons (tablet) | 16px |
+| Inline meta icons | 12px |
+| Empty state illustration | 48px |
+| Mobile unsupported screen | 64px |
+| Navigation sidebar items | 18px |
+
+---
+
+## 18. Chip/Badge Colour Semantics
+
+All badges and chips in the product share one colour-meaning vocabulary:
+
+| Colour Family | Semantic meaning | CSS Variable | Do Not Use For |
+|---------------|-----------------|-------------|----------------|
+| Red / Danger | Critical priority, blocking, error, over-due | `--color-urgency-critical` | Informational content |
+| Orange | High priority, warning, approaching deadline | `--color-urgency-high` | Neutral status |
+| Yellow | Medium priority, caution | `--color-urgency-medium` | Success states |
+| Green | Done, success, on track | `--color-status-done` | Priority levels |
+| Blue | In Progress, informational, AI score | `--color-status-inprogress` | Completion states |
+| Grey | Neutral, low priority, muted, backlog | `--color-status-backlog` | Active states |
+
+Domain theme colours (Health, Wealth, etc.) are used exclusively for aesthetic theming of goal/story cards. They do not carry semantic meaning and must not be used for status or priority signals.
+
+---
+
+## 19. Density Guide: When to Use Each View
+
+| Context | Recommended View | Rationale |
+|---------|-----------------|-----------|
+| Planning (desktop, sprint review) | **Table** | Highest data density; sort and compare many items |
+| Triage (desktop, quick decisions) | **Card** | Visual scanning; status/priority badges visible |
+| Execution (desktop, active sprint) | **Kanban** | Workflow progression; drag to change status |
+| Mobile overview | **Mobile Card** | Touch-optimised; top priority items only |
+| Mobile triage | **Mobile Card** with filters | Filter chip UX; compact cards |
+| Mobile execution | **Mobile Card** with status picker | Tap to mark done |
+| Analytics (desktop) | **Table** with sort + AI col | Data analysis; compare scores |

--- a/ux-audit/05-responsive-policy.md
+++ b/ux-audit/05-responsive-policy.md
@@ -1,0 +1,252 @@
+# BOB UX Audit — 05: Responsive Support Policy
+
+**Audit date**: 2026-03-17
+**Purpose**: Define the official mobile support classification for every major surface. This document is the authoritative source for mobile/desktop routing decisions.
+
+---
+
+## Policy Definitions
+
+| Classification | Definition | Implementation |
+|----------------|------------|----------------|
+| **`show full`** | The surface is designed for mobile. Full feature parity with desktop. | Default; no conditional rendering needed. |
+| **`show simplified card`** | The surface renders a mobile-optimised card or list view instead of the desktop table/kanban/planner. Data access is full; interaction is simplified. | Detect mobile viewport; render alternate mobile component or switch view mode. |
+| **`show summary/read-only`** | The surface shows key data points in a compact read-only format. Edit and create actions are hidden or reduced. | Render a mobile summary component; deep editing deferred to desktop. |
+| **`hide — route to desktop`** | The surface is not appropriate for mobile. Render `MobileUnsupportedScreen` instead. | Replace component with `MobileUnsupportedScreen` on mobile viewport. |
+
+## Viewport Breakpoints
+
+| Name | Width | Description |
+|------|-------|-------------|
+| Mobile | < 768px | Primary mobile context. All `show simplified card` and `hide` rules activate here. |
+| Tablet | 768–992px | Mobile rules apply for touch-dependent or highly dense surfaces. Desktop rules apply for readable surfaces. |
+| Desktop | ≥ 992px | Full desktop experience. No restrictions. |
+
+---
+
+## Surface Policy Table
+
+### Dashboard & Overview
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/` | RootRedirect | — | Redirect only; auto-routes mobile to `/mobile` |
+| `/dashboard` | Dashboard | `show summary/read-only` | Show key metrics cards and upcoming events. Hide complex analytics panels. Charts collapse to single metric tiles. |
+| `/metrics` | AdvancedOverview | `hide — route to desktop` | Multi-chart analytics surface with Recharts; not appropriate for mobile. |
+| `/metrics/progress` | ThemeProgressDashboard | `hide — route to desktop` | Same rationale as AdvancedOverview. |
+| `/mobile-priorities` | MobilePriorityDashboard | `show full` | Mobile-first surface. |
+
+---
+
+### Task Management
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/tasks` (table mode) | ModernTaskTable | `show simplified card` | Auto-switch to card view below 768px. User cannot toggle back to table on mobile. |
+| `/tasks` (card mode) | TasksCardView | `show simplified card` | Card view renders but with mobile card spec: larger tap targets, overflow action menu. |
+| `/tasks/:id` | DeepLinkTask | `show full` | Modal detail view; acceptable on mobile. |
+
+---
+
+### Story Management
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/stories` (table mode) | ModernStoriesTable | `show simplified card` | Same as tasks: auto-switch to card view below 768px. |
+| `/stories` (card mode) | StoriesCardView | `show simplified card` | Same as TasksCardView mobile treatment. |
+| `/stories/:id` | DeepLinkStory | `show full` | Modal detail view acceptable on mobile. |
+
+---
+
+### Kanban & Sprints
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/sprints/kanban` | KanbanBoardV2 | `show simplified card` | On mobile: single-column stacked list grouped by status. Drag-and-drop replaced by status picker. |
+| `/sprints` | SprintsPage | `show summary/read-only` | Sprint list with key dates; no deep editing on mobile. |
+| `/sprints/management` | SprintManagementView | `show summary/read-only` | Show only overview tab on mobile. Board, table, burndown, retrospective tabs hidden. |
+| `/sprints/table` | ModernSprintsTable | `show simplified card` | Same table→card rule applies. |
+| `/sprints/planning` | SprintPlanningMatrix | `hide — route to desktop` | Dense planning matrix; no mobile interaction model. |
+| `/sprints/capacity` | CapacityDashboard | `show summary/read-only` | Show current vs available capacity as numbers and a simple progress bar. Chart hidden. |
+| `/sprints/retrospective` | SprintRetrospective | `show full` | Form-based; mobile-appropriate. |
+
+---
+
+### Goals Management
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/goals` (table mode) | ModernGoalsTable | `show simplified card` | Auto-switch to card view below 768px. |
+| `/goals` (card mode) | GoalsCardView | `show simplified card` | Mobile card spec applied; tap to view/edit. |
+| `/goals/:id` | DeepLinkGoal | `show full` | Modal detail view acceptable. |
+| `/focus-goals` | FocusGoalsPage | `show summary/read-only` | Show countdown banner and goal list only. Hide KPI studio and wizard. |
+| `/goals/year-planner` | GoalsYearPlanner | `hide — route to desktop` | Complex planning grid; touch-incompatible. |
+| `/goals/roadmap` | GoalRoadmapV5 | `hide — route to desktop` | Gantt chart; no mobile interaction model. |
+| `/goals/roadmap-v6` | GoalRoadmapV6 | `hide — route to desktop` | Same rationale. This is the recommended primary target. |
+| `/goals/roadmap-legacy` | GoalRoadmapV3 | `hide — route to desktop` | Legacy; same rationale. |
+| `/goals/timeline` | EnhancedGanttChart | `hide — route to desktop` | Timeline Gantt; no mobile model. |
+| `/goals/viz` | GoalVizPage | `hide — route to desktop` | Visualisation surface; desktop-only. |
+
+---
+
+### Calendar & Planner
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/calendar` | UnifiedPlannerPage | `show summary/read-only` | Lock to agenda view on mobile. Remove drag-and-drop. Show FAB for adding items. |
+| `/calendar/planner` | WeeklyThemePlanner | `hide — route to desktop` | Theme-based week planner; desktop-only interaction. |
+| `/calendar/integration` | CalendarIntegrationView | `show full` | Simple form; mobile-acceptable. |
+| `/checkin/daily` | CheckInDaily | `show full` | Mobile-first form. |
+| `/checkin/weekly` | CheckInWeekly | `show full` | Mobile-first form. |
+| `/planning/approvals` | ApprovalsCenter | `show summary/read-only` | List of pending approvals, read-only on mobile. |
+| `/planning/approval` | PlanningApprovalPage | `show full` | Single approval form; acceptable on mobile. |
+
+---
+
+### Finance
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/finance/dashboard` | FinanceDashboardAdvanced | `show summary/read-only` | Show 3-4 key metric tiles (month spend, budget remaining, recent transactions). Hide charts and tables. |
+| `/finance/transactions` | TransactionsList | `show simplified card` | Render transactions as swipeable cards with date/merchant/amount. No dense table. |
+| `/finance/budgets` | BudgetsPage | `hide — route to desktop` | Budget configuration table; desktop management task. |
+| `/finance/merchants` | MerchantMappings | `hide — route to desktop` | Configuration table; desktop-only. |
+| `/finance/flow` | FinanceFlowDiagram | `hide — route to desktop` | Sankey chart; not renderable on mobile. |
+| `/finance/pots` | PotsBoard | `show simplified card` | Show pots as a scrollable card list; no kanban drag on mobile. |
+| `/finance/goals` | GoalPotLinking | `show summary/read-only` | Show existing links read-only; editing deferred to desktop. |
+
+---
+
+### Fitness & Health
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/fitness` | WorkoutsDashboard | `show summary/read-only` | Show recent workouts as cards and key metric tiles (weekly distance, weekly time). Charts hidden on mobile. |
+| `/parkrun-results` | WorkoutsDashboard | `show summary/read-only` | Same as fitness dashboard. |
+
+---
+
+### Chores & Habits
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/dashboard/habit-tracking` | HabitsChoresDashboard | `show simplified card` | Habit tracking card view; grid becomes single column. |
+| `/chores` | ChoresTasksPage | `show simplified card` | Chore list as mobile cards. |
+| `/chores/checklist` | ChoreChecklistPage | `show full` | Mobile-first checklist. |
+
+---
+
+### Content Backlogs
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/games-backlog` | GamesBacklog | `show simplified card` | Card view; single column on mobile. |
+| `/shows-backlog` | ShowsBacklog | `show simplified card` | Same. |
+| `/books-backlog` | BooksBacklog | `show simplified card` | Same. |
+| `/videos-backlog` | VideosBacklog | `show simplified card` | Same. |
+| `/youtube-history` | YouTubeHistoryDashboard | `hide — route to desktop` | Analytics dashboard; desktop-only. |
+| `/personal-lists` | BacklogManager | `show simplified card` | Legacy; same card treatment. |
+| `/personal-lists-modern` | PersonalListsManagement | `show simplified card` | Modern table → card on mobile. |
+
+---
+
+### Journals
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/journals` | JournalsManagement | `show simplified card` | Journal list as cards; tap to open. |
+| `/journals/insights` | JournalInsightsPage | `show summary/read-only` | Show recent insight summary card; hide full analytics. |
+| `/journals/:id` | JournalsManagement | `show full` | Journal detail form acceptable on mobile. |
+
+---
+
+### Settings & Integrations
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/settings` | SettingsPage | `show summary/read-only` | Show profile and notification tabs only on mobile. Hide AI, finance, developer tabs. |
+| `/settings/email` | SettingsEmailPage | `show full` | Simple form; mobile-acceptable. |
+| `/settings/planner` | SettingsPlannerPage | `hide — route to desktop` | Configuration surface; desktop-appropriate. |
+| `/settings/integrations` | IntegrationSettings | `hide — route to desktop` | Integration management; desktop-appropriate. |
+| `/settings/integrations/*` | Various | `hide — route to desktop` | All per-integration config pages. |
+
+---
+
+### Diagnostics & Logs
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/logs/integrations` | IntegrationLogs | `hide — route to desktop` | Developer/ops surface. |
+| `/logs/ai` | AiDiagnosticsLogs | `hide — route to desktop` | Developer/ops surface. |
+| `/logs/transcripts` | TranscriptProcessingLogs | `hide — route to desktop` | Developer/ops surface. |
+
+---
+
+### Mobile-First Surfaces
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/mobile` | MobileHome | `show full` | Primary mobile experience. |
+| `/mobile-view` | MobileView | `show full` | Mobile detail view. |
+| `/mobile-checklist` | MobileChecklistView | `show full` | Mobile checklist. |
+
+---
+
+### Miscellaneous
+
+| Route | Surface | Mobile Policy | Notes |
+|-------|---------|---------------|-------|
+| `/travel` | TravelMap | `hide — route to desktop` | Map visualisation; not appropriate for mobile. |
+| `/canvas` | VisualCanvas | `hide — route to desktop` | Custom canvas; desktop-only. |
+| `/routes` | RoutesManagementView | `hide — route to desktop` | Route management; desktop-appropriate. |
+| `/share/:shareCode` | PublicGoalView | `show full` | Public-facing shared view; single-column card layout on all viewports. |
+
+---
+
+## Implementation Guidelines
+
+### Breakpoint Detection
+Use the existing `deviceDetection.ts` utility which already defines:
+```typescript
+isMobile(): width < 768px OR mobile UA string
+isTablet(): (iPad/Android) AND 768 <= width < 1024
+```
+
+For component-level checks, use a shared `useIsMobile()` hook wrapping the device detection utility. Do not inline `window.innerWidth` checks in component render logic.
+
+### Route-Level Gates vs Component-Level Gates
+
+**Route-level gates** (in App.tsx or a layout wrapper): Used for `hide — route to desktop` surfaces. The gate wraps the entire route and renders `MobileUnsupportedScreen` when `isMobile`.
+
+**Component-level gates**: Used for `show simplified card` and `show summary/read-only`. The component itself detects mobile and renders the simplified variant.
+
+**Preferred pattern for `show simplified card`**:
+```tsx
+const isMobile = useIsMobile();
+
+if (isMobile) {
+  return <TasksCardView items={items} mode="mobile" />;
+}
+return <ModernTaskTable items={items} />;
+```
+
+### Sidebar Navigation on Mobile
+Per REC-036: Hide sidebar navigation items leading to `hide — route to desktop` surfaces when `isMobile`. This prevents users from navigating to surfaces that will only show them `MobileUnsupportedScreen`.
+
+Surfaces classified as `show summary/read-only` should remain in mobile navigation — they provide value on mobile, just in a simplified form.
+
+### The `/mobile` Route vs Desktop Routes on Mobile
+The current architecture auto-routes new mobile users to `/mobile`. However, existing mobile users with bookmarked desktop URLs still land on those desktop surfaces. The responsive policy above ensures those desktop surfaces handle mobile visitors gracefully even without the auto-redirect.
+
+Do not remove the `/mobile` route. It provides the optimised mobile experience. The responsive policy fills in the gaps for all other routes.
+
+---
+
+## Summary by Classification
+
+| Policy | Count | Examples |
+|--------|-------|---------|
+| `show full` | 9 | MobileHome, CheckInDaily, CheckInWeekly, ChoreChecklist, PublicShareView, DeepLink detail views |
+| `show simplified card` | 14 | Tasks, Stories, Goals (card mode), Kanban (stacked), Finance Transactions, Content Backlogs, Journals |
+| `show summary/read-only` | 12 | Dashboard, SprintManagement (overview tab), FocusGoals (banner + list), Calendar (agenda), Finance summary, Fitness |
+| `hide — route to desktop` | 18 | Roadmaps, Sprint Planning, Year Planner, Finance deep config, Analytics, Logs, Settings integrations, Map, Canvas |

--- a/ux-audit/06-theme-governance.md
+++ b/ux-audit/06-theme-governance.md
@@ -1,0 +1,564 @@
+# BOB UX Audit — 06: Theme Governance
+
+**Audit date**: 2026-03-17
+**Purpose**: Define the authoritative theme system, its governance rules, and catalogue all known violations.
+
+---
+
+## 1. Current Theme System Overview
+
+The app currently has **four CSS systems** that all respond to `[data-theme="dark"]`:
+
+| System | Files | Status | Description |
+|--------|-------|--------|-------------|
+| **System A — Core** | `index.css` | ✅ Active | Defines `--bg`, `--panel`, `--card`, `--text`, `--muted`, `--brand`, `--line`. Light and dark mode tokens. Primary theme system. |
+| **System B — Domain Themes** | `ThemeColors.css`, `globalThemes.ts` | ✅ Active | 16 domain colour palettes (Health, Wealth, Growth, etc.) with `--theme-X-primary/light/lighter/dark/darker` variables. No dark mode overrides. |
+| **System C — Notion Style** | `themeConsistency.css`, `theme-aware.css` | ⚠️ Partially active | "Notion-inspired" button and form styles using `--notion-*` variables. Has its own `[data-theme="dark"]` overrides that may conflict with System A. |
+| **System D — Material Design** | `MaterialDesign.css` | ❌ Unused | Defines `--md-*` variables. No component references these. 520 lines of dead CSS. |
+
+**Theme Toggle** sets three attributes simultaneously (ModernThemeContext.tsx):
+```typescript
+root.setAttribute('data-theme', theme)        // Used by Systems A, B, C, D
+root.classList.toggle('dark', theme === 'dark') // Tailwind convention (unused)
+document.body.setAttribute('data-bs-theme', theme) // Bootstrap adaptation
+```
+
+---
+
+## 2. Authoritative Token Set (System A)
+
+All feature components must use only these CSS variables. No direct hex or RGBA values in component files.
+
+### Core Surface Tokens
+| Token | Light | Dark | Use for |
+|-------|-------|------|---------|
+| `--bg` | `#f0f2f5` | `#0b0d11` | Page background |
+| `--panel` | `#ffffff` | `#12141a` | Sidebar, modal backgrounds, header |
+| `--card` | `#ffffff` | `#171a21` | Card backgrounds |
+| `--line` | `#e0e0e0` | `#232632` | Borders, dividers, separators |
+
+### Core Text Tokens
+| Token | Light | Dark | Use for |
+|-------|-------|------|---------|
+| `--text` | `#333333` | `#e8e9ed` | Primary body text, titles |
+| `--muted` | `#666666` | `#a0a5b1` | Secondary text, placeholders, labels |
+| `--on-accent` | `#ffffff` | `#ffffff` | Text on coloured backgrounds |
+
+### Core Accent Tokens
+| Token | Light | Dark | Use for |
+|-------|-------|------|---------|
+| `--brand` | `#007bff` | `#6aa5ff` | Primary actions, active states, links |
+
+### Semantic Status Tokens (To Be Added — Required by REC-001, REC-008)
+These do not currently exist and must be added to index.css:
+
+| Token | Light | Dark | Use for |
+|-------|-------|------|---------|
+| `--color-urgency-critical` | `#dc3545` | `#e87d87` | Critical priority, errors, overdue |
+| `--color-urgency-high` | `#fd7e14` | `#f4a45a` | High priority, warnings |
+| `--color-urgency-medium` | `#e5a400` | `#f0c040` | Medium priority, caution |
+| `--color-urgency-low` | `#6c757d` | `#a0a5b1` | Low priority, neutral |
+| `--color-status-done` | `#198754` | `#5dba85` | Completed states, success |
+| `--color-status-inprogress` | `#0d6efd` | `#6aa5ff` | Active/in-progress states |
+| `--color-status-backlog` | `#6c757d` | `#a0a5b1` | Inactive/backlog states |
+| `--color-status-blocked` | `#dc3545` | `#e87d87` | Blocked states |
+| `--color-status-review` | `#fd7e14` | `#f4a45a` | Under review states |
+
+### Glass/Overlay Tokens
+| Token | Light | Dark | Use for |
+|-------|-------|------|---------|
+| `--glass-bg-opacity` | `0.7` | `0.15` | Glass card opacity |
+| `--glass-border-color` | `rgba(255,255,255,0.3)` | `rgba(255,255,255,0.1)` | Glass borders |
+| `--glass-shadow-color` | `rgba(0,0,0,0.1)` | `rgba(0,0,0,0.3)` | Glass shadows |
+
+---
+
+## 3. Governance Rules
+
+### Rule 1: No hard-coded colour values in feature components
+Feature component files (`.tsx`) must not contain inline hex (`#rrggbb`), RGB (`rgb()`), or RGBA (`rgba()`) colour values. All colours must be expressed as CSS variable references: `var(--token-name)`.
+
+**Applies to**: All component files in `react-app/src/components/`
+**Exceptions**: CSS utility files and shared CSS may define colour values as part of token definitions. Test/story files are exempt.
+**Enforcement**: Reviewer checklist item on all PRs touching component files.
+
+---
+
+### Rule 2: Bootstrap colour utility classes are banned in new code
+Bootstrap utility classes that carry semantic colour meaning (`bg-light`, `bg-dark`, `bg-primary`, `bg-danger`, `bg-warning`, `bg-success`, `text-danger`, `text-success`, `text-warning`, `text-muted`) must not be used in new component code. They bypass the custom theme system.
+
+**Use instead**: CSS variable tokens or pill CSS classes from KanbanCards.css.
+**Existing usages**: Acceptable but flagged for removal during refactor passes (see violation list below).
+**Permitted Bootstrap utilities**: Layout/spacing utilities (`d-flex`, `mb-3`, `p-2`, `gap-2`) are permitted — only colour-semantic utilities are banned.
+
+---
+
+### Rule 3: Domain theme colours must have dark mode counterparts
+Every colour variant in `ThemeColors.css` (`--theme-X-lighter`, `--theme-X-light`, `--theme-X-primary`, `--theme-X-dark`, `--theme-X-darker`) must have a corresponding `[data-theme="dark"]` override.
+
+**Dark mode values**: Increase opacity on `-lighter` variants from `0.1` to `0.15-0.2`. Shift hue slightly warmer/lighter to maintain readability against `--card: #171a21`.
+
+---
+
+### Rule 4: Lucide icon `color` prop must use CSS variables
+Icon components used with an explicit `color` prop (e.g., `<Activity color="#0066cc" />`) must use `var(--brand)`, `var(--muted)`, `var(--text)`, or a semantic token instead of a hex value.
+
+**Pattern**:
+```tsx
+// ❌ Banned
+<Activity color="#0066cc" />
+
+// ✅ Correct
+<Activity color="var(--brand)" />
+// or via CSS class
+<Activity className="icon-brand" />  // where .icon-brand { color: var(--brand); }
+```
+
+---
+
+### Rule 5: Theme attributes are set only by ModernThemeContext
+No component may call `document.documentElement.setAttribute('data-theme', ...)` or toggle the `dark` class directly. All theme switching goes through `ModernThemeContext`.
+
+---
+
+### Rule 6: MaterialDesign.css must be removed
+MaterialDesign.css defines 520 lines of `--md-*` CSS variables consumed by no component. It is a source of potential future confusion and CSS load overhead. It must be deleted when the theme governance cleanup begins.
+
+---
+
+### Rule 7: themeConsistency.css must be scoped or merged
+themeConsistency.css defines `--notion-*` variables and `[data-theme="dark"]` rules that may conflict with System A. Its rules must be audited for conflicts and either:
+- Merged into `theme-aware.css` under a clear namespace, or
+- Scoped to specific component classes to prevent cascade pollution
+
+---
+
+## 4. Priority Fix Order
+
+1. **Add semantic tokens to index.css** (REC-001, REC-008) — foundational; all other colour fixes depend on this
+2. **Fix FocusGoalCountdownBanner** (REC-001) — Critical WCAG violation
+3. **Fix Dashboard.css hard-coded calendar colours** (REC-002) — Critical dark mode break
+4. **Add dark mode overrides to ThemeColors.css** (REC-012) — High impact across all domain-themed cards
+5. **Fix MobileHome THEME_COLORS map** (REC-015) — Only mobile surface; highest mobile impact
+6. **Replace Bootstrap Badge components in card views** (REC-021) — Prerequisite for unified chip standard
+7. **Remove MaterialDesign.css** (REC-035) — Dead code cleanup
+8. **Audit and remediate remaining hard-coded colours** (REC-020) — Long tail
+
+---
+
+## 5. Hard-Coded Colour Violation Catalogue
+
+The following components contain hard-coded colour values that violate Rule 1. This is a representative list from the code exploration; a full automated scan should be run before remediation.
+
+### Critical Violations (WCAG failure risk)
+
+| File | Line(s) | Hard-coded value | Replace with |
+|------|---------|-----------------|--------------|
+| `FocusGoalCountdownBanner.tsx` | `getUrgencyColor()` switch | `#dc3545`, `#fd7e14`, `#0066cc`, `#6c757d` | `var(--color-urgency-*)` |
+| `Dashboard.css` | ~413-420 | `#dc3545` (`.rbc-current-time-indicator`) | `var(--color-urgency-critical)` |
+
+### High Priority Violations
+
+| File | Line(s) | Hard-coded value | Replace with |
+|------|---------|-----------------|--------------|
+| `KanbanCardV2.tsx` | Drag handle | `rgba(59, 130, 246, ...)` | `var(--brand)` at low opacity |
+| `KanbanCardV2.tsx` | Blocked border | `var(--bs-danger, #dc3545)` | `var(--color-urgency-critical)` |
+| `SortableStoryCard.tsx` | Manual priority badge | `rgba(220, 53, 69, 0.45)` | `var(--color-urgency-critical)` at 20% opacity |
+| `Dashboard.tsx` | Calendar event fallback | `'#3b82f6'` | `var(--brand)` |
+| `Dashboard.tsx` | Gradient banners | `#fd7e14`, `#b35c00` | `var(--color-urgency-high)` |
+| `MobileHome.tsx` | `THEME_COLORS` map | Multiple hex values per category | `--theme-X-primary` CSS vars |
+| `FocusGoalWizard.tsx` | Selection states | `#0066cc`, `#ddd` | `var(--brand)`, `var(--line)` |
+
+### Medium Priority Violations
+
+| File | Hard-coded value(s) | Notes |
+|------|---------------------|-------|
+| `FitnessKPIDisplay.tsx` | `#0066cc` on Lucide icon `color` prop | Violates Rule 4 |
+| `BirthdayMilestoneCard.tsx` | Unknown — to be confirmed in remediation pass | Not fully audited |
+| `StoriesCardView.tsx` | `withAlpha(themeColor, 0.25)` for border | Uses utility function not CSS var — borderline |
+| `KanbanCards.css` | `rgba(220, 38, 38, ...)`, `rgba(253, 126, 20, ...)`, `rgba(234, 179, 8, ...)`, `rgba(34, 197, 94, ...)` in pill variants | These are CSS-level definitions, acceptable *if* they map to the semantic tokens defined in Section 2. Migrate to use `var(--color-urgency-*)` |
+
+### Bootstrap Badge Violations (Rule 2)
+
+| File | Badge usage | Replace with |
+|------|------------|--------------|
+| `StoriesCardView.tsx` | `<Badge bg="secondary">AI NN/100</Badge>` | `AiScoreBadge` component (pill CSS) |
+| `StoriesCardView.tsx` | `<Badge bg="danger">#N Priority</Badge>` | `ManualPriorityBadge` component |
+| `TasksCardView.tsx` | Same as StoriesCardView | Same |
+| `GoalsCardView.tsx` | Same pattern (assumed) | Same |
+| Various table components | `text-muted`, `text-danger` classes | `var(--muted)`, `var(--color-urgency-critical)` |
+
+---
+
+## 6. CSS Load Order Documentation
+
+The following is the required CSS load order and intended precedence (lowest specificity first, highest last):
+
+```
+1. index.css          — Core System A tokens (light + dark). Global resets.
+2. ThemeColors.css    — System B domain theme palettes.
+3. theme-aware.css    — System C component-level dark mode overrides.
+4. themeConsistency.css — System C Notion-style component rules (must not conflict with 1-3).
+5. Bootstrap CSS      — Bootstrap base (loaded by React app entry point).
+6. Dashboard.css      — Dashboard-specific calendar overrides.
+7. KanbanCards.css    — Kanban/card pill and badge CSS.
+8. GlobalEditButton.css — Shared edit button styles.
+9. unified-planner.css — Planner-specific calendar overrides.
+```
+
+**Principle**: More specific or component-scoped CSS loads last. Global theme tokens load first so they can be referenced throughout. Bootstrap loads after tokens so Bootstrap's `var(--bs-*)` variables can reference custom tokens where mapped.
+
+**Current risk**: `themeConsistency.css` (item 4) defines `[data-theme="dark"]` rules that can override items 1-3 depending on selector specificity. This is the cascade conflict identified in the audit. It must be resolved by scoping themeConsistency.css rules to specific component class namespaces (e.g., `.notion-nav [data-theme="dark"]`) rather than bare `[data-theme="dark"]`.
+
+---
+
+## 7. Dark Mode Test Checklist
+
+Before shipping any component change, verify in both light and dark mode:
+
+- [ ] Text is readable (minimum 4.5:1 contrast ratio for normal text, 3:1 for large text)
+- [ ] Card backgrounds are visually distinct from page background
+- [ ] Status pills and priority pills are visible and distinctive
+- [ ] Domain theme colours (if applied) are visible and distinct on dark card background
+- [ ] Borders and dividers are visible but not harsh
+- [ ] Icon colours are visible
+- [ ] Button states (hover, focus, active, disabled) are all visible
+- [ ] Modal overlay (scrim) is appropriately dark
+- [ ] Empty state and loading skeleton use theme-appropriate colours
+- [ ] Any gradient backgrounds look acceptable (not overly saturated)
+- [ ] Focus rings are visible (keyboard navigation)
+
+**Test viewport**: Render in Chrome DevTools with colour theme set to dark. Also test with OS-level dark mode to verify `prefers-color-scheme` media query consistency (if applicable).
+
+---
+
+## 8. Proposed Token Additions to index.css
+
+Add these new tokens to index.css under a `/* Semantic Status & Urgency Tokens */` comment block:
+
+```css
+/* Semantic Status & Urgency Tokens */
+:root {
+  --color-urgency-critical: #dc3545;
+  --color-urgency-high: #fd7e14;
+  --color-urgency-medium: #e5a400;
+  --color-urgency-low: #6c757d;
+
+  --color-status-done: #198754;
+  --color-status-inprogress: #0d6efd;
+  --color-status-backlog: #6c757d;
+  --color-status-blocked: #dc3545;
+  --color-status-review: #fd7e14;
+
+  --color-gradient-accent-start: #fd7e14;
+  --color-gradient-accent-end: #b35c00;
+}
+
+[data-theme="dark"] {
+  --color-urgency-critical: #e87d87;
+  --color-urgency-high: #f4a45a;
+  --color-urgency-medium: #f0c040;
+  --color-urgency-low: #a0a5b1;
+
+  --color-status-done: #5dba85;
+  --color-status-inprogress: #6aa5ff;
+  --color-status-backlog: #a0a5b1;
+  --color-status-blocked: #e87d87;
+  --color-status-review: #f4a45a;
+
+  --color-gradient-accent-start: #c46a0a;
+  --color-gradient-accent-end: #8a4200;
+}
+```
+
+---
+
+## 9. Proposed Dark Mode Additions to ThemeColors.css
+
+For each of the 16 domain themes, add a `[data-theme="dark"]` block. Example for Health:
+
+```css
+/* Current (light only) */
+:root {
+  --theme-health-primary: #e53e3e;
+  --theme-health-light: rgba(229, 62, 62, 0.2);
+  --theme-health-lighter: rgba(229, 62, 62, 0.1);
+  --theme-health-dark: #c53030;
+  --theme-health-darker: #9b2c2c;
+}
+
+/* Add dark mode overrides */
+[data-theme="dark"] {
+  --theme-health-light: rgba(232, 125, 135, 0.2);
+  --theme-health-lighter: rgba(232, 125, 135, 0.15);
+  /* primary, dark, darker: increase brightness for dark backgrounds */
+  --theme-health-primary: #e87d87;
+  --theme-health-dark: #d4606c;
+  --theme-health-darker: #b84d58;
+}
+```
+
+Repeat for all 16 themes: health, growth, wealth, tribe, home, work, sidegig, sleep, random, chores, rest, travel, and the `defect` variant.
+
+---
+
+## 10. Annotated Before/After: Top 12 UX Changes
+
+The following descriptions serve as annotated wireframe guidance for the highest-impact recommendations. These are text-based layout sketches, not pixel-precise mockups.
+
+---
+
+### Change 1: Unified Status + Priority Pill Row (REC-008)
+
+**Before** (three different renderings of the same data):
+```
+Kanban:   [In Progress]  [High]     ← CSS text in meta row, read-only
+Card:     [In Progress▾] [High▾]   ← Bootstrap Button, click to cycle
+Table:    [▼ In Progress] [▼ High]  ← HTML <select> dropdown, no pill style
+```
+
+**After** (one component, three modes):
+```
+Kanban:   [In Progress] [High]      ← StatusPill mode="readonly", same CSS pill
+Card:     [In Progress] [High]      ← StatusPill mode="interactive", click to cycle
+Table:    [In Progress▾] [High▾]   ← StatusPill mode="select", styled to match pill
+```
+Identical visual output. Interaction mode is controlled by `mode` prop. Same CSS class on all three.
+
+---
+
+### Change 2: Standard Action Row (REC-013, REC-014)
+
+**Before** (mixed icons, sizes, no labels):
+```
+Kanban:    [Edit3:12px] [Activity:12px] [CalendarPlus:12px]
+Card view: [Calendar:24px] [Activity:24px] [Edit3:24px]    (top-right)
+           [Clock3:?px] [Trash2:?px]                         (bottom bar)
+Table:     Unknown
+```
+
+**After** (consistent order, consistent icons, labelled at ≥ 992px):
+```
+Desktop (≥992px):  [📅 Schedule] [📊 Activity] [✏ Edit] [⏱ Defer] [🗑 Delete]
+Tablet (768-992px): [📅] [📊] [✏] [⏱] [🗑]  ← icons only with title tooltip
+Mobile (<768px):    [•••]  ← single overflow button → bottom sheet
+```
+Standard order and icon set enforced globally. `CalendarClock` for schedule, `Pencil` for edit.
+
+---
+
+### Change 3: AI Score + Top 3 Badge on All View Types (REC-009, REC-010)
+
+**Before**:
+```
+Kanban:   [In Progress] [High]                     ← no AI score, no Top 3
+Card:     [In Progress] [High] [AI 87/100] [#2 Priority]  ← verbose format
+Table:    row column: 87                            ← numeric only, no badge
+```
+
+**After**:
+```
+Kanban:   [In Progress] [High] [AI 87] [#2]        ← compact; both visible
+Card:     [In Progress] [High] [AI 87] [#2]        ← same compact format
+Table:    AI col: [AI 87]  +  inline: [#2]          ← compact badges in cells
+```
+Compact `AI 87` format (not `/100`). `#2` manual priority rank badge. Consistent across all three view types. Hidden when score < 20 or rank is unset.
+
+---
+
+### Change 4: Mobile Card Layout with Overflow Menu (REC-011, REC-024)
+
+**Before** (card view on mobile — 24px buttons, not tap-safe):
+```
+┌────────────────────────────────────┐
+│ TASK-042     [⏰:24px][📊:24px][✏:24px] │  ← too small to tap
+│ Build auth middleware               │
+│ [In Progress:btn] [High:btn]        │  ← buttons small, action unclear
+│ ─────────────────────────────────  │
+│ Theme: Work   [Clock:24px] [Trash:24px] │  ← bottom bar, also small
+└────────────────────────────────────┘
+```
+
+**After** (mobile card with overflow and 44px targets):
+```
+┌────────────────────────────────────┐
+│ Build auth middleware    [High] [•••] │  ← priority compact + overflow btn
+│ TASK-042  •  In Progress  •  Mar 20  │
+│ ↳ Sprint 14                          │
+└────────────────────────────────────┘
+
+Tap •••:
+┌────────────────────────────────────┐
+│ [📅] Schedule                        │  ← 44px rows
+│ [📊] Activity stream                 │
+│ [✏] Edit                             │
+│ [⏱] Defer                            │
+│ [🗑] Delete                           │
+└────────────────────────────────────┘
+```
+
+---
+
+### Change 5: Table → Card Auto-Switch on Narrow Viewport (REC-004)
+
+**Before**: At 600px viewport width, ModernTaskTable renders full-width with horizontal scroll. Column widths overflow. Drag handles and dropdowns are unusable.
+
+**After**: At < 768px, the wrapper component (TaskListView) automatically renders TasksCardView in mobile mode. The view toggle button is hidden. Users interact with cards, not a table.
+
+```
+> 768px:  [Toggle: Table | Card]  [Sortable table rendering]
+< 768px:  [No toggle — card view only]  [Mobile card grid, 1 column]
+```
+
+---
+
+### Change 6: Empty State Component (REC-016)
+
+**Before** (Kanban empty column):
+```
+[Empty column white space — nothing]
+or
+[Loading board...]
+```
+
+**After** (consistent empty state):
+```
+         📋
+    No backlog items
+
+    All caught up! Add new tasks to
+    start planning your sprint.
+
+         [+ Add task]
+```
+Same pattern for table (empty rows) and mobile (empty tab).
+
+---
+
+### Change 7: Domain Theme Dark Mode Adaptation (REC-012)
+
+**Before** (dark mode — light theme colours on dark background):
+```
+┌────────────────────────────────────┐  ← card: #171a21
+│░░ Health goal card (light red)     │  ← --theme-health-lighter: rgba(229,62,62,0.1)
+│   Build daily running habit        │  ← barely visible red strip on dark card
+└────────────────────────────────────┘
+```
+
+**After** (dark mode — higher opacity, lighter hue):
+```
+┌────────────────────────────────────┐  ← card: #171a21
+│▓▓ Health goal card (bright red)    │  ← --theme-health-lighter dark: rgba(232,125,135,0.15)
+│   Build daily running habit        │  ← clearly visible salmon/red strip on dark card
+└────────────────────────────────────┘
+```
+
+---
+
+### Change 8: GoalRoadmap Mobile Gate (REC-005)
+
+**Before** (mobile — partial Gantt render, broken interaction):
+```
+[Partially visible Gantt chart — labels cut off, no scroll, no zoom, no touch drag]
+```
+
+**After** (mobile — clean unsupported screen):
+```
+            🖥
+    Goal Roadmap requires desktop
+
+    The roadmap view is a Gantt chart
+    designed for desktop use.
+    Open this link on your laptop to
+    access the full roadmap.
+
+            [📋 Copy link]
+```
+
+---
+
+### Change 9: Finance Dashboard Mobile Summary (REC-017)
+
+**Before** (mobile — desktop charts render at 375px width, overflow and unreadable):
+```
+[Partial chart rendering — legend overlaps bars — numbers illegible — tabs cut off]
+```
+
+**After** (mobile — 3 key metric tiles + link to desktop):
+```
+┌─────────────────┐  ┌─────────────────┐
+│  Mar Spending    │  │  Budget Left    │
+│    £1,247        │  │    £312         │
+│   of £1,500      │  │  21% remaining  │
+└─────────────────┘  └─────────────────┘
+
+┌───────────────────────────────────────┐
+│  Last transaction: Costa Coffee £3.40  │
+│  2 hours ago                           │
+└───────────────────────────────────────┘
+
+[View full dashboard on desktop →]
+```
+
+---
+
+### Change 10: Unified Filter Chip Bar (REC-019)
+
+**Before** (inconsistent per-view filter controls):
+```
+Kanban toolbar:   [Overdue ▼] [Sort: AI ▼] [Theme ▼]  ← dropdowns
+Task table:       Column visibility toggle in header
+Mobile:           [Top 3] [Due Today] [Overdue] [All]   ← button group
+```
+
+**After** (shared filter chip bar):
+```
+All views:  [Top 3 ✓] [Overdue] [Critical] [AI Critical] [+ Filter]
+                ↑ active chip    ↑ inactive chip
+```
+Active chip: `var(--brand)` border + light fill. Inactive: `var(--line)` border. Identical on desktop and mobile (wraps to second row on narrow viewports).
+
+---
+
+### Change 11: Calendar Agenda-Only Mobile View (REC-007)
+
+**Before** (mobile — React Big Calendar week view with broken drag-and-drop):
+```
+[7-column week grid — events too small to read — drag fails on touch — overflow not visible]
+```
+
+**After** (mobile — agenda list with FAB):
+```
+TODAY — TUESDAY, MARCH 17
+
+09:00  Sprint standup [30m]
+10:30  Focus: Auth middleware [2h]
+14:00  1:1 with team [1h]
+
+TOMORROW — WEDNESDAY, MARCH 18
+
+09:00  Design review [45m]
+
+                              [+]  ← FAB to add item
+```
+
+---
+
+### Change 12: Settings Responsive Hide Pattern (REC-031)
+
+**Before** (mobile — SettingsPage full multi-tab settings form rendered):
+```
+[Profile | AI | Finance | Notifications | Privacy | Developer]  ← tabs overflow
+[Dense form fields, integration config tables, developer tools]
+```
+
+**After** (mobile — profile + notifications only, rest gated):
+```
+┌─────────────────────────────────────────┐
+│ Profile     [editable form fields]      │
+│ Notifications [toggle switches]         │
+│                                          │
+│ More settings available on desktop →    │
+└─────────────────────────────────────────┘
+```
+Integration, AI, Finance, Developer, Privacy tabs hidden on mobile. A single "More settings on desktop" link at the bottom allows power users to navigate there and see the `MobileUnsupportedScreen`.


### PR DESCRIPTION
## Summary
- reconcile `plan.md` to the current codebase and treat code as the source of truth
- checkpoint the full intentional local web workspace state in one release commit
- carry forward the newer focus-goal, mobile priority, planner, calendar dedup, and UX audit work in a single release PR

## What Changed
- updated `plan.md` with a 17 Mar 2026 reconciliation note that supersedes older stale roadmap sections
- included the current intentional local changes across `react-app/`, `functions/`, planner surfaces, focus-goal planning surfaces, and `ux-audit/`
- fixed release-blocking type issues so the current dirty-state branch now builds again

## Validation
- `npm run -s build --prefix react-app` ✅
- `node -c functions/calendarSync.js && node -c functions/services/schedulingService.js && node -c functions/capacityPlanning.js && node -c functions/deferralSuggestions.js && node -c functions/lib/reporting.js` ✅
- `node scripts/validate-sprints-perf.js --serviceAccount=/Users/jim/GitHub/secret/bob20250810-firebase-adminsdk-fbsvc-0f8ac23f94.json --uid=3L3nnXSuTPfr08c8DTXG5zYX37A2 --project=bob20250810` ✅
- `npm run -s validate:calendar-links -- --serviceAccount=/Users/jim/GitHub/secret/bob20250810-firebase-adminsdk-fbsvc-0f8ac23f94.json --uid=3L3nnXSuTPfr08c8DTXG5zYX37A2 --project=bob20250810` not captured to completion in this release session; needs rerun or explicit waiver before deploy if required

## Notes
- supersedes PR #504 for release purposes; PR #504 can remain as the narrower historical slice
- transient `.firebase` cache and `build-logs/manifest.json` were intentionally left out of the release commit
- local working tree still has only those two transient generated files dirty after the checkpoint commit
